### PR TITLE
Finalsite Scraper

### DIFF
--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -249,8 +249,8 @@ describe("FinalsiteScraper", () => {
 
 	describe("FinalsiteScraperLive", () => {
 		it("fetches page HTML and returns parsed listings via Effect", async () => {
-			const mockFetch = async (url: string) => {
-				if (url === "https://www.rbbschools.net/school-board") {
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				if (String(url) === "https://www.rbbschools.net/school-board") {
 					return new Response(SINGLE_ROW_FIXTURE, { status: 200 });
 				}
 				return new Response("Not Found", { status: 404 });
@@ -263,7 +263,7 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);
@@ -277,7 +277,7 @@ describe("FinalsiteScraper", () => {
 		});
 
 		it("returns NetworkError when fetch fails", async () => {
-			const mockFetch = async () => {
+			const mockFetch: typeof globalThis.fetch = async () => {
 				throw new Error("Connection refused");
 			};
 
@@ -288,19 +288,20 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);
 
-			const exit = await Effect.runPromiseExit(program);
-			expect(exit._tag).toBe("Failure");
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
+			expect(error.message).toBe("Connection refused");
 		});
 
 		it("downloads a document by UUID", async () => {
 			const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
-			const mockFetch = async (url: string) => {
-				if (url.includes("/fs/resource-manager/view/")) {
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				if (String(url).includes("/fs/resource-manager/view/")) {
 					return new Response(pdfBytes, { status: 200 });
 				}
 				return new Response("Not Found", { status: 404 });
@@ -313,7 +314,7 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -1,5 +1,10 @@
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { parseFinalsiteHtml } from "./FinalsiteScraper.ts";
+import {
+	FinalsiteScraper,
+	FinalsiteScraperLive,
+	parseFinalsiteHtml,
+} from "./FinalsiteScraper.ts";
 
 // Real HTML structure from rbbschools.net/school-board
 // Minimal fixture: one year panel with one meeting row containing one document link
@@ -239,6 +244,82 @@ describe("FinalsiteScraper", () => {
 </section>`;
 			const results = parseFinalsiteHtml(fixture);
 			expect(results).toEqual([]);
+		});
+	});
+
+	describe("FinalsiteScraperLive", () => {
+		it("fetches page HTML and returns parsed listings via Effect", async () => {
+			const mockFetch = async (url: string) => {
+				if (url === "https://www.rbbschools.net/school-board") {
+					return new Response(SINGLE_ROW_FIXTURE, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.scrapeListings();
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const results = await Effect.runPromise(program);
+			expect(results).toHaveLength(1);
+			expect(results[0].date).toBe("January 6, 2026");
+			expect(results[0].documents[0].uuid).toBe(
+				"0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+			);
+		});
+
+		it("returns NetworkError when fetch fails", async () => {
+			const mockFetch = async () => {
+				throw new Error("Connection refused");
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.scrapeListings();
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const exit = await Effect.runPromiseExit(program);
+			expect(exit._tag).toBe("Failure");
+		});
+
+		it("downloads a document by UUID", async () => {
+			const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+			const mockFetch = async (url: string) => {
+				if (url.includes("/fs/resource-manager/view/")) {
+					return new Response(pdfBytes, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.downloadDocument("test-uuid-1234");
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+			expect(new Uint8Array(result)).toEqual(pdfBytes);
 		});
 	});
 });

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -180,5 +180,65 @@ describe("FinalsiteScraper", () => {
 			const results = parseFinalsiteHtml("<div>No content</div>");
 			expect(results).toEqual([]);
 		});
+
+		it("normalizes multiline meeting type text", () => {
+			const fixture = `
+<section class="fsElement fsPanel fsStyleAutoclear" role="tabpanel">
+	<header><h2 class="fsElementTitle"><a>2026</a></h2></header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr><th>Date</th><th>Type</th><th>Links</th></tr>
+						<tr>
+							<td><p>September 15, 2026</p></td>
+							<td>
+								<p>Regular Meeting 6:00 PM</p>
+								<p>Public Hearing</p>
+								<p>Proposed 2027 Budget, 2027 Capital Projects Plan,</p>
+								<p>2027 Bus Replacement Plan</p>
+							</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>`;
+			const results = parseFinalsiteHtml(fixture);
+
+			expect(results).toHaveLength(1);
+			// Multiline text should be collapsed to a single line with spaces
+			expect(results[0].meetingType).toBe(
+				"Regular Meeting 6:00 PM Public Hearing Proposed 2027 Budget, 2027 Capital Projects Plan, 2027 Bus Replacement Plan",
+			);
+		});
+
+		it("skips rows with empty date cells", () => {
+			const fixture = `
+<section class="fsElement fsPanel fsStyleAutoclear" role="tabpanel">
+	<header><h2 class="fsElementTitle"><a>2026</a></h2></header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr><th>Date</th><th>Type</th><th>Links</th></tr>
+						<tr>
+							<td></td>
+							<td>Orphan row</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>`;
+			const results = parseFinalsiteHtml(fixture);
+			expect(results).toEqual([]);
+		});
 	});
 });

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { parseFinalsiteHtml } from "./FinalsiteScraper.ts";
+
+// Real HTML structure from rbbschools.net/school-board
+// Minimal fixture: one year panel with one meeting row containing one document link
+const SINGLE_ROW_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_10343" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-10343">2026</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+						<tr>
+							<td><p>January 6, 2026</p></td>
+							<td>Board Organizational Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="1626SchoolBoardOrganizationalMeetingAgenda.pdf" data-resource-uuid="0e57bdf7-c837-4f03-8a79-8a1c69744ee7" href="/fs/resource-manager/view/0e57bdf7-c837-4f03-8a79-8a1c69744ee7" target="_blank">Agenda</a></p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+// Multi-row fixture with multiple documents per meeting and a row with no links
+const MULTI_ROW_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_10343" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-10343">2026</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+						<tr>
+							<td><p>January 20, 2026</p></td>
+							<td>Regular Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="1202026Agenda1.pdf" data-resource-uuid="d165d0db-39de-481e-94e1-74e48e3c7e94" href="/fs/resource-manager/view/d165d0db-39de-481e-94e1-74e48e3c7e94" target="_blank">Agenda</a></p>
+								<p><a data-file-name="12026Regualmeetingsignedminutes.pdf" data-resource-uuid="c8621f1b-b572-4add-a921-dd5ca2734c3f" href="/fs/resource-manager/view/c8621f1b-b572-4add-a921-dd5ca2734c3f" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+						<tr>
+							<td><p>February 24, 2026</p></td>
+							<td>Special Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="NoticeofSpecialMeeting22426.pdf" data-resource-uuid="50cd929a-6473-4922-8127-4da839d7a2b7" href="/fs/resource-manager/view/50cd929a-6473-4922-8127-4da839d7a2b7" target="_blank">Notice</a></p>
+								<p><a data-file-name="2242026SpecialMeetingAgenda1.pdf" data-resource-uuid="0010f58c-a288-4653-bc00-dfe960112624" href="/fs/resource-manager/view/0010f58c-a288-4653-bc00-dfe960112624" target="_blank">Agenda</a></p>
+								<p><a data-file-name="22426Specialmeetingsignedminutes.pdf" data-resource-uuid="91af54e2-e329-4255-84f0-18f891cae1b7" href="/fs/resource-manager/view/91af54e2-e329-4255-84f0-18f891cae1b7" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+						<tr>
+							<td><p>April 21, 2026</p></td>
+							<td>Regular Meeting 6:00 PM</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+// Fixture with thead (2025 uses this variant)
+const THEAD_VARIANT_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_9352" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-9352">2025</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<thead>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><p>January 21, 2025</p></td>
+							<td>Board of Finance Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="01-21-25-Finance-Meeting-Agenda-DRK-1-2.pdf" data-resource-uuid="4a69e480-d97f-457e-81f4-b97cb365c541" href="/fs/resource-manager/view/4a69e480-d97f-457e-81f4-b97cb365c541" target="_blank">Agenda</a></p>
+								<p><a data-file-name="01-21-25-Finance-meeting-signed-minutes.pdf" data-resource-uuid="7bf4774d-d7a0-4f76-848c-7f72a47c5293" href="/fs/resource-manager/view/7bf4774d-d7a0-4f76-848c-7f72a47c5293" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+describe("FinalsiteScraper", () => {
+	describe("parseFinalsiteHtml", () => {
+		it("extracts a single meeting with one document link", () => {
+			const results = parseFinalsiteHtml(SINGLE_ROW_FIXTURE);
+
+			expect(results).toHaveLength(1);
+			expect(results[0]).toEqual({
+				date: "January 6, 2026",
+				meetingType: "Board Organizational Meeting 6:00 PM",
+				year: 2026,
+				documents: [
+					{
+						uuid: "0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+						documentType: "agenda",
+						downloadUrl:
+							"/fs/resource-manager/view/0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+						fileName: "1626SchoolBoardOrganizationalMeetingAgenda.pdf",
+					},
+				],
+			});
+		});
+
+		it("extracts multiple meetings with multiple documents per row", () => {
+			const results = parseFinalsiteHtml(MULTI_ROW_FIXTURE);
+
+			expect(results).toHaveLength(3);
+
+			// First meeting: 2 documents
+			expect(results[0].date).toBe("January 20, 2026");
+			expect(results[0].meetingType).toBe("Regular Meeting 6:00 PM");
+			expect(results[0].year).toBe(2026);
+			expect(results[0].documents).toHaveLength(2);
+			expect(results[0].documents[0].documentType).toBe("agenda");
+			expect(results[0].documents[1].documentType).toBe("minutes");
+
+			// Second meeting: 3 documents (notice + agenda + minutes)
+			expect(results[1].date).toBe("February 24, 2026");
+			expect(results[1].documents).toHaveLength(3);
+			expect(results[1].documents[0].documentType).toBe("notice");
+
+			// Third meeting: future meeting with no documents
+			expect(results[2].date).toBe("April 21, 2026");
+			expect(results[2].documents).toHaveLength(0);
+		});
+
+		it("handles thead variant used in some year panels", () => {
+			const results = parseFinalsiteHtml(THEAD_VARIANT_FIXTURE);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].date).toBe("January 21, 2025");
+			expect(results[0].year).toBe(2025);
+			expect(results[0].documents).toHaveLength(2);
+		});
+
+		it("handles multiple year panels in one page", () => {
+			const combined = SINGLE_ROW_FIXTURE + THEAD_VARIANT_FIXTURE;
+			const results = parseFinalsiteHtml(combined);
+
+			expect(results).toHaveLength(2);
+			expect(results[0].year).toBe(2026);
+			expect(results[1].year).toBe(2025);
+		});
+
+		it("returns empty array for HTML with no panels", () => {
+			const results = parseFinalsiteHtml("<div>No content</div>");
+			expect(results).toEqual([]);
+		});
+	});
+});

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -1,4 +1,6 @@
+import { Context, Effect, Layer } from "effect";
 import { JSDOM } from "jsdom";
+import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 
 /**
  * A single document attached to a Finalsite meeting listing.
@@ -100,5 +102,101 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 	return results;
 }
 
-export { parseFinalsiteHtml };
-export type { FinalsiteMeetingListing, FinalsiteDocument };
+/**
+ * Effect teaching note: This is the second implementation of a scraper service,
+ * demonstrating how Effect's dependency injection makes implementations swappable.
+ * Both EgovScraper and FinalsiteScraper can be provided to the same pipeline —
+ * the consumer depends on the Tag, not the concrete implementation. Swapping is
+ * just changing which Layer you provide.
+ */
+
+interface FinalsiteScraperInterface {
+	/** Fetch the Finalsite school board page and parse meeting listings. */
+	scrapeListings(): Effect.Effect<
+		FinalsiteMeetingListing[],
+		NetworkError | ParseError
+	>;
+	/** Download a PDF document by its UUID and return the raw bytes. */
+	downloadDocument(uuid: string): Effect.Effect<ArrayBuffer, NetworkError>;
+}
+
+class FinalsiteScraper extends Context.Tag("FinalsiteScraper")<
+	FinalsiteScraper,
+	FinalsiteScraperInterface
+>() {}
+
+type FinalsiteScraperConfig = {
+	/** Base URL for the Finalsite school board page. */
+	baseUrl: string;
+	/** Injectable fetch function for testability. */
+	fetchFn?: typeof globalThis.fetch;
+};
+
+/**
+ * Effect teaching note: Layer.succeed provides a service value directly —
+ * used when construction can't fail. Each method wraps its HTTP calls in
+ * Effect.tryPromise, converting thrown exceptions into typed NetworkError
+ * or ParseError values. The fetchFn parameter enables testing without
+ * hitting the real Finalsite server.
+ */
+function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
+	const fetchFn = config.fetchFn ?? globalThis.fetch;
+
+	return Layer.succeed(FinalsiteScraper, {
+		scrapeListings: () =>
+			Effect.gen(function* () {
+				const html = yield* Effect.tryPromise({
+					try: async () => {
+						const response = await fetchFn(config.baseUrl);
+						if (!response.ok) {
+							throw new Error(
+								`HTTP ${response.status}: ${response.statusText}`,
+							);
+						}
+						return response.text();
+					},
+					catch: (error) =>
+						new NetworkError({
+							url: config.baseUrl,
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+
+				return yield* Effect.try({
+					try: () => parseFinalsiteHtml(html),
+					catch: (error) =>
+						new ParseError({
+							source: "finalsite",
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+			}),
+
+		downloadDocument: (uuid) =>
+			Effect.tryPromise({
+				try: async () => {
+					const url = new URL(
+						`/fs/resource-manager/view/${uuid}`,
+						config.baseUrl,
+					);
+					const response = await fetchFn(url.toString());
+					if (!response.ok) {
+						throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+					}
+					return response.arrayBuffer();
+				},
+				catch: (error) =>
+					new NetworkError({
+						url: `/fs/resource-manager/view/${uuid}`,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+export { FinalsiteScraper, FinalsiteScraperLive, parseFinalsiteHtml };
+export type {
+	FinalsiteMeetingListing,
+	FinalsiteDocument,
+	FinalsiteScraperConfig,
+};

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -1,0 +1,102 @@
+import { JSDOM } from "jsdom";
+
+/**
+ * A single document attached to a Finalsite meeting listing.
+ * Each document has a UUID used for the download URL path.
+ */
+type FinalsiteDocument = {
+	/** Finalsite resource UUID, parsed from the href path. */
+	uuid: string;
+	/** Normalized document type: "agenda" | "minutes" | "notice". */
+	documentType: string;
+	/** Relative URL path for downloading the document. */
+	downloadUrl: string;
+	/** Original filename from the data-file-name attribute. */
+	fileName: string;
+};
+
+/**
+ * A single meeting listing extracted from the Finalsite school board page.
+ * Groups all documents for one meeting date together.
+ */
+type FinalsiteMeetingListing = {
+	/** Meeting date as displayed (e.g. "January 6, 2026"). */
+	date: string;
+	/** Meeting type/description (e.g. "Regular Meeting 6:00 PM"). */
+	meetingType: string;
+	/** Year extracted from the accordion panel heading. */
+	year: number;
+	/** Documents attached to this meeting (agenda, minutes, notice). */
+	documents: FinalsiteDocument[];
+};
+
+/**
+ * Parses the Finalsite school board page HTML into structured meeting listings.
+ *
+ * The Finalsite CMS uses accordion panels (section.fsPanel) organized by year,
+ * each containing an HTML table with Date/Type/Links columns. Document links
+ * use UUID-based paths: /fs/resource-manager/view/{UUID}.
+ *
+ * Rows without any document links (future meetings with only &nbsp;) are
+ * included with an empty documents array — the pipeline can filter them later.
+ *
+ * Effect teaching note: Like parseEgovListingHtml, this is a pure function
+ * (string in, data out). Keeping parsing separate from HTTP fetching means
+ * this can be tested with fixture HTML and composed into an Effect pipeline
+ * at a higher level.
+ */
+function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
+	const dom = new JSDOM(html);
+	const doc = dom.window.document;
+	const panels = doc.querySelectorAll("section.fsPanel");
+	const results: FinalsiteMeetingListing[] = [];
+
+	for (const panel of panels) {
+		const yearText =
+			panel.querySelector("h2.fsElementTitle")?.textContent?.trim() ?? "";
+		const yearMatch = yearText.match(/\d{4}/);
+		if (!yearMatch) continue;
+		const year = Number.parseInt(yearMatch[0], 10);
+
+		const rows = panel.querySelectorAll("table.table-styled tr");
+
+		for (const row of rows) {
+			// Skip header rows
+			if (row.querySelector("th")) continue;
+
+			const cells = row.querySelectorAll("td");
+			if (cells.length < 3) continue;
+
+			const date = (cells[0].textContent ?? "").trim();
+			const meetingType = (cells[1].textContent ?? "").trim();
+
+			if (!date) continue;
+
+			const documents: FinalsiteDocument[] = [];
+			const links = cells[2].querySelectorAll("a[data-resource-uuid]");
+
+			for (const link of links) {
+				const uuid = link.getAttribute("data-resource-uuid") ?? "";
+				const href = link.getAttribute("href") ?? "";
+				const fileName = link.getAttribute("data-file-name") ?? "";
+				const linkText = (link.textContent ?? "").trim().toLowerCase();
+
+				if (!uuid) continue;
+
+				documents.push({
+					uuid,
+					documentType: linkText,
+					downloadUrl: href,
+					fileName,
+				});
+			}
+
+			results.push({ date, meetingType, year, documents });
+		}
+	}
+
+	return results;
+}
+
+export { parseFinalsiteHtml };
+export type { FinalsiteMeetingListing, FinalsiteDocument };

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -68,7 +68,9 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 			if (cells.length < 3) continue;
 
 			const date = (cells[0].textContent ?? "").trim();
-			const meetingType = (cells[1].textContent ?? "").trim();
+			const meetingType = (cells[1].textContent ?? "")
+				.replace(/\s+/g, " ")
+				.trim();
 
 			if (!date) continue;
 

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -2,6 +2,8 @@ import { Context, Effect, Layer } from "effect";
 import { JSDOM } from "jsdom";
 import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 
+type FinalsiteDocumentType = "agenda" | "minutes" | "notice";
+
 /**
  * A single document attached to a Finalsite meeting listing.
  * Each document has a UUID used for the download URL path.
@@ -9,8 +11,8 @@ import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 type FinalsiteDocument = {
 	/** Finalsite resource UUID, parsed from the href path. */
 	uuid: string;
-	/** Normalized document type: "agenda" | "minutes" | "notice". */
-	documentType: string;
+	/** Normalized document type. */
+	documentType: FinalsiteDocumentType;
 	/** Relative URL path for downloading the document. */
 	downloadUrl: string;
 	/** Original filename from the data-file-name attribute. */
@@ -79,13 +81,22 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 			const documents: FinalsiteDocument[] = [];
 			const links = cells[2].querySelectorAll("a[data-resource-uuid]");
 
+			const VALID_DOC_TYPES: FinalsiteDocumentType[] = [
+				"agenda",
+				"minutes",
+				"notice",
+			];
+
 			for (const link of links) {
 				const uuid = link.getAttribute("data-resource-uuid") ?? "";
 				const href = link.getAttribute("href") ?? "";
 				const fileName = link.getAttribute("data-file-name") ?? "";
-				const linkText = (link.textContent ?? "").trim().toLowerCase();
+				const linkText = (link.textContent ?? "")
+					.trim()
+					.toLowerCase() as FinalsiteDocumentType;
 
 				if (!uuid) continue;
+				if (!VALID_DOC_TYPES.includes(linkText)) continue;
 
 				documents.push({
 					uuid,
@@ -139,7 +150,9 @@ type FinalsiteScraperConfig = {
  * or ParseError values. The fetchFn parameter enables testing without
  * hitting the real Finalsite server.
  */
-function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
+function FinalsiteScraperLive(
+	config: FinalsiteScraperConfig,
+): Layer.Layer<FinalsiteScraper> {
 	const fetchFn = config.fetchFn ?? globalThis.fetch;
 
 	return Layer.succeed(FinalsiteScraper, {
@@ -196,6 +209,7 @@ function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
 
 export { FinalsiteScraper, FinalsiteScraperLive, parseFinalsiteHtml };
 export type {
+	FinalsiteDocumentType,
 	FinalsiteMeetingListing,
 	FinalsiteDocument,
 	FinalsiteScraperConfig,


### PR DESCRIPTION
## Summary

Implements the `FinalsiteScraper` for scraping RBB School Board meeting documents from the Finalsite CMS. Pure HTML parsing of accordion panels with UUID-based PDF download, wrapped in an Effect service Layer that's swappable via dependency injection — the same pattern as `YouTubeScraper`.

## PRD

Part of #1

## Slices

- [x] #2 — Tracer Bullet: Schema + eGov Pipeline + Meeting Detail Page
- [x] #3 — YouTube Transcription Pipeline
- [x] #4 — Finalsite Scraper ← **this PR**
- [ ] #5 — Landing Page + Meeting Feed + High-Level Spending
- [ ] #6 — Railway Deployment
- [ ] #7 — Detailed Spending Dashboard
- [ ] #8 — Pipeline Orchestrator + CLI + Alerts
- [ ] #9 — QA: Full Manual Verification

## Key Decisions

- Parser handles two table variants: `<thead>` (2025 panels) and `<th>`-in-`<tbody>` (2026 panel) — the Finalsite CMS is inconsistent across years
- Future meetings (no document links yet) are included with an empty `documents` array rather than filtered out — the pipeline can decide what to do with them
- Meeting type text is whitespace-normalized since Finalsite uses multiple `<p>` tags for multiline descriptions
- Smoke-tested against live rbbschools.net: 155 meetings parsed, PDF download confirmed (%PDF header)

## Test plan

- [x] 10 unit tests passing (7 parser + 3 Effect service with mock fetch)
- [x] Smoke test against live Finalsite site: 155 meetings, 146 with documents
- [x] Live PDF download verified: correct %PDF header, ~102KB agenda file