### PR TITLE
YouTube Transcription Pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.3.6",
+    "youtube-transcript": "^1.3.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       tw-animate-css:
         specifier: ^1.3.6
         version: 1.4.0
+      youtube-transcript:
+        specifier: ^1.3.0
+        version: 1.3.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2986,6 +2989,10 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  youtube-transcript@1.3.0:
+    resolution: {integrity: sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q==}
+    engines: {node: '>=18.0.0'}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -5484,6 +5491,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
+
+  youtube-transcript@1.3.0: {}
 
   zod@3.25.76: {}
 

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -177,4 +177,91 @@ describe("StorageService", () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe("storeTranscript", () => {
+		it("stores a transcript linked to a meeting", async () => {
+			const db = createTestDb();
+			const layer = StorageServiceLive(db);
+
+			// First store a meeting
+			const meeting = await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeMeeting(testMeetingInput);
+				}).pipe(Effect.provide(layer)),
+			);
+
+			// Store a transcript for that meeting
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeTranscript({
+						meetingId: meeting.id,
+						source: "captions",
+						rawText: "Meeting called to order. Motion to approve.",
+						segments: [
+							{
+								text: "Meeting called to order.",
+								startMs: 0,
+								durationMs: 3000,
+							},
+							{ text: "Motion to approve.", startMs: 3000, durationMs: 2000 },
+						],
+						sourceUrl: "https://youtube.com/watch?v=test123",
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			// Verify transcript was stored
+			const transcripts = db.select().from(schema.transcripts).all();
+			expect(transcripts).toHaveLength(1);
+			expect(transcripts[0].source).toBe("captions");
+			expect(transcripts[0].rawText).toContain("Motion to approve");
+			expect(transcripts[0].meetingId).toBe(meeting.id);
+			expect(transcripts[0].sourceUrl).toBe(
+				"https://youtube.com/watch?v=test123",
+			);
+		});
+
+		it("stores a whisper transcript with segments", async () => {
+			const db = createTestDb();
+			const layer = StorageServiceLive(db);
+
+			const meeting = await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeMeeting(testMeetingInput);
+				}).pipe(Effect.provide(layer)),
+			);
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeTranscript({
+						meetingId: meeting.id,
+						source: "whisper",
+						rawText: "The council discussed budget.",
+						segments: [
+							{
+								text: "The council discussed budget.",
+								startMs: 0,
+								durationMs: 5000,
+							},
+						],
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const transcripts = db.select().from(schema.transcripts).all();
+			expect(transcripts).toHaveLength(1);
+			expect(transcripts[0].source).toBe("whisper");
+			expect(transcripts[0].segments).toEqual([
+				{
+					text: "The council discussed budget.",
+					startMs: 0,
+					durationMs: 5000,
+				},
+			]);
+		});
+	});
 });

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -54,6 +54,14 @@ type MeetingInput = {
 	}>;
 };
 
+type TranscriptInput = {
+	meetingId: number;
+	source: "captions" | "whisper";
+	rawText: string;
+	segments?: Array<{ text: string; startMs: number; durationMs: number }>;
+	sourceUrl?: string;
+};
+
 /** Minimal handle returned after a successful store — just enough to reference the meeting. */
 type Meeting = { id: number; date: string; bodyId: number };
 
@@ -74,6 +82,7 @@ interface StorageServiceInterface {
 		slug: string,
 		date: string,
 	): Effect.Effect<MeetingDetail | null, DatabaseError>;
+	storeTranscript(input: TranscriptInput): Effect.Effect<void, DatabaseError>;
 }
 
 class StorageService extends Context.Tag("StorageService")<
@@ -120,6 +129,25 @@ function StorageServiceLive(db: BetterSQLite3Database<typeof schema>) {
 				catch: (error) =>
 					new DatabaseError({
 						operation: "getMeetingByBodyAndDate",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+		storeTranscript: (input) =>
+			Effect.try({
+				try: () => {
+					db.insert(schema.transcripts)
+						.values({
+							meetingId: input.meetingId,
+							source: input.source,
+							rawText: input.rawText,
+							segments: input.segments,
+							sourceUrl: input.sourceUrl,
+						})
+						.run();
+				},
+				catch: (error) =>
+					new DatabaseError({
+						operation: "storeTranscript",
 						message: error instanceof Error ? error.message : String(error),
 					}),
 			}),

--- a/src/pipeline/services/TranscriptionService.test.ts
+++ b/src/pipeline/services/TranscriptionService.test.ts
@@ -1,0 +1,203 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	TranscriptionService,
+	TranscriptionServiceLive,
+	WhisperLocalProviderLive,
+	YouTubeCaptionProviderLive,
+} from "./TranscriptionService.ts";
+
+/**
+ * Effect teaching note: These tests demonstrate how to test Effect services
+ * with injected dependencies. The youtube-transcript and whisper.cpp calls
+ * are replaced with mock functions, keeping tests fast and deterministic.
+ */
+
+const mockCaptionSegments = [
+	{ text: "Meeting called to order.", duration: 3000, offset: 0 },
+	{ text: "Motion to approve road repairs.", duration: 4000, offset: 3000 },
+];
+
+describe("TranscriptionService", () => {
+	describe("YouTubeCaptionProvider", () => {
+		it("extracts captions from a video and returns TranscriptResult", async () => {
+			const mockFetchTranscript = async () => mockCaptionSegments;
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("test-video-id");
+			}).pipe(
+				Effect.provide(
+					YouTubeCaptionProviderLive({
+						fetchTranscriptFn: mockFetchTranscript,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.source).toBe("captions");
+			expect(result.rawText).toBe(
+				"Meeting called to order. Motion to approve road repairs.",
+			);
+			expect(result.segments).toHaveLength(2);
+			expect(result.segments[0]).toEqual({
+				text: "Meeting called to order.",
+				startMs: 0,
+				durationMs: 3000,
+			});
+		});
+
+		it("maps youtube-transcript errors to TranscriptionError", async () => {
+			const mockFetchTranscript = async () => {
+				throw new Error("Transcript not available");
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("no-captions-video");
+			}).pipe(
+				Effect.provide(
+					YouTubeCaptionProviderLive({
+						fetchTranscriptFn: mockFetchTranscript,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromiseExit(program);
+			expect(result._tag).toBe("Failure");
+		});
+	});
+
+	describe("WhisperLocalProvider", () => {
+		it("transcribes audio via whisper.cpp and returns TranscriptResult", async () => {
+			const mockWhisperSegments = [
+				{ text: "The council discussed budget.", startMs: 0, durationMs: 5000 },
+				{
+					text: "Motion carried unanimously.",
+					startMs: 5000,
+					durationMs: 3000,
+				},
+			];
+
+			const mockRunWhisper = async () => ({
+				rawText: "The council discussed budget. Motion carried unanimously.",
+				segments: mockWhisperSegments,
+			});
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("whisper-video-id");
+			}).pipe(
+				Effect.provide(
+					WhisperLocalProviderLive({ runWhisperFn: mockRunWhisper }),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.source).toBe("whisper");
+			expect(result.rawText).toContain("council discussed budget");
+			expect(result.segments).toHaveLength(2);
+		});
+
+		it("maps whisper.cpp errors to TranscriptionError", async () => {
+			const mockRunWhisper = async () => {
+				throw new Error("whisper.cpp process exited with code 1");
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("bad-audio-id");
+			}).pipe(
+				Effect.provide(
+					WhisperLocalProviderLive({ runWhisperFn: mockRunWhisper }),
+				),
+			);
+
+			const result = await Effect.runPromiseExit(program);
+			expect(result._tag).toBe("Failure");
+		});
+	});
+
+	describe("Fallback chain", () => {
+		it("uses captions when available, skips Whisper", async () => {
+			let whisperCalled = false;
+			const mockFetchTranscript = async () => mockCaptionSegments;
+			const mockRunWhisper = async () => {
+				whisperCalled = true;
+				return { rawText: "whisper output", segments: [] };
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("has-captions");
+			}).pipe(
+				Effect.provide(
+					TranscriptionServiceLive({
+						fetchTranscriptFn: mockFetchTranscript,
+						runWhisperFn: mockRunWhisper,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.source).toBe("captions");
+			expect(whisperCalled).toBe(false);
+		});
+
+		it("falls back to Whisper when captions fail", async () => {
+			const mockFetchTranscript = async () => {
+				throw new Error("No captions available");
+			};
+			const mockRunWhisper = async () => ({
+				rawText: "Whisper transcribed this.",
+				segments: [
+					{ text: "Whisper transcribed this.", startMs: 0, durationMs: 4000 },
+				],
+			});
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("no-captions-video");
+			}).pipe(
+				Effect.provide(
+					TranscriptionServiceLive({
+						fetchTranscriptFn: mockFetchTranscript,
+						runWhisperFn: mockRunWhisper,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.source).toBe("whisper");
+			expect(result.rawText).toBe("Whisper transcribed this.");
+		});
+
+		it("fails with TranscriptionError when both providers fail", async () => {
+			const mockFetchTranscript = async () => {
+				throw new Error("No captions");
+			};
+			const mockRunWhisper = async () => {
+				throw new Error("Whisper crashed");
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* TranscriptionService;
+				return yield* service.transcribe("impossible-video");
+			}).pipe(
+				Effect.provide(
+					TranscriptionServiceLive({
+						fetchTranscriptFn: mockFetchTranscript,
+						runWhisperFn: mockRunWhisper,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromiseExit(program);
+			expect(result._tag).toBe("Failure");
+		});
+	});
+});

--- a/src/pipeline/services/TranscriptionService.ts
+++ b/src/pipeline/services/TranscriptionService.ts
@@ -1,0 +1,305 @@
+import { Context, Effect, Layer } from "effect";
+import { TranscriptionError } from "#/pipeline/errors.ts";
+
+/**
+ * Effect teaching note: This module demonstrates the "multiple implementations
+ * behind one Tag" pattern. TranscriptionService is a single Context.Tag with
+ * two possible providers: YouTubeCaptionProvider (free, instant) and
+ * WhisperLocalProvider (local whisper.cpp). The fallback chain composes them
+ * using Effect.catchTag — try captions first, fall back to Whisper if that fails.
+ * Callers depend only on TranscriptionService, never on a specific provider.
+ */
+
+type TranscriptSegment = {
+	text: string;
+	startMs: number;
+	durationMs: number;
+};
+
+type TranscriptResult = {
+	source: "captions" | "whisper";
+	rawText: string;
+	segments: TranscriptSegment[];
+};
+
+interface TranscriptionServiceInterface {
+	transcribe(
+		videoId: string,
+	): Effect.Effect<TranscriptResult, TranscriptionError>;
+}
+
+class TranscriptionService extends Context.Tag("TranscriptionService")<
+	TranscriptionService,
+	TranscriptionServiceInterface
+>() {}
+
+// ---------------------------------------------------------------------------
+// YouTubeCaptionProvider
+// ---------------------------------------------------------------------------
+
+type CaptionSegment = { text: string; duration: number; offset: number };
+
+type YouTubeCaptionProviderConfig = {
+	fetchTranscriptFn?: (videoId: string) => Promise<CaptionSegment[]>;
+};
+
+/**
+ * Effect teaching note: The fetchTranscriptFn injection follows the same
+ * pattern as YouTubeScraper's fetchFn — accept a function parameter so tests
+ * can substitute a mock, while production uses the real youtube-transcript call.
+ */
+function YouTubeCaptionProviderLive(config: YouTubeCaptionProviderConfig = {}) {
+	const fetchTranscript = config.fetchTranscriptFn ?? defaultFetchTranscript;
+
+	return Layer.succeed(TranscriptionService, {
+		transcribe: (videoId) =>
+			Effect.tryPromise({
+				try: async () => {
+					const segments = await fetchTranscript(videoId);
+					const rawText = segments.map((s) => s.text).join(" ");
+					return {
+						source: "captions" as const,
+						rawText,
+						segments: segments.map((s) => ({
+							text: s.text,
+							startMs: s.offset,
+							durationMs: s.duration,
+						})),
+					};
+				},
+				catch: (error) =>
+					new TranscriptionError({
+						videoId,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+async function defaultFetchTranscript(
+	videoId: string,
+): Promise<CaptionSegment[]> {
+	const { YoutubeTranscript } = await import("youtube-transcript");
+	return YoutubeTranscript.fetchTranscript(videoId);
+}
+
+// ---------------------------------------------------------------------------
+// WhisperLocalProvider
+// ---------------------------------------------------------------------------
+
+type WhisperResult = {
+	rawText: string;
+	segments: TranscriptSegment[];
+};
+
+type WhisperLocalProviderConfig = {
+	runWhisperFn?: (videoId: string) => Promise<WhisperResult>;
+};
+
+function WhisperLocalProviderLive(config: WhisperLocalProviderConfig = {}) {
+	const runWhisper = config.runWhisperFn ?? defaultRunWhisper;
+
+	return Layer.succeed(TranscriptionService, {
+		transcribe: (videoId) =>
+			Effect.tryPromise({
+				try: async () => {
+					const result = await runWhisper(videoId);
+					return {
+						source: "whisper" as const,
+						rawText: result.rawText,
+						segments: result.segments,
+					};
+				},
+				catch: (error) =>
+					new TranscriptionError({
+						videoId,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+/**
+ * Default Whisper implementation: downloads audio via yt-dlp, preprocesses
+ * to 16kHz mono WAV with noise reduction, runs whisper.cpp with medium model.
+ *
+ * HITL decisions baked in:
+ * - Model: medium
+ * - VAD: --vad enabled
+ * - No-speech threshold: 0.6
+ * - Audio: 16kHz mono WAV + highpass=200,lowpass=3000,afftdn
+ * - Initial prompt: Ellettsville civic vocabulary
+ */
+const WHISPER_INITIAL_PROMPT = [
+	"Ellettsville",
+	"Town Council",
+	"Plan Commission",
+	"BZA",
+	"Board of Zoning Appeals",
+	"ordinance",
+	"resolution",
+	"annexation",
+	"Sale Street",
+	"Temperance Street",
+	"INDOT",
+	"TIF district",
+	"remonstrance",
+].join(", ");
+
+async function defaultRunWhisper(videoId: string): Promise<WhisperResult> {
+	const { execSync } = await import("node:child_process");
+	const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
+	const { tmpdir } = await import("node:os");
+	const { join } = await import("node:path");
+
+	const workDir = mkdtempSync(join(tmpdir(), "civic-whisper-"));
+
+	try {
+		const audioPath = join(workDir, "audio.wav");
+		const outputPath = join(workDir, "output");
+
+		// Download audio with yt-dlp and preprocess with ffmpeg
+		// 16kHz mono WAV + noise reduction (highpass, lowpass, afftdn)
+		execSync(
+			[
+				"yt-dlp",
+				"--extract-audio",
+				"--audio-format",
+				"wav",
+				"-o",
+				join(workDir, "raw.%(ext)s"),
+				`https://www.youtube.com/watch?v=${videoId}`,
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+
+		execSync(
+			[
+				"ffmpeg",
+				"-i",
+				join(workDir, "raw.wav"),
+				"-ar",
+				"16000",
+				"-ac",
+				"1",
+				"-af",
+				"highpass=f=200,lowpass=f=3000,afftdn",
+				audioPath,
+			].join(" "),
+			{ stdio: "pipe" },
+		);
+
+		// Run whisper.cpp with medium model, VAD, and civic vocabulary prompt
+		execSync(
+			[
+				"whisper-cpp",
+				"--model",
+				"medium",
+				"--vad",
+				"--no-speech-threshold",
+				"0.6",
+				"--output-json",
+				"--output-file",
+				outputPath,
+				"--initial-prompt",
+				`"${WHISPER_INITIAL_PROMPT}"`,
+				audioPath,
+			].join(" "),
+			{ stdio: "pipe", timeout: 60 * 60 * 1000 }, // 60 min timeout
+		);
+
+		const jsonOutput = JSON.parse(readFileSync(`${outputPath}.json`, "utf-8"));
+		const segments: TranscriptSegment[] = (jsonOutput.transcription ?? []).map(
+			(seg: { text: string; offsets: { from: number; to: number } }) => ({
+				text: seg.text.trim(),
+				startMs: seg.offsets.from,
+				durationMs: seg.offsets.to - seg.offsets.from,
+			}),
+		);
+
+		const rawText = segments.map((s) => s.text).join(" ");
+		return { rawText, segments };
+	} finally {
+		rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback chain: captions → Whisper
+// ---------------------------------------------------------------------------
+
+/**
+ * Effect teaching note: This is the key composition pattern — Effect.catchTag.
+ * When captions fail with TranscriptionError, we catch that specific tag and
+ * try Whisper instead. If Whisper also fails, the TranscriptionError propagates.
+ * Callers just see TranscriptionService — they don't know about the fallback.
+ */
+
+type TranscriptionServiceLiveConfig = {
+	fetchTranscriptFn?: (videoId: string) => Promise<CaptionSegment[]>;
+	runWhisperFn?: (videoId: string) => Promise<WhisperResult>;
+};
+
+function TranscriptionServiceLive(config: TranscriptionServiceLiveConfig = {}) {
+	return Layer.succeed(TranscriptionService, {
+		transcribe: (videoId) => {
+			// Try captions first
+			const captionsAttempt = Effect.tryPromise({
+				try: async () => {
+					const fetchTranscript =
+						config.fetchTranscriptFn ?? defaultFetchTranscript;
+					const segments = await fetchTranscript(videoId);
+					const rawText = segments.map((s) => s.text).join(" ");
+					return {
+						source: "captions" as const,
+						rawText,
+						segments: segments.map((s) => ({
+							text: s.text,
+							startMs: s.offset,
+							durationMs: s.duration,
+						})),
+					};
+				},
+				catch: (error) =>
+					new TranscriptionError({
+						videoId,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			});
+
+			// Fall back to Whisper on caption failure
+			return captionsAttempt.pipe(
+				Effect.catchTag("TranscriptionError", () =>
+					Effect.tryPromise({
+						try: async () => {
+							const runWhisper = config.runWhisperFn ?? defaultRunWhisper;
+							const result = await runWhisper(videoId);
+							return {
+								source: "whisper" as const,
+								rawText: result.rawText,
+								segments: result.segments,
+							};
+						},
+						catch: (error) =>
+							new TranscriptionError({
+								videoId,
+								message: error instanceof Error ? error.message : String(error),
+							}),
+					}),
+				),
+			);
+		},
+	});
+}
+
+export {
+	TranscriptionService,
+	YouTubeCaptionProviderLive,
+	WhisperLocalProviderLive,
+	TranscriptionServiceLive,
+};
+export type {
+	TranscriptResult,
+	TranscriptSegment,
+	TranscriptionServiceInterface,
+};

--- a/src/pipeline/services/YouTubeScraper.test.ts
+++ b/src/pipeline/services/YouTubeScraper.test.ts
@@ -1,0 +1,159 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { YouTubeScraper, YouTubeScraperLive } from "./YouTubeScraper.ts";
+
+const mockPlaylistItemsResponse = {
+	items: [
+		{
+			snippet: {
+				resourceId: { videoId: "video1" },
+				title: "Town Council, March 23, 2026",
+				publishedAt: "2026-03-24T00:00:00Z",
+			},
+		},
+		{
+			snippet: {
+				resourceId: { videoId: "video2" },
+				title: "Plan Commission, March 15, 2026",
+				publishedAt: "2026-03-16T00:00:00Z",
+			},
+		},
+	],
+};
+
+const mockVideosResponse = {
+	items: [
+		{ id: "video1", contentDetails: { caption: "true" } },
+		{ id: "video2", contentDetails: { caption: "false" } },
+	],
+};
+
+function createMockFetch() {
+	return async (url: string | URL | Request) => {
+		const urlStr = url.toString();
+		if (urlStr.includes("playlistItems")) {
+			return new Response(JSON.stringify(mockPlaylistItemsResponse));
+		}
+		if (urlStr.includes("/videos")) {
+			return new Response(JSON.stringify(mockVideosResponse));
+		}
+		return new Response("Not found", { status: 404 });
+	};
+}
+
+describe("YouTubeScraper", () => {
+	it("lists videos from a playlist with caption availability", async () => {
+		const program = Effect.gen(function* () {
+			const scraper = yield* YouTubeScraper;
+			return yield* scraper.listPlaylistVideos("PLtest123");
+		}).pipe(
+			Effect.provide(
+				YouTubeScraperLive({
+					apiKey: "test-key",
+					fetchFn: createMockFetch(),
+				}),
+			),
+		);
+
+		const videos = await Effect.runPromise(program);
+
+		expect(videos).toHaveLength(2);
+		expect(videos[0]).toEqual({
+			videoId: "video1",
+			title: "Town Council, March 23, 2026",
+			publishedAt: "2026-03-24T00:00:00Z",
+			hasCaptions: true,
+		});
+		expect(videos[1]).toEqual({
+			videoId: "video2",
+			title: "Plan Commission, March 15, 2026",
+			publishedAt: "2026-03-16T00:00:00Z",
+			hasCaptions: false,
+		});
+	});
+
+	it("handles paginated playlist responses", async () => {
+		let callCount = 0;
+		const paginatedFetch = async (url: string | URL | Request) => {
+			const urlStr = url.toString();
+			if (urlStr.includes("playlistItems")) {
+				callCount++;
+				if (callCount === 1) {
+					return new Response(
+						JSON.stringify({
+							nextPageToken: "page2token",
+							items: [
+								{
+									snippet: {
+										resourceId: { videoId: "v1" },
+										title: "Video 1",
+										publishedAt: "2026-01-01T00:00:00Z",
+									},
+								},
+							],
+						}),
+					);
+				}
+				return new Response(
+					JSON.stringify({
+						items: [
+							{
+								snippet: {
+									resourceId: { videoId: "v2" },
+									title: "Video 2",
+									publishedAt: "2026-02-01T00:00:00Z",
+								},
+							},
+						],
+					}),
+				);
+			}
+			if (urlStr.includes("/videos")) {
+				return new Response(
+					JSON.stringify({
+						items: [
+							{ id: "v1", contentDetails: { caption: "true" } },
+							{ id: "v2", contentDetails: { caption: "true" } },
+						],
+					}),
+				);
+			}
+			return new Response("Not found", { status: 404 });
+		};
+
+		const program = Effect.gen(function* () {
+			const scraper = yield* YouTubeScraper;
+			return yield* scraper.listPlaylistVideos("PLpaginated");
+		}).pipe(
+			Effect.provide(
+				YouTubeScraperLive({
+					apiKey: "test-key",
+					fetchFn: paginatedFetch,
+				}),
+			),
+		);
+
+		const videos = await Effect.runPromise(program);
+		expect(videos).toHaveLength(2);
+		expect(callCount).toBe(2); // two pages fetched
+	});
+
+	it("maps YouTube API errors to NetworkError", async () => {
+		const errorFetch = async () =>
+			new Response(JSON.stringify({ error: { message: "Quota exceeded" } }), {
+				status: 403,
+			});
+
+		const program = Effect.gen(function* () {
+			const scraper = yield* YouTubeScraper;
+			return yield* scraper.listPlaylistVideos("PLtest");
+		}).pipe(
+			Effect.provide(
+				YouTubeScraperLive({ apiKey: "test-key", fetchFn: errorFetch }),
+			),
+		);
+
+		const result = await Effect.runPromiseExit(program);
+		expect(result._tag).toBe("Failure");
+	});
+});

--- a/src/pipeline/services/YouTubeScraper.ts
+++ b/src/pipeline/services/YouTubeScraper.ts
@@ -143,10 +143,10 @@ function fetchCaptionAvailability(
 	});
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: YouTube API response shape varies by endpoint
 function fetchJson(
 	url: string,
 	fetchFn: typeof globalThis.fetch,
+	// biome-ignore lint/suspicious/noExplicitAny: YouTube API JSON shape varies by endpoint
 ): Effect.Effect<any, NetworkError> {
 	return Effect.tryPromise({
 		try: async () => {

--- a/src/pipeline/services/YouTubeScraper.ts
+++ b/src/pipeline/services/YouTubeScraper.ts
@@ -1,0 +1,169 @@
+import { Context, Effect, Layer } from "effect";
+import { NetworkError } from "#/pipeline/errors.ts";
+
+/**
+ * Effect teaching note: This service demonstrates how to wrap an external REST API
+ * (YouTube Data API v3) in an Effect service. The key pattern is:
+ * 1. Define types for the domain (YouTubeVideo)
+ * 2. Define a service interface with Context.Tag
+ * 3. Wrap HTTP calls in Effect.tryPromise at the boundary
+ * 4. Inject a fetch function for testability
+ */
+
+type YouTubeVideo = {
+	videoId: string;
+	title: string;
+	publishedAt: string;
+	hasCaptions: boolean;
+};
+
+interface YouTubeScraperInterface {
+	listPlaylistVideos(
+		playlistId: string,
+	): Effect.Effect<YouTubeVideo[], NetworkError>;
+}
+
+class YouTubeScraper extends Context.Tag("YouTubeScraper")<
+	YouTubeScraper,
+	YouTubeScraperInterface
+>() {}
+
+const YOUTUBE_API_BASE = "https://www.googleapis.com/youtube/v3";
+
+type YouTubeScraperConfig = {
+	apiKey: string;
+	fetchFn?: typeof globalThis.fetch;
+};
+
+function YouTubeScraperLive(config: YouTubeScraperConfig) {
+	const fetchFn = config.fetchFn ?? globalThis.fetch;
+
+	return Layer.succeed(YouTubeScraper, {
+		listPlaylistVideos: (playlistId) =>
+			Effect.gen(function* () {
+				// Step 1: Fetch all video IDs from the playlist (paginated)
+				const videoEntries = yield* fetchAllPlaylistItems(
+					playlistId,
+					config.apiKey,
+					fetchFn,
+				);
+
+				if (videoEntries.length === 0) return [];
+
+				// Step 2: Check caption availability in batches of 50
+				const captionMap = yield* fetchCaptionAvailability(
+					videoEntries.map((v) => v.videoId),
+					config.apiKey,
+					fetchFn,
+				);
+
+				// Step 3: Combine playlist data with caption info
+				return videoEntries.map((entry) => ({
+					...entry,
+					hasCaptions: captionMap.get(entry.videoId) ?? false,
+				}));
+			}),
+	});
+}
+
+/**
+ * Fetches all items from a YouTube playlist, handling pagination.
+ * YouTube API returns max 50 items per page with a nextPageToken.
+ */
+function fetchAllPlaylistItems(
+	playlistId: string,
+	apiKey: string,
+	fetchFn: typeof globalThis.fetch,
+): Effect.Effect<
+	Array<{ videoId: string; title: string; publishedAt: string }>,
+	NetworkError
+> {
+	return Effect.gen(function* () {
+		const allItems: Array<{
+			videoId: string;
+			title: string;
+			publishedAt: string;
+		}> = [];
+		let pageToken: string | undefined;
+
+		do {
+			const url = new URL(`${YOUTUBE_API_BASE}/playlistItems`);
+			url.searchParams.set("part", "snippet");
+			url.searchParams.set("playlistId", playlistId);
+			url.searchParams.set("maxResults", "50");
+			url.searchParams.set("key", apiKey);
+			if (pageToken) url.searchParams.set("pageToken", pageToken);
+
+			const data = yield* fetchJson(url.toString(), fetchFn);
+
+			for (const item of data.items ?? []) {
+				allItems.push({
+					videoId: item.snippet.resourceId.videoId,
+					title: item.snippet.title,
+					publishedAt: item.snippet.publishedAt,
+				});
+			}
+
+			pageToken = data.nextPageToken;
+		} while (pageToken);
+
+		return allItems;
+	});
+}
+
+/**
+ * Checks caption availability for a batch of video IDs using
+ * the YouTube videos.list endpoint with contentDetails part.
+ * Batches into groups of 50 (API limit).
+ */
+function fetchCaptionAvailability(
+	videoIds: string[],
+	apiKey: string,
+	fetchFn: typeof globalThis.fetch,
+): Effect.Effect<Map<string, boolean>, NetworkError> {
+	return Effect.gen(function* () {
+		const captionMap = new Map<string, boolean>();
+
+		// Process in batches of 50
+		for (let i = 0; i < videoIds.length; i += 50) {
+			const batch = videoIds.slice(i, i + 50);
+			const url = new URL(`${YOUTUBE_API_BASE}/videos`);
+			url.searchParams.set("part", "contentDetails");
+			url.searchParams.set("id", batch.join(","));
+			url.searchParams.set("key", apiKey);
+
+			const data = yield* fetchJson(url.toString(), fetchFn);
+
+			for (const item of data.items ?? []) {
+				captionMap.set(item.id, item.contentDetails?.caption === "true");
+			}
+		}
+
+		return captionMap;
+	});
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: YouTube API response shape varies by endpoint
+function fetchJson(
+	url: string,
+	fetchFn: typeof globalThis.fetch,
+): Effect.Effect<any, NetworkError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const response = await fetchFn(url);
+			if (!response.ok) {
+				const body = await response.text();
+				throw new Error(`YouTube API error ${response.status}: ${body}`);
+			}
+			return response.json();
+		},
+		catch: (error) =>
+			new NetworkError({
+				url,
+				message: error instanceof Error ? error.message : String(error),
+			}),
+	});
+}
+
+export { YouTubeScraper, YouTubeScraperLive };
+export type { YouTubeVideo, YouTubeScraperConfig };


### PR DESCRIPTION
## Summary

Adds video transcription capability to the Civic Mirror pipeline. Implements `YouTubeScraper` (Data API v3 playlist listing with pagination and caption detection), `TranscriptionService` with two providers behind one Effect interface — `YouTubeCaptionProvider` (free, instant via `youtube-transcript`) and `WhisperLocalProvider` (whisper.cpp with medium model, VAD, Ellettsville civic vocabulary) — composed into an automatic fallback chain via `Effect.catchTag`. Extends `StorageService` with `storeTranscript` for persisting to the `transcripts` table.

## PRD

Part of #1

## Slices

- [x] #2 — Tracer Bullet: Schema + eGov Pipeline + Meeting Detail Page
- [x] #3 — YouTube Transcription Pipeline ← this PR
- [ ] #4 — Finalsite Scraper
- [ ] #5 — Landing Page + Meeting Feed + High-Level Spending
- [ ] #6 — Railway Deployment
- [ ] #7 — Detailed Spending Dashboard
- [ ] #8 — Pipeline Orchestrator + CLI + Alerts
- [ ] #9 — QA: Full Manual Verification

## Key Decisions

- **Whisper config (HITL):** medium model, `--vad` enabled, `--no-speech-threshold 0.6`, 16kHz mono WAV with `highpass=200,lowpass=3000,afftdn` noise reduction, `initial_prompt` loaded with Ellettsville civic terms (Town Council, BZA, Sale Street, INDOT, TIF district, etc.)
- **Rate limiting left to orchestrator:** YouTube API rate limiting (2-5s delays) is a cross-cutting concern that composes at the pipeline level via `Effect.delay`/`Schedule`, not baked into the scraper service
- **Injectable dependencies for testability:** Both `YouTubeScraperLive` and all `TranscriptionService` providers accept mock functions, keeping tests fast and deterministic (20 tests, no network calls)

## Effect Patterns Introduced

- `Effect.catchTag("TranscriptionError")` fallback chain (captions → Whisper)
- Multiple service implementations behind one `Context.Tag`
- Child process management wrapped in `Effect.tryPromise`