### PR TITLE
Finalsite scraper + landing page with meeting feed and fiscal summary

### DIFF
--- a/src/components/FiscalSummary.test.tsx
+++ b/src/components/FiscalSummary.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { FiscalSummary } from "./FiscalSummary.tsx";
+
+afterEach(cleanup);
+
+const sampleProps = {
+	byBody: [
+		{
+			bodyName: "Ellettsville Town Council",
+			bodySlug: "ellettsville-town-council",
+			totalAmount: 75000,
+			decisionCount: 3,
+		},
+		{
+			bodyName: "RBBSC School Board",
+			bodySlug: "rbbsc-school-board",
+			totalAmount: 30000,
+			decisionCount: 2,
+		},
+	],
+	byCategory: [
+		{ budgetCategory: "infrastructure", totalAmount: 50000, decisionCount: 2 },
+		{ budgetCategory: "education", totalAmount: 30000, decisionCount: 1 },
+	],
+	byTimePeriod: [
+		{ period: "2026-03", totalAmount: 65000, decisionCount: 3 },
+		{ period: "2026-02", totalAmount: 40000, decisionCount: 2 },
+	],
+	notableDecisions: [
+		{
+			title: "Sale Street Road Repairs",
+			amount: 50000,
+			status: "approved" as const,
+			bodyName: "Ellettsville Town Council",
+			bodySlug: "ellettsville-town-council",
+			date: "2026-03-23",
+		},
+	],
+};
+
+describe("FiscalSummary", () => {
+	it("renders spending by body totals", () => {
+		render(<FiscalSummary {...sampleProps} />);
+
+		expect(screen.getByText("Spending by Body")).toBeDefined();
+		expect(screen.getByText("$75,000")).toBeDefined();
+		expect(
+			screen.getAllByText("Ellettsville Town Council").length,
+		).toBeGreaterThanOrEqual(1);
+		expect(screen.getByText("RBBSC School Board")).toBeDefined();
+	});
+
+	it("renders spending by category", () => {
+		render(<FiscalSummary {...sampleProps} />);
+
+		expect(screen.getByText("Spending by Category")).toBeDefined();
+		expect(screen.getByText("infrastructure")).toBeDefined();
+		expect(screen.getByText("education")).toBeDefined();
+	});
+
+	it("renders spending by time period", () => {
+		render(<FiscalSummary {...sampleProps} />);
+
+		expect(screen.getByText("2026-03")).toBeDefined();
+		expect(screen.getByText("$65,000")).toBeDefined();
+	});
+
+	it("renders notable fiscal decisions", () => {
+		render(<FiscalSummary {...sampleProps} />);
+
+		expect(screen.getByText("Sale Street Road Repairs")).toBeDefined();
+	});
+
+	it("shows empty state when no fiscal data", () => {
+		render(
+			<FiscalSummary
+				byBody={[]}
+				byCategory={[]}
+				byTimePeriod={[]}
+				notableDecisions={[]}
+			/>,
+		);
+
+		expect(screen.getByText(/no fiscal data/i)).toBeDefined();
+	});
+});

--- a/src/components/FiscalSummary.test.tsx
+++ b/src/components/FiscalSummary.test.tsx
@@ -44,33 +44,33 @@ describe("FiscalSummary", () => {
 	it("renders spending by body totals", () => {
 		render(<FiscalSummary {...sampleProps} />);
 
-		expect(screen.getByText("Spending by Body")).toBeDefined();
-		expect(screen.getByText("$75,000")).toBeDefined();
+		screen.getByText("Spending by Body");
+		screen.getByText("$75,000");
 		expect(
 			screen.getAllByText("Ellettsville Town Council").length,
 		).toBeGreaterThanOrEqual(1);
-		expect(screen.getByText("RBBSC School Board")).toBeDefined();
+		screen.getByText("RBBSC School Board");
 	});
 
 	it("renders spending by category", () => {
 		render(<FiscalSummary {...sampleProps} />);
 
-		expect(screen.getByText("Spending by Category")).toBeDefined();
-		expect(screen.getByText("infrastructure")).toBeDefined();
-		expect(screen.getByText("education")).toBeDefined();
+		screen.getByText("Spending by Category");
+		screen.getByText("infrastructure");
+		screen.getByText("education");
 	});
 
 	it("renders spending by time period", () => {
 		render(<FiscalSummary {...sampleProps} />);
 
-		expect(screen.getByText("2026-03")).toBeDefined();
-		expect(screen.getByText("$65,000")).toBeDefined();
+		screen.getByText("2026-03");
+		screen.getByText("$65,000");
 	});
 
 	it("renders notable fiscal decisions", () => {
 		render(<FiscalSummary {...sampleProps} />);
 
-		expect(screen.getByText("Sale Street Road Repairs")).toBeDefined();
+		screen.getByText("Sale Street Road Repairs");
 	});
 
 	it("shows empty state when no fiscal data", () => {
@@ -83,6 +83,6 @@ describe("FiscalSummary", () => {
 			/>,
 		);
 
-		expect(screen.getByText(/no fiscal data/i)).toBeDefined();
+		screen.getByText(/no fiscal data/i);
 	});
 });

--- a/src/components/FiscalSummary.tsx
+++ b/src/components/FiscalSummary.tsx
@@ -1,0 +1,190 @@
+import type {
+	FiscalByBody,
+	FiscalByCategory,
+	FiscalByTimePeriod,
+	NotableFiscalDecision,
+} from "#/db/queries.ts";
+
+function formatCurrency(amount: number): string {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	}).format(amount);
+}
+
+type FiscalSummaryProps = {
+	byBody: FiscalByBody[];
+	byCategory: FiscalByCategory[];
+	byTimePeriod: FiscalByTimePeriod[];
+	notableDecisions: NotableFiscalDecision[];
+};
+
+export function FiscalSummary({
+	byBody,
+	byCategory,
+	byTimePeriod,
+	notableDecisions,
+}: FiscalSummaryProps) {
+	const hasData =
+		byBody.length > 0 ||
+		byCategory.length > 0 ||
+		byTimePeriod.length > 0 ||
+		notableDecisions.length > 0;
+
+	if (!hasData) {
+		return (
+			<section className="island-shell rounded-2xl p-6">
+				<p className="island-kicker mb-2">Fiscal Overview</p>
+				<p className="text-sm text-[var(--sea-ink-soft)]">
+					No fiscal data available yet.
+				</p>
+			</section>
+		);
+	}
+
+	return (
+		<section className="island-shell rounded-2xl p-6">
+			<p className="island-kicker mb-4">Fiscal Overview</p>
+
+			{/* Spending by Body */}
+			{byBody.length > 0 && (
+				<div className="mb-6">
+					<h3 className="mb-3 text-base font-semibold text-[var(--sea-ink)]">
+						Spending by Body
+					</h3>
+					<div className="space-y-2">
+						{byBody.map((row) => (
+							<div
+								key={row.bodySlug}
+								className="flex items-center justify-between rounded-xl border border-[rgba(23,58,64,0.1)] px-4 py-3"
+							>
+								<span className="text-sm font-medium text-[var(--sea-ink)]">
+									{row.bodyName}
+								</span>
+								<div className="text-right">
+									<span className="text-sm font-semibold text-[var(--sea-ink)]">
+										{formatCurrency(row.totalAmount)}
+									</span>
+									<span className="ml-2 text-xs text-[var(--sea-ink-soft)]">
+										{row.decisionCount} decision
+										{row.decisionCount !== 1 ? "s" : ""}
+									</span>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Spending by Category */}
+			{byCategory.length > 0 && (
+				<div className="mb-6">
+					<h3 className="mb-3 text-base font-semibold text-[var(--sea-ink)]">
+						Spending by Category
+					</h3>
+					<div className="space-y-2">
+						{byCategory.map((row) => (
+							<div
+								key={row.budgetCategory}
+								className="flex items-center justify-between rounded-xl border border-[rgba(23,58,64,0.1)] px-4 py-3"
+							>
+								<span className="text-sm font-medium text-[var(--sea-ink)]">
+									{row.budgetCategory}
+								</span>
+								<span className="text-sm font-semibold text-[var(--sea-ink)]">
+									{formatCurrency(row.totalAmount)}
+								</span>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Spending by Time Period */}
+			{byTimePeriod.length > 0 && (
+				<div className="mb-6">
+					<h3 className="mb-3 text-base font-semibold text-[var(--sea-ink)]">
+						Monthly Trends
+					</h3>
+					<div className="space-y-2">
+						{byTimePeriod.map((row) => (
+							<div
+								key={row.period}
+								className="flex items-center justify-between rounded-xl border border-[rgba(23,58,64,0.1)] px-4 py-3"
+							>
+								<span className="text-sm font-medium text-[var(--sea-ink)]">
+									{row.period}
+								</span>
+								<div className="text-right">
+									<span className="text-sm font-semibold text-[var(--sea-ink)]">
+										{formatCurrency(row.totalAmount)}
+									</span>
+									<span className="ml-2 text-xs text-[var(--sea-ink-soft)]">
+										{row.decisionCount} decision
+										{row.decisionCount !== 1 ? "s" : ""}
+									</span>
+								</div>
+							</div>
+						))}
+					</div>
+				</div>
+			)}
+
+			{/* Notable Decisions */}
+			{notableDecisions.length > 0 && (
+				<div>
+					<h3 className="mb-3 text-base font-semibold text-[var(--sea-ink)]">
+						Notable Recent Decisions
+					</h3>
+					<div className="space-y-2">
+						{notableDecisions.map((d) => {
+							let statusColor: string;
+							switch (d.status) {
+								case "approved":
+									statusColor = "text-emerald-700 bg-emerald-50";
+									break;
+								case "denied":
+									statusColor = "text-red-700 bg-red-50";
+									break;
+								case "tabled":
+									statusColor = "text-amber-700 bg-amber-50";
+									break;
+								default: {
+									const _exhaustive: never = d.status;
+									return _exhaustive;
+								}
+							}
+							return (
+								<div
+									key={`${d.title}-${d.date}`}
+									className="flex items-center justify-between rounded-xl border border-[rgba(23,58,64,0.1)] px-4 py-3"
+								>
+									<div>
+										<p className="text-sm font-medium text-[var(--sea-ink)]">
+											{d.title}
+										</p>
+										<p className="text-xs text-[var(--sea-ink-soft)]">
+											{d.bodyName}
+										</p>
+									</div>
+									<div className="flex items-center gap-2">
+										<span className="text-sm font-semibold text-[var(--sea-ink)]">
+											{formatCurrency(d.amount)}
+										</span>
+										<span
+											className={`rounded-full px-2 py-0.5 text-xs font-medium ${statusColor}`}
+										>
+											{d.status}
+										</span>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			)}
+		</section>
+	);
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ export default function Header() {
 				<h2 className="m-0 flex-shrink-0 text-base font-semibold tracking-tight">
 					<Link
 						to="/"
+						search={{ body: undefined }}
 						className="inline-flex items-center gap-2 rounded-full border border-[var(--chip-line)] bg-[var(--chip-bg)] px-3 py-1.5 text-sm text-[var(--sea-ink)] no-underline shadow-[0_8px_24px_rgba(30,90,72,0.08)] sm:px-4 sm:py-2"
 					>
 						<span className="h-2 w-2 rounded-full bg-[linear-gradient(90deg,#56c6be,#7ed3bf)]" />
@@ -51,6 +52,7 @@ export default function Header() {
 				<div className="order-3 flex w-full flex-wrap items-center gap-x-4 gap-y-1 pb-1 text-sm font-semibold sm:order-2 sm:w-auto sm:flex-nowrap sm:pb-0">
 					<Link
 						to="/"
+						search={{ body: undefined }}
 						className="nav-link"
 						activeProps={{ className: "nav-link is-active" }}
 					>

--- a/src/components/MeetingCard.test.tsx
+++ b/src/components/MeetingCard.test.tsx
@@ -21,22 +21,22 @@ describe("MeetingCard", () => {
 	it("renders body name and formatted date", () => {
 		render(<MeetingCard meeting={baseMeeting} />);
 
-		expect(screen.getByText("Ellettsville Town Council")).toBeDefined();
-		expect(screen.getByText("March 23, 2026")).toBeDefined();
+		screen.getByText("Ellettsville Town Council");
+		screen.getByText("March 23, 2026");
 	});
 
 	it("renders highlights as a list", () => {
 		render(<MeetingCard meeting={baseMeeting} />);
 
-		expect(screen.getByText("Approved road repairs")).toBeDefined();
-		expect(screen.getByText("Discussed park budget")).toBeDefined();
+		screen.getByText("Approved road repairs");
+		screen.getByText("Discussed park budget");
 	});
 
 	it("renders fiscal decision count and total spending", () => {
 		render(<MeetingCard meeting={baseMeeting} />);
 
-		expect(screen.getByText("$75,000")).toBeDefined();
-		expect(screen.getByText(/2 decisions/i)).toBeDefined();
+		screen.getByText("$75,000");
+		screen.getByText(/2 decisions/i);
 	});
 
 	it("links to the meeting detail page", () => {

--- a/src/components/MeetingCard.test.tsx
+++ b/src/components/MeetingCard.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MeetingCard } from "./MeetingCard.tsx";
+
+afterEach(cleanup);
+
+const baseMeeting = {
+	id: 1,
+	date: "2026-03-23",
+	meetingType: "regular" as const,
+	bodyName: "Ellettsville Town Council",
+	bodySlug: "ellettsville-town-council",
+	highlights: ["Approved road repairs", "Discussed park budget"],
+	prose: "The council met to discuss infrastructure spending.",
+	fiscalDecisionCount: 2,
+	totalSpending: 75000,
+};
+
+describe("MeetingCard", () => {
+	it("renders body name and formatted date", () => {
+		render(<MeetingCard meeting={baseMeeting} />);
+
+		expect(screen.getByText("Ellettsville Town Council")).toBeDefined();
+		expect(screen.getByText("March 23, 2026")).toBeDefined();
+	});
+
+	it("renders highlights as a list", () => {
+		render(<MeetingCard meeting={baseMeeting} />);
+
+		expect(screen.getByText("Approved road repairs")).toBeDefined();
+		expect(screen.getByText("Discussed park budget")).toBeDefined();
+	});
+
+	it("renders fiscal decision count and total spending", () => {
+		render(<MeetingCard meeting={baseMeeting} />);
+
+		expect(screen.getByText("$75,000")).toBeDefined();
+		expect(screen.getByText(/2 decisions/i)).toBeDefined();
+	});
+
+	it("links to the meeting detail page", () => {
+		render(<MeetingCard meeting={baseMeeting} />);
+
+		const link = screen.getByRole("link");
+		expect(link.getAttribute("href")).toBe(
+			"/meetings/ellettsville-town-council/2026-03-23",
+		);
+	});
+
+	it("hides fiscal section when no spending", () => {
+		render(
+			<MeetingCard
+				meeting={{ ...baseMeeting, fiscalDecisionCount: 0, totalSpending: 0 }}
+			/>,
+		);
+
+		expect(screen.queryByText(/decisions/i)).toBeNull();
+	});
+});

--- a/src/components/MeetingCard.tsx
+++ b/src/components/MeetingCard.tsx
@@ -1,0 +1,52 @@
+import type { MeetingCardData } from "#/db/queries.ts";
+
+function formatDate(iso: string): string {
+	const [year, month, day] = iso.split("-");
+	const date = new Date(Number(year), Number(month) - 1, Number(day));
+	return date.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+function formatCurrency(amount: number): string {
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 0,
+		maximumFractionDigits: 0,
+	}).format(amount);
+}
+
+export function MeetingCard({ meeting }: { meeting: MeetingCardData }) {
+	return (
+		<article className="island-shell feature-card rounded-2xl p-5">
+			<a
+				href={`/meetings/${meeting.bodySlug}/${meeting.date}`}
+				className="block no-underline"
+			>
+				<p className="island-kicker mb-1">{meeting.bodyName}</p>
+				<h3 className="mb-2 text-lg font-semibold text-[var(--sea-ink)]">
+					{formatDate(meeting.date)}
+				</h3>
+				<ul className="m-0 mb-3 list-disc space-y-1 pl-5 text-sm text-[var(--sea-ink-soft)]">
+					{meeting.highlights.slice(0, 3).map((h) => (
+						<li key={h}>{h}</li>
+					))}
+				</ul>
+				{meeting.fiscalDecisionCount > 0 && (
+					<div className="flex items-center gap-3 text-sm text-[var(--sea-ink-soft)]">
+						<span className="font-semibold text-[var(--sea-ink)]">
+							{formatCurrency(meeting.totalSpending)}
+						</span>
+						<span>
+							{meeting.fiscalDecisionCount} decision
+							{meeting.fiscalDecisionCount !== 1 ? "s" : ""}
+						</span>
+					</div>
+				)}
+			</a>
+		</article>
+	);
+}

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -1,0 +1,370 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { describe, expect, it } from "vitest";
+import * as schema from "#/db/schema.ts";
+import {
+	aggregateFiscalByBodyQuery,
+	aggregateFiscalByCategoryQuery,
+	aggregateFiscalByTimePeriodQuery,
+	listGoverningBodiesQuery,
+	listNotableFiscalDecisionsQuery,
+	listRecentMeetingsQuery,
+} from "./queries.ts";
+
+function createTestDb() {
+	const sqlite = new Database(":memory:");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: "./drizzle" });
+	return db;
+}
+
+function seedBody(
+	db: ReturnType<typeof createTestDb>,
+	overrides: Partial<typeof schema.governingBodies.$inferInsert> = {},
+) {
+	return db
+		.insert(schema.governingBodies)
+		.values({
+			name: "Ellettsville Town Council",
+			slug: "ellettsville-town-council",
+			type: "town",
+			...overrides,
+		})
+		.returning()
+		.get();
+}
+
+function seedMeetingWithSummary(
+	db: ReturnType<typeof createTestDb>,
+	bodyId: number,
+	date: string,
+	opts: {
+		highlights?: string[];
+		prose?: string;
+		fiscalDecisions?: Array<{
+			title: string;
+			amount: number;
+			originalAmount: string;
+			status?: "approved" | "denied" | "tabled";
+			budgetCategory?: string;
+		}>;
+	} = {},
+) {
+	const meeting = db
+		.insert(schema.meetings)
+		.values({ bodyId, date, meetingType: "regular" })
+		.returning()
+		.get();
+
+	db.insert(schema.summaries)
+		.values({
+			meetingId: meeting.id,
+			highlights: opts.highlights ?? ["Highlight one"],
+			prose: opts.prose ?? "Summary prose.",
+			model: "gemini-2.5-flash",
+		})
+		.run();
+
+	for (const fd of opts.fiscalDecisions ?? []) {
+		db.insert(schema.fiscalDecisions)
+			.values({
+				meetingId: meeting.id,
+				title: fd.title,
+				description: `Description for ${fd.title}`,
+				amount: fd.amount,
+				originalAmount: fd.originalAmount,
+				status: fd.status ?? "approved",
+				budgetCategory: fd.budgetCategory ?? null,
+				confidence: 0.95,
+				isRecurring: false,
+			})
+			.run();
+	}
+
+	return meeting;
+}
+
+describe("listRecentMeetingsQuery", () => {
+	it("returns meetings ordered by date descending", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-01-15");
+		seedMeetingWithSummary(db, body.id, "2026-03-23");
+		seedMeetingWithSummary(db, body.id, "2026-02-10");
+
+		const result = listRecentMeetingsQuery(db);
+
+		expect(result).toHaveLength(3);
+		expect(result[0].date).toBe("2026-03-23");
+		expect(result[1].date).toBe("2026-02-10");
+		expect(result[2].date).toBe("2026-01-15");
+	});
+
+	it("filters by body slug when provided", () => {
+		const db = createTestDb();
+		const council = seedBody(db);
+		const school = seedBody(db, {
+			name: "RBBSC School Board",
+			slug: "rbbsc-school-board",
+			type: "school",
+		});
+		seedMeetingWithSummary(db, council.id, "2026-03-23");
+		seedMeetingWithSummary(db, school.id, "2026-03-20");
+		seedMeetingWithSummary(db, council.id, "2026-02-10");
+
+		const result = listRecentMeetingsQuery(db, "rbbsc-school-board");
+
+		expect(result).toHaveLength(1);
+		expect(result[0].bodySlug).toBe("rbbsc-school-board");
+	});
+
+	it("returns empty array for unknown body slug", () => {
+		const db = createTestDb();
+		seedBody(db);
+
+		const result = listRecentMeetingsQuery(db, "nonexistent-body");
+
+		expect(result).toHaveLength(0);
+	});
+
+	it("skips meetings without summaries", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23");
+		// Insert a meeting with no summary
+		db.insert(schema.meetings)
+			.values({ bodyId: body.id, date: "2026-04-01", meetingType: "regular" })
+			.run();
+
+		const result = listRecentMeetingsQuery(db);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].date).toBe("2026-03-23");
+	});
+
+	it("includes fiscal decision count and total spending", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{
+					title: "Road Repairs",
+					amount: 50000,
+					originalAmount: "$50,000",
+					budgetCategory: "infrastructure",
+				},
+				{
+					title: "Park Equipment",
+					amount: 25000,
+					originalAmount: "$25,000",
+					budgetCategory: "parks",
+				},
+			],
+		});
+
+		const result = listRecentMeetingsQuery(db);
+
+		expect(result[0].fiscalDecisionCount).toBe(2);
+		expect(result[0].totalSpending).toBe(75000);
+	});
+
+	it("returns empty array when no meetings exist", () => {
+		const db = createTestDb();
+
+		const result = listRecentMeetingsQuery(db);
+
+		expect(result).toHaveLength(0);
+	});
+});
+
+describe("aggregateFiscalByBodyQuery", () => {
+	it("sums spending by governing body", () => {
+		const db = createTestDb();
+		const council = seedBody(db);
+		const school = seedBody(db, {
+			name: "RBBSC School Board",
+			slug: "rbbsc-school-board",
+			type: "school",
+		});
+		seedMeetingWithSummary(db, council.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "Roads", amount: 50000, originalAmount: "$50,000" },
+			],
+		});
+		seedMeetingWithSummary(db, school.id, "2026-03-20", {
+			fiscalDecisions: [
+				{ title: "Books", amount: 10000, originalAmount: "$10,000" },
+				{ title: "Computers", amount: 20000, originalAmount: "$20,000" },
+			],
+		});
+
+		const result = aggregateFiscalByBodyQuery(db);
+
+		expect(result).toHaveLength(2);
+		const councilRow = result.find(
+			(r) => r.bodySlug === "ellettsville-town-council",
+		);
+		const schoolRow = result.find((r) => r.bodySlug === "rbbsc-school-board");
+		expect(councilRow?.totalAmount).toBe(50000);
+		expect(councilRow?.decisionCount).toBe(1);
+		expect(schoolRow?.totalAmount).toBe(30000);
+		expect(schoolRow?.decisionCount).toBe(2);
+	});
+
+	it("returns empty array when no fiscal decisions exist", () => {
+		const db = createTestDb();
+
+		const result = aggregateFiscalByBodyQuery(db);
+
+		expect(result).toHaveLength(0);
+	});
+});
+
+describe("aggregateFiscalByCategoryQuery", () => {
+	it("sums spending by budget category", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{
+					title: "Road Repairs",
+					amount: 50000,
+					originalAmount: "$50,000",
+					budgetCategory: "infrastructure",
+				},
+				{
+					title: "Sidewalks",
+					amount: 30000,
+					originalAmount: "$30,000",
+					budgetCategory: "infrastructure",
+				},
+				{
+					title: "Park Equipment",
+					amount: 25000,
+					originalAmount: "$25,000",
+					budgetCategory: "parks",
+				},
+			],
+		});
+
+		const result = aggregateFiscalByCategoryQuery(db);
+
+		const infra = result.find((r) => r.budgetCategory === "infrastructure");
+		const parks = result.find((r) => r.budgetCategory === "parks");
+		expect(infra?.totalAmount).toBe(80000);
+		expect(infra?.decisionCount).toBe(2);
+		expect(parks?.totalAmount).toBe(25000);
+		expect(parks?.decisionCount).toBe(1);
+	});
+
+	it("labels null categories as Uncategorized", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "Misc", amount: 5000, originalAmount: "$5,000" },
+			],
+		});
+
+		const result = aggregateFiscalByCategoryQuery(db);
+
+		expect(result[0].budgetCategory).toBe("Uncategorized");
+	});
+});
+
+describe("aggregateFiscalByTimePeriodQuery", () => {
+	it("sums spending by month ordered newest first", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-01-15", {
+			fiscalDecisions: [
+				{ title: "Jan item", amount: 10000, originalAmount: "$10,000" },
+			],
+		});
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "Mar item 1", amount: 50000, originalAmount: "$50,000" },
+				{ title: "Mar item 2", amount: 20000, originalAmount: "$20,000" },
+			],
+		});
+
+		const result = aggregateFiscalByTimePeriodQuery(db);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].period).toBe("2026-03");
+		expect(result[0].totalAmount).toBe(70000);
+		expect(result[1].period).toBe("2026-01");
+		expect(result[1].totalAmount).toBe(10000);
+	});
+});
+
+describe("listNotableFiscalDecisionsQuery", () => {
+	it("returns decisions ordered by amount descending", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "Small", amount: 5000, originalAmount: "$5,000" },
+				{ title: "Big", amount: 100000, originalAmount: "$100,000" },
+				{ title: "Medium", amount: 30000, originalAmount: "$30,000" },
+			],
+		});
+
+		const result = listNotableFiscalDecisionsQuery(db);
+
+		expect(result[0].title).toBe("Big");
+		expect(result[0].amount).toBe(100000);
+		expect(result[1].title).toBe("Medium");
+		expect(result[2].title).toBe("Small");
+	});
+
+	it("includes body name and meeting date", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "Item", amount: 50000, originalAmount: "$50,000" },
+			],
+		});
+
+		const result = listNotableFiscalDecisionsQuery(db);
+
+		expect(result[0].bodyName).toBe("Ellettsville Town Council");
+		expect(result[0].date).toBe("2026-03-23");
+	});
+
+	it("respects limit parameter", () => {
+		const db = createTestDb();
+		const body = seedBody(db);
+		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+			fiscalDecisions: [
+				{ title: "A", amount: 1000, originalAmount: "$1,000" },
+				{ title: "B", amount: 2000, originalAmount: "$2,000" },
+				{ title: "C", amount: 3000, originalAmount: "$3,000" },
+			],
+		});
+
+		const result = listNotableFiscalDecisionsQuery(db, 2);
+
+		expect(result).toHaveLength(2);
+	});
+});
+
+describe("listGoverningBodiesQuery", () => {
+	it("returns all bodies ordered by name", () => {
+		const db = createTestDb();
+		seedBody(db, { name: "Zebra Board", slug: "zebra-board", type: "county" });
+		seedBody(db, {
+			name: "Alpha Council",
+			slug: "alpha-council",
+			type: "town",
+		});
+
+		const result = listGoverningBodiesQuery(db);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("Alpha Council");
+		expect(result[1].name).toBe("Zebra Board");
+	});
+});

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -2,10 +2,27 @@ import { and, desc, eq, sql, sum } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import * as schema from "#/db/schema.ts";
 
+export type MeetingType = "regular" | "special" | "workshop";
+export type FiscalStatus = "approved" | "denied" | "tabled";
+export type BodyType = "town" | "county" | "school";
+
+const MEETING_TYPES = new Set<string>(["regular", "special", "workshop"]);
+const FISCAL_STATUSES = new Set<string>(["approved", "denied", "tabled"]);
+
+function parseMeetingType(raw: string): MeetingType {
+	if (MEETING_TYPES.has(raw)) return raw as MeetingType;
+	throw new Error(`Invalid meeting type: ${raw}`);
+}
+
+function parseFiscalStatus(raw: string): FiscalStatus {
+	if (FISCAL_STATUSES.has(raw)) return raw as FiscalStatus;
+	throw new Error(`Invalid fiscal status: ${raw}`);
+}
+
 export type MeetingCardData = {
 	id: number;
 	date: string;
-	meetingType: "regular" | "special" | "workshop";
+	meetingType: MeetingType;
 	bodyName: string;
 	bodySlug: string;
 	highlights: string[];
@@ -36,10 +53,16 @@ export type FiscalByTimePeriod = {
 export type NotableFiscalDecision = {
 	title: string;
 	amount: number;
-	status: "approved" | "denied" | "tabled";
+	status: FiscalStatus;
 	bodyName: string;
 	bodySlug: string;
 	date: string;
+};
+
+export type GoverningBodySummary = {
+	name: string;
+	slug: string;
+	type: BodyType;
 };
 
 /**
@@ -95,7 +118,7 @@ export function listRecentMeetingsQuery(
 		result.push({
 			id: m.id,
 			date: m.date,
-			meetingType: m.meetingType as MeetingCardData["meetingType"],
+			meetingType: parseMeetingType(m.meetingType),
 			bodyName: body.name,
 			bodySlug: body.slug,
 			highlights: summary.highlights as string[],
@@ -224,7 +247,7 @@ export function listNotableFiscalDecisionsQuery(
 	return rows.map((r) => ({
 		title: r.title,
 		amount: r.amount,
-		status: r.status as NotableFiscalDecision["status"],
+		status: parseFiscalStatus(r.status),
 		bodyName: r.bodyName,
 		bodySlug: r.bodySlug,
 		date: r.date,
@@ -236,7 +259,7 @@ export function listNotableFiscalDecisionsQuery(
  */
 export function listGoverningBodiesQuery(
 	db: BetterSQLite3Database<typeof schema>,
-): Array<{ name: string; slug: string; type: string }> {
+): GoverningBodySummary[] {
 	return db
 		.select({
 			name: schema.governingBodies.name,
@@ -245,7 +268,8 @@ export function listGoverningBodiesQuery(
 		})
 		.from(schema.governingBodies)
 		.orderBy(schema.governingBodies.name)
-		.all();
+		.all()
+		.map((r) => ({ ...r, type: r.type as BodyType }));
 }
 
 export type FiscalDecisionDetail = {
@@ -254,7 +278,7 @@ export type FiscalDecisionDetail = {
 	amount: number;
 	originalAmount: string;
 	budgetCategory: string | null;
-	status: "approved" | "denied" | "tabled";
+	status: FiscalStatus;
 	voteRecord: { yea: number; nay: number; abstain: number } | null;
 	vendor: string | null;
 	fundingSource: string | null;
@@ -270,7 +294,7 @@ export type FiscalDecisionDetail = {
 export type MeetingDetail = {
 	id: number;
 	date: string;
-	meetingType: "regular" | "special" | "workshop";
+	meetingType: MeetingType;
 	bodyName: string;
 	bodySlug: string;
 	documents: Array<{
@@ -347,7 +371,7 @@ export function getMeetingByBodyAndDateQuery(
 	return {
 		id: meeting.id,
 		date: meeting.date,
-		meetingType: meeting.meetingType as MeetingDetail["meetingType"],
+		meetingType: parseMeetingType(meeting.meetingType),
 		bodyName: body.name,
 		bodySlug: body.slug,
 		documents: docs.map((d) => ({
@@ -367,7 +391,7 @@ export function getMeetingByBodyAndDateQuery(
 			amount: f.amount,
 			originalAmount: f.originalAmount,
 			budgetCategory: f.budgetCategory,
-			status: f.status as FiscalDecisionDetail["status"],
+			status: parseFiscalStatus(f.status),
 			voteRecord: f.voteRecord as {
 				yea: number;
 				nay: number;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,252 @@
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq, sql, sum } from "drizzle-orm";
 import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
 import * as schema from "#/db/schema.ts";
+
+export type MeetingCardData = {
+	id: number;
+	date: string;
+	meetingType: "regular" | "special" | "workshop";
+	bodyName: string;
+	bodySlug: string;
+	highlights: string[];
+	prose: string;
+	fiscalDecisionCount: number;
+	totalSpending: number;
+};
+
+export type FiscalByBody = {
+	bodyName: string;
+	bodySlug: string;
+	totalAmount: number;
+	decisionCount: number;
+};
+
+export type FiscalByCategory = {
+	budgetCategory: string;
+	totalAmount: number;
+	decisionCount: number;
+};
+
+export type FiscalByTimePeriod = {
+	period: string;
+	totalAmount: number;
+	decisionCount: number;
+};
+
+export type NotableFiscalDecision = {
+	title: string;
+	amount: number;
+	status: "approved" | "denied" | "tabled";
+	bodyName: string;
+	bodySlug: string;
+	date: string;
+};
+
+/**
+ * Lists recent meetings with summary data for the landing page feed.
+ * Optionally filtered by body slug. Returns newest first.
+ */
+export function listRecentMeetingsQuery(
+	db: BetterSQLite3Database<typeof schema>,
+	bodySlug?: string,
+	limit = 20,
+): MeetingCardData[] {
+	let bodyFilter: number | undefined;
+	if (bodySlug) {
+		const body = db
+			.select()
+			.from(schema.governingBodies)
+			.where(eq(schema.governingBodies.slug, bodySlug))
+			.get();
+		if (!body) return [];
+		bodyFilter = body.id;
+	}
+
+	const meetingRows = db
+		.select()
+		.from(schema.meetings)
+		.where(bodyFilter ? eq(schema.meetings.bodyId, bodyFilter) : undefined)
+		.orderBy(desc(schema.meetings.date))
+		.limit(limit)
+		.all();
+
+	const result: MeetingCardData[] = [];
+	for (const m of meetingRows) {
+		const body = db
+			.select()
+			.from(schema.governingBodies)
+			.where(eq(schema.governingBodies.id, m.bodyId))
+			.get();
+		if (!body) continue;
+
+		const summary = db
+			.select()
+			.from(schema.summaries)
+			.where(eq(schema.summaries.meetingId, m.id))
+			.get();
+		if (!summary) continue;
+
+		const fiscals = db
+			.select()
+			.from(schema.fiscalDecisions)
+			.where(eq(schema.fiscalDecisions.meetingId, m.id))
+			.all();
+
+		result.push({
+			id: m.id,
+			date: m.date,
+			meetingType: m.meetingType as MeetingCardData["meetingType"],
+			bodyName: body.name,
+			bodySlug: body.slug,
+			highlights: summary.highlights as string[],
+			prose: summary.prose,
+			fiscalDecisionCount: fiscals.length,
+			totalSpending: fiscals.reduce((sum, f) => sum + f.amount, 0),
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Aggregates fiscal decision totals by governing body.
+ */
+export function aggregateFiscalByBodyQuery(
+	db: BetterSQLite3Database<typeof schema>,
+): FiscalByBody[] {
+	const rows = db
+		.select({
+			bodyName: schema.governingBodies.name,
+			bodySlug: schema.governingBodies.slug,
+			totalAmount: sum(schema.fiscalDecisions.amount),
+			decisionCount: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.innerJoin(
+			schema.governingBodies,
+			eq(schema.meetings.bodyId, schema.governingBodies.id),
+		)
+		.groupBy(schema.governingBodies.id)
+		.all();
+
+	return rows.map((r) => ({
+		bodyName: r.bodyName,
+		bodySlug: r.bodySlug,
+		totalAmount: Number(r.totalAmount) || 0,
+		decisionCount: r.decisionCount,
+	}));
+}
+
+/**
+ * Aggregates fiscal decision totals by budget category.
+ */
+export function aggregateFiscalByCategoryQuery(
+	db: BetterSQLite3Database<typeof schema>,
+): FiscalByCategory[] {
+	const rows = db
+		.select({
+			budgetCategory: schema.fiscalDecisions.budgetCategory,
+			totalAmount: sum(schema.fiscalDecisions.amount),
+			decisionCount: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.groupBy(schema.fiscalDecisions.budgetCategory)
+		.all();
+
+	return rows.map((r) => ({
+		budgetCategory: r.budgetCategory ?? "Uncategorized",
+		totalAmount: Number(r.totalAmount) || 0,
+		decisionCount: r.decisionCount,
+	}));
+}
+
+/**
+ * Aggregates fiscal decision totals by month (YYYY-MM).
+ */
+export function aggregateFiscalByTimePeriodQuery(
+	db: BetterSQLite3Database<typeof schema>,
+): FiscalByTimePeriod[] {
+	const rows = db
+		.select({
+			period: sql<string>`substr(${schema.meetings.date}, 1, 7)`,
+			totalAmount: sum(schema.fiscalDecisions.amount),
+			decisionCount: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.groupBy(sql`substr(${schema.meetings.date}, 1, 7)`)
+		.orderBy(desc(sql`substr(${schema.meetings.date}, 1, 7)`))
+		.all();
+
+	return rows.map((r) => ({
+		period: r.period,
+		totalAmount: Number(r.totalAmount) || 0,
+		decisionCount: r.decisionCount,
+	}));
+}
+
+/**
+ * Returns the most notable recent fiscal decisions (highest amounts).
+ */
+export function listNotableFiscalDecisionsQuery(
+	db: BetterSQLite3Database<typeof schema>,
+	limit = 5,
+): NotableFiscalDecision[] {
+	const rows = db
+		.select({
+			title: schema.fiscalDecisions.title,
+			amount: schema.fiscalDecisions.amount,
+			status: schema.fiscalDecisions.status,
+			bodyName: schema.governingBodies.name,
+			bodySlug: schema.governingBodies.slug,
+			date: schema.meetings.date,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.innerJoin(
+			schema.governingBodies,
+			eq(schema.meetings.bodyId, schema.governingBodies.id),
+		)
+		.orderBy(desc(schema.fiscalDecisions.amount))
+		.limit(limit)
+		.all();
+
+	return rows.map((r) => ({
+		title: r.title,
+		amount: r.amount,
+		status: r.status as NotableFiscalDecision["status"],
+		bodyName: r.bodyName,
+		bodySlug: r.bodySlug,
+		date: r.date,
+	}));
+}
+
+/**
+ * Lists all governing bodies (for the filter dropdown).
+ */
+export function listGoverningBodiesQuery(
+	db: BetterSQLite3Database<typeof schema>,
+): Array<{ name: string; slug: string; type: string }> {
+	return db
+		.select({
+			name: schema.governingBodies.name,
+			slug: schema.governingBodies.slug,
+			type: schema.governingBodies.type,
+		})
+		.from(schema.governingBodies)
+		.orderBy(schema.governingBodies.name)
+		.all();
+}
 
 export type FiscalDecisionDetail = {
 	title: string;

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -249,8 +249,8 @@ describe("FinalsiteScraper", () => {
 
 	describe("FinalsiteScraperLive", () => {
 		it("fetches page HTML and returns parsed listings via Effect", async () => {
-			const mockFetch = async (url: string) => {
-				if (url === "https://www.rbbschools.net/school-board") {
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				if (String(url) === "https://www.rbbschools.net/school-board") {
 					return new Response(SINGLE_ROW_FIXTURE, { status: 200 });
 				}
 				return new Response("Not Found", { status: 404 });
@@ -263,7 +263,7 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);
@@ -277,7 +277,7 @@ describe("FinalsiteScraper", () => {
 		});
 
 		it("returns NetworkError when fetch fails", async () => {
-			const mockFetch = async () => {
+			const mockFetch: typeof globalThis.fetch = async () => {
 				throw new Error("Connection refused");
 			};
 
@@ -288,19 +288,20 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);
 
-			const exit = await Effect.runPromiseExit(program);
-			expect(exit._tag).toBe("Failure");
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
+			expect(error.message).toBe("Connection refused");
 		});
 
 		it("downloads a document by UUID", async () => {
 			const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
-			const mockFetch = async (url: string) => {
-				if (url.includes("/fs/resource-manager/view/")) {
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				if (String(url).includes("/fs/resource-manager/view/")) {
 					return new Response(pdfBytes, { status: 200 });
 				}
 				return new Response("Not Found", { status: 404 });
@@ -313,7 +314,7 @@ describe("FinalsiteScraper", () => {
 				Effect.provide(
 					FinalsiteScraperLive({
 						baseUrl: "https://www.rbbschools.net/school-board",
-						fetchFn: mockFetch as typeof globalThis.fetch,
+						fetchFn: mockFetch,
 					}),
 				),
 			);

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -1,5 +1,10 @@
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { parseFinalsiteHtml } from "./FinalsiteScraper.ts";
+import {
+	FinalsiteScraper,
+	FinalsiteScraperLive,
+	parseFinalsiteHtml,
+} from "./FinalsiteScraper.ts";
 
 // Real HTML structure from rbbschools.net/school-board
 // Minimal fixture: one year panel with one meeting row containing one document link
@@ -239,6 +244,82 @@ describe("FinalsiteScraper", () => {
 </section>`;
 			const results = parseFinalsiteHtml(fixture);
 			expect(results).toEqual([]);
+		});
+	});
+
+	describe("FinalsiteScraperLive", () => {
+		it("fetches page HTML and returns parsed listings via Effect", async () => {
+			const mockFetch = async (url: string) => {
+				if (url === "https://www.rbbschools.net/school-board") {
+					return new Response(SINGLE_ROW_FIXTURE, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.scrapeListings();
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const results = await Effect.runPromise(program);
+			expect(results).toHaveLength(1);
+			expect(results[0].date).toBe("January 6, 2026");
+			expect(results[0].documents[0].uuid).toBe(
+				"0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+			);
+		});
+
+		it("returns NetworkError when fetch fails", async () => {
+			const mockFetch = async () => {
+				throw new Error("Connection refused");
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.scrapeListings();
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const exit = await Effect.runPromiseExit(program);
+			expect(exit._tag).toBe("Failure");
+		});
+
+		it("downloads a document by UUID", async () => {
+			const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+			const mockFetch = async (url: string) => {
+				if (url.includes("/fs/resource-manager/view/")) {
+					return new Response(pdfBytes, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* FinalsiteScraper;
+				return yield* scraper.downloadDocument("test-uuid-1234");
+			}).pipe(
+				Effect.provide(
+					FinalsiteScraperLive({
+						baseUrl: "https://www.rbbschools.net/school-board",
+						fetchFn: mockFetch as typeof globalThis.fetch,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+			expect(new Uint8Array(result)).toEqual(pdfBytes);
 		});
 	});
 });

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -180,5 +180,65 @@ describe("FinalsiteScraper", () => {
 			const results = parseFinalsiteHtml("<div>No content</div>");
 			expect(results).toEqual([]);
 		});
+
+		it("normalizes multiline meeting type text", () => {
+			const fixture = `
+<section class="fsElement fsPanel fsStyleAutoclear" role="tabpanel">
+	<header><h2 class="fsElementTitle"><a>2026</a></h2></header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr><th>Date</th><th>Type</th><th>Links</th></tr>
+						<tr>
+							<td><p>September 15, 2026</p></td>
+							<td>
+								<p>Regular Meeting 6:00 PM</p>
+								<p>Public Hearing</p>
+								<p>Proposed 2027 Budget, 2027 Capital Projects Plan,</p>
+								<p>2027 Bus Replacement Plan</p>
+							</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>`;
+			const results = parseFinalsiteHtml(fixture);
+
+			expect(results).toHaveLength(1);
+			// Multiline text should be collapsed to a single line with spaces
+			expect(results[0].meetingType).toBe(
+				"Regular Meeting 6:00 PM Public Hearing Proposed 2027 Budget, 2027 Capital Projects Plan, 2027 Bus Replacement Plan",
+			);
+		});
+
+		it("skips rows with empty date cells", () => {
+			const fixture = `
+<section class="fsElement fsPanel fsStyleAutoclear" role="tabpanel">
+	<header><h2 class="fsElementTitle"><a>2026</a></h2></header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr><th>Date</th><th>Type</th><th>Links</th></tr>
+						<tr>
+							<td></td>
+							<td>Orphan row</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>`;
+			const results = parseFinalsiteHtml(fixture);
+			expect(results).toEqual([]);
+		});
 	});
 });

--- a/src/pipeline/services/FinalsiteScraper.test.ts
+++ b/src/pipeline/services/FinalsiteScraper.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import { parseFinalsiteHtml } from "./FinalsiteScraper.ts";
+
+// Real HTML structure from rbbschools.net/school-board
+// Minimal fixture: one year panel with one meeting row containing one document link
+const SINGLE_ROW_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_10343" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-10343">2026</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+						<tr>
+							<td><p>January 6, 2026</p></td>
+							<td>Board Organizational Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="1626SchoolBoardOrganizationalMeetingAgenda.pdf" data-resource-uuid="0e57bdf7-c837-4f03-8a79-8a1c69744ee7" href="/fs/resource-manager/view/0e57bdf7-c837-4f03-8a79-8a1c69744ee7" target="_blank">Agenda</a></p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+// Multi-row fixture with multiple documents per meeting and a row with no links
+const MULTI_ROW_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_10343" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-10343">2026</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<tbody>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+						<tr>
+							<td><p>January 20, 2026</p></td>
+							<td>Regular Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="1202026Agenda1.pdf" data-resource-uuid="d165d0db-39de-481e-94e1-74e48e3c7e94" href="/fs/resource-manager/view/d165d0db-39de-481e-94e1-74e48e3c7e94" target="_blank">Agenda</a></p>
+								<p><a data-file-name="12026Regualmeetingsignedminutes.pdf" data-resource-uuid="c8621f1b-b572-4add-a921-dd5ca2734c3f" href="/fs/resource-manager/view/c8621f1b-b572-4add-a921-dd5ca2734c3f" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+						<tr>
+							<td><p>February 24, 2026</p></td>
+							<td>Special Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="NoticeofSpecialMeeting22426.pdf" data-resource-uuid="50cd929a-6473-4922-8127-4da839d7a2b7" href="/fs/resource-manager/view/50cd929a-6473-4922-8127-4da839d7a2b7" target="_blank">Notice</a></p>
+								<p><a data-file-name="2242026SpecialMeetingAgenda1.pdf" data-resource-uuid="0010f58c-a288-4653-bc00-dfe960112624" href="/fs/resource-manager/view/0010f58c-a288-4653-bc00-dfe960112624" target="_blank">Agenda</a></p>
+								<p><a data-file-name="22426Specialmeetingsignedminutes.pdf" data-resource-uuid="91af54e2-e329-4255-84f0-18f891cae1b7" href="/fs/resource-manager/view/91af54e2-e329-4255-84f0-18f891cae1b7" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+						<tr>
+							<td><p>April 21, 2026</p></td>
+							<td>Regular Meeting 6:00 PM</td>
+							<td><p>&nbsp;</p></td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+// Fixture with thead (2025 uses this variant)
+const THEAD_VARIANT_FIXTURE = `
+<section class="fsElement fsPanel fsStyleAutoclear" id="fsEl_9352" role="tabpanel">
+	<header>
+		<h2 class="fsElementTitle"><a role="button" href="#fs-panel-9352">2025</a></h2>
+	</header>
+	<div class="fsElementContent">
+		<div class="fsElement fsContent">
+			<div class="fsElementContent">
+				<table class="table-styled">
+					<thead>
+						<tr>
+							<th scope="col">Date</th>
+							<th scope="col">Type</th>
+							<th scope="col">Links</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td><p>January 21, 2025</p></td>
+							<td>Board of Finance Meeting 6:00 PM</td>
+							<td>
+								<p><a data-file-name="01-21-25-Finance-Meeting-Agenda-DRK-1-2.pdf" data-resource-uuid="4a69e480-d97f-457e-81f4-b97cb365c541" href="/fs/resource-manager/view/4a69e480-d97f-457e-81f4-b97cb365c541" target="_blank">Agenda</a></p>
+								<p><a data-file-name="01-21-25-Finance-meeting-signed-minutes.pdf" data-resource-uuid="7bf4774d-d7a0-4f76-848c-7f72a47c5293" href="/fs/resource-manager/view/7bf4774d-d7a0-4f76-848c-7f72a47c5293" target="_blank">Minutes</a></p>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+			</div>
+		</div>
+	</div>
+</section>
+`;
+
+describe("FinalsiteScraper", () => {
+	describe("parseFinalsiteHtml", () => {
+		it("extracts a single meeting with one document link", () => {
+			const results = parseFinalsiteHtml(SINGLE_ROW_FIXTURE);
+
+			expect(results).toHaveLength(1);
+			expect(results[0]).toEqual({
+				date: "January 6, 2026",
+				meetingType: "Board Organizational Meeting 6:00 PM",
+				year: 2026,
+				documents: [
+					{
+						uuid: "0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+						documentType: "agenda",
+						downloadUrl:
+							"/fs/resource-manager/view/0e57bdf7-c837-4f03-8a79-8a1c69744ee7",
+						fileName: "1626SchoolBoardOrganizationalMeetingAgenda.pdf",
+					},
+				],
+			});
+		});
+
+		it("extracts multiple meetings with multiple documents per row", () => {
+			const results = parseFinalsiteHtml(MULTI_ROW_FIXTURE);
+
+			expect(results).toHaveLength(3);
+
+			// First meeting: 2 documents
+			expect(results[0].date).toBe("January 20, 2026");
+			expect(results[0].meetingType).toBe("Regular Meeting 6:00 PM");
+			expect(results[0].year).toBe(2026);
+			expect(results[0].documents).toHaveLength(2);
+			expect(results[0].documents[0].documentType).toBe("agenda");
+			expect(results[0].documents[1].documentType).toBe("minutes");
+
+			// Second meeting: 3 documents (notice + agenda + minutes)
+			expect(results[1].date).toBe("February 24, 2026");
+			expect(results[1].documents).toHaveLength(3);
+			expect(results[1].documents[0].documentType).toBe("notice");
+
+			// Third meeting: future meeting with no documents
+			expect(results[2].date).toBe("April 21, 2026");
+			expect(results[2].documents).toHaveLength(0);
+		});
+
+		it("handles thead variant used in some year panels", () => {
+			const results = parseFinalsiteHtml(THEAD_VARIANT_FIXTURE);
+
+			expect(results).toHaveLength(1);
+			expect(results[0].date).toBe("January 21, 2025");
+			expect(results[0].year).toBe(2025);
+			expect(results[0].documents).toHaveLength(2);
+		});
+
+		it("handles multiple year panels in one page", () => {
+			const combined = SINGLE_ROW_FIXTURE + THEAD_VARIANT_FIXTURE;
+			const results = parseFinalsiteHtml(combined);
+
+			expect(results).toHaveLength(2);
+			expect(results[0].year).toBe(2026);
+			expect(results[1].year).toBe(2025);
+		});
+
+		it("returns empty array for HTML with no panels", () => {
+			const results = parseFinalsiteHtml("<div>No content</div>");
+			expect(results).toEqual([]);
+		});
+	});
+});

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -1,4 +1,6 @@
+import { Context, Effect, Layer } from "effect";
 import { JSDOM } from "jsdom";
+import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 
 /**
  * A single document attached to a Finalsite meeting listing.
@@ -100,5 +102,101 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 	return results;
 }
 
-export { parseFinalsiteHtml };
-export type { FinalsiteMeetingListing, FinalsiteDocument };
+/**
+ * Effect teaching note: This is the second implementation of a scraper service,
+ * demonstrating how Effect's dependency injection makes implementations swappable.
+ * Both EgovScraper and FinalsiteScraper can be provided to the same pipeline —
+ * the consumer depends on the Tag, not the concrete implementation. Swapping is
+ * just changing which Layer you provide.
+ */
+
+interface FinalsiteScraperInterface {
+	/** Fetch the Finalsite school board page and parse meeting listings. */
+	scrapeListings(): Effect.Effect<
+		FinalsiteMeetingListing[],
+		NetworkError | ParseError
+	>;
+	/** Download a PDF document by its UUID and return the raw bytes. */
+	downloadDocument(uuid: string): Effect.Effect<ArrayBuffer, NetworkError>;
+}
+
+class FinalsiteScraper extends Context.Tag("FinalsiteScraper")<
+	FinalsiteScraper,
+	FinalsiteScraperInterface
+>() {}
+
+type FinalsiteScraperConfig = {
+	/** Base URL for the Finalsite school board page. */
+	baseUrl: string;
+	/** Injectable fetch function for testability. */
+	fetchFn?: typeof globalThis.fetch;
+};
+
+/**
+ * Effect teaching note: Layer.succeed provides a service value directly —
+ * used when construction can't fail. Each method wraps its HTTP calls in
+ * Effect.tryPromise, converting thrown exceptions into typed NetworkError
+ * or ParseError values. The fetchFn parameter enables testing without
+ * hitting the real Finalsite server.
+ */
+function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
+	const fetchFn = config.fetchFn ?? globalThis.fetch;
+
+	return Layer.succeed(FinalsiteScraper, {
+		scrapeListings: () =>
+			Effect.gen(function* () {
+				const html = yield* Effect.tryPromise({
+					try: async () => {
+						const response = await fetchFn(config.baseUrl);
+						if (!response.ok) {
+							throw new Error(
+								`HTTP ${response.status}: ${response.statusText}`,
+							);
+						}
+						return response.text();
+					},
+					catch: (error) =>
+						new NetworkError({
+							url: config.baseUrl,
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+
+				return yield* Effect.try({
+					try: () => parseFinalsiteHtml(html),
+					catch: (error) =>
+						new ParseError({
+							source: "finalsite",
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+			}),
+
+		downloadDocument: (uuid) =>
+			Effect.tryPromise({
+				try: async () => {
+					const url = new URL(
+						`/fs/resource-manager/view/${uuid}`,
+						config.baseUrl,
+					);
+					const response = await fetchFn(url.toString());
+					if (!response.ok) {
+						throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+					}
+					return response.arrayBuffer();
+				},
+				catch: (error) =>
+					new NetworkError({
+						url: `/fs/resource-manager/view/${uuid}`,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+export { FinalsiteScraper, FinalsiteScraperLive, parseFinalsiteHtml };
+export type {
+	FinalsiteMeetingListing,
+	FinalsiteDocument,
+	FinalsiteScraperConfig,
+};

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -1,0 +1,102 @@
+import { JSDOM } from "jsdom";
+
+/**
+ * A single document attached to a Finalsite meeting listing.
+ * Each document has a UUID used for the download URL path.
+ */
+type FinalsiteDocument = {
+	/** Finalsite resource UUID, parsed from the href path. */
+	uuid: string;
+	/** Normalized document type: "agenda" | "minutes" | "notice". */
+	documentType: string;
+	/** Relative URL path for downloading the document. */
+	downloadUrl: string;
+	/** Original filename from the data-file-name attribute. */
+	fileName: string;
+};
+
+/**
+ * A single meeting listing extracted from the Finalsite school board page.
+ * Groups all documents for one meeting date together.
+ */
+type FinalsiteMeetingListing = {
+	/** Meeting date as displayed (e.g. "January 6, 2026"). */
+	date: string;
+	/** Meeting type/description (e.g. "Regular Meeting 6:00 PM"). */
+	meetingType: string;
+	/** Year extracted from the accordion panel heading. */
+	year: number;
+	/** Documents attached to this meeting (agenda, minutes, notice). */
+	documents: FinalsiteDocument[];
+};
+
+/**
+ * Parses the Finalsite school board page HTML into structured meeting listings.
+ *
+ * The Finalsite CMS uses accordion panels (section.fsPanel) organized by year,
+ * each containing an HTML table with Date/Type/Links columns. Document links
+ * use UUID-based paths: /fs/resource-manager/view/{UUID}.
+ *
+ * Rows without any document links (future meetings with only &nbsp;) are
+ * included with an empty documents array — the pipeline can filter them later.
+ *
+ * Effect teaching note: Like parseEgovListingHtml, this is a pure function
+ * (string in, data out). Keeping parsing separate from HTTP fetching means
+ * this can be tested with fixture HTML and composed into an Effect pipeline
+ * at a higher level.
+ */
+function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
+	const dom = new JSDOM(html);
+	const doc = dom.window.document;
+	const panels = doc.querySelectorAll("section.fsPanel");
+	const results: FinalsiteMeetingListing[] = [];
+
+	for (const panel of panels) {
+		const yearText =
+			panel.querySelector("h2.fsElementTitle")?.textContent?.trim() ?? "";
+		const yearMatch = yearText.match(/\d{4}/);
+		if (!yearMatch) continue;
+		const year = Number.parseInt(yearMatch[0], 10);
+
+		const rows = panel.querySelectorAll("table.table-styled tr");
+
+		for (const row of rows) {
+			// Skip header rows
+			if (row.querySelector("th")) continue;
+
+			const cells = row.querySelectorAll("td");
+			if (cells.length < 3) continue;
+
+			const date = (cells[0].textContent ?? "").trim();
+			const meetingType = (cells[1].textContent ?? "").trim();
+
+			if (!date) continue;
+
+			const documents: FinalsiteDocument[] = [];
+			const links = cells[2].querySelectorAll("a[data-resource-uuid]");
+
+			for (const link of links) {
+				const uuid = link.getAttribute("data-resource-uuid") ?? "";
+				const href = link.getAttribute("href") ?? "";
+				const fileName = link.getAttribute("data-file-name") ?? "";
+				const linkText = (link.textContent ?? "").trim().toLowerCase();
+
+				if (!uuid) continue;
+
+				documents.push({
+					uuid,
+					documentType: linkText,
+					downloadUrl: href,
+					fileName,
+				});
+			}
+
+			results.push({ date, meetingType, year, documents });
+		}
+	}
+
+	return results;
+}
+
+export { parseFinalsiteHtml };
+export type { FinalsiteMeetingListing, FinalsiteDocument };

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -68,7 +68,9 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 			if (cells.length < 3) continue;
 
 			const date = (cells[0].textContent ?? "").trim();
-			const meetingType = (cells[1].textContent ?? "").trim();
+			const meetingType = (cells[1].textContent ?? "")
+				.replace(/\s+/g, " ")
+				.trim();
 
 			if (!date) continue;
 

--- a/src/pipeline/services/FinalsiteScraper.ts
+++ b/src/pipeline/services/FinalsiteScraper.ts
@@ -2,6 +2,8 @@ import { Context, Effect, Layer } from "effect";
 import { JSDOM } from "jsdom";
 import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 
+type FinalsiteDocumentType = "agenda" | "minutes" | "notice";
+
 /**
  * A single document attached to a Finalsite meeting listing.
  * Each document has a UUID used for the download URL path.
@@ -9,8 +11,8 @@ import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 type FinalsiteDocument = {
 	/** Finalsite resource UUID, parsed from the href path. */
 	uuid: string;
-	/** Normalized document type: "agenda" | "minutes" | "notice". */
-	documentType: string;
+	/** Normalized document type. */
+	documentType: FinalsiteDocumentType;
 	/** Relative URL path for downloading the document. */
 	downloadUrl: string;
 	/** Original filename from the data-file-name attribute. */
@@ -79,13 +81,22 @@ function parseFinalsiteHtml(html: string): FinalsiteMeetingListing[] {
 			const documents: FinalsiteDocument[] = [];
 			const links = cells[2].querySelectorAll("a[data-resource-uuid]");
 
+			const VALID_DOC_TYPES: FinalsiteDocumentType[] = [
+				"agenda",
+				"minutes",
+				"notice",
+			];
+
 			for (const link of links) {
 				const uuid = link.getAttribute("data-resource-uuid") ?? "";
 				const href = link.getAttribute("href") ?? "";
 				const fileName = link.getAttribute("data-file-name") ?? "";
-				const linkText = (link.textContent ?? "").trim().toLowerCase();
+				const linkText = (link.textContent ?? "")
+					.trim()
+					.toLowerCase() as FinalsiteDocumentType;
 
 				if (!uuid) continue;
+				if (!VALID_DOC_TYPES.includes(linkText)) continue;
 
 				documents.push({
 					uuid,
@@ -139,7 +150,9 @@ type FinalsiteScraperConfig = {
  * or ParseError values. The fetchFn parameter enables testing without
  * hitting the real Finalsite server.
  */
-function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
+function FinalsiteScraperLive(
+	config: FinalsiteScraperConfig,
+): Layer.Layer<FinalsiteScraper> {
 	const fetchFn = config.fetchFn ?? globalThis.fetch;
 
 	return Layer.succeed(FinalsiteScraper, {
@@ -196,6 +209,7 @@ function FinalsiteScraperLive(config: FinalsiteScraperConfig) {
 
 export { FinalsiteScraper, FinalsiteScraperLive, parseFinalsiteHtml };
 export type {
+	FinalsiteDocumentType,
 	FinalsiteMeetingListing,
 	FinalsiteDocument,
 	FinalsiteScraperConfig,

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, it } from "vitest";
 import { LandingPage } from "./index.tsx";
 
 afterEach(cleanup);
@@ -32,7 +32,7 @@ const populatedData = {
 		{
 			name: "Ellettsville Town Council",
 			slug: "ellettsville-town-council",
-			type: "town",
+			type: "town" as const,
 		},
 	],
 	fiscalByBody: [
@@ -65,31 +65,30 @@ describe("LandingPage", () => {
 	it("renders hero section with site title", () => {
 		render(<LandingPage data={emptyData} />);
 
-		expect(screen.getByText("Civic Mirror")).toBeDefined();
+		screen.getByText("Civic Mirror");
 	});
 
 	it("shows empty state when no meetings exist", () => {
 		render(<LandingPage data={emptyData} />);
 
-		expect(screen.getByText(/no meetings/i)).toBeDefined();
+		screen.getByText(/no meetings/i);
 	});
 
 	it("renders meeting cards when meetings exist", () => {
 		render(<LandingPage data={populatedData} />);
 
-		expect(screen.getByText("March 23, 2026")).toBeDefined();
+		screen.getByText("March 23, 2026");
 	});
 
 	it("renders fiscal summary section", () => {
 		render(<LandingPage data={populatedData} />);
 
-		expect(screen.getByText("Fiscal Overview")).toBeDefined();
+		screen.getByText("Fiscal Overview");
 	});
 
 	it("renders body filter options", () => {
 		render(<LandingPage data={populatedData} />);
 
-		const select = screen.getByRole("combobox");
-		expect(select).toBeDefined();
+		screen.getByRole("combobox");
 	});
 });

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LandingPage } from "./index.tsx";
+
+afterEach(cleanup);
+
+const emptyData = {
+	meetings: [],
+	bodies: [],
+	fiscalByBody: [],
+	fiscalByCategory: [],
+	fiscalByTimePeriod: [],
+	notableDecisions: [],
+};
+
+const populatedData = {
+	meetings: [
+		{
+			id: 1,
+			date: "2026-03-23",
+			meetingType: "regular" as const,
+			bodyName: "Ellettsville Town Council",
+			bodySlug: "ellettsville-town-council",
+			highlights: ["Approved road repairs"],
+			prose: "Council met to discuss infrastructure.",
+			fiscalDecisionCount: 1,
+			totalSpending: 50000,
+		},
+	],
+	bodies: [
+		{
+			name: "Ellettsville Town Council",
+			slug: "ellettsville-town-council",
+			type: "town",
+		},
+	],
+	fiscalByBody: [
+		{
+			bodyName: "Ellettsville Town Council",
+			bodySlug: "ellettsville-town-council",
+			totalAmount: 50000,
+			decisionCount: 1,
+		},
+	],
+	fiscalByCategory: [
+		{ budgetCategory: "infrastructure", totalAmount: 50000, decisionCount: 1 },
+	],
+	fiscalByTimePeriod: [
+		{ period: "2026-03", totalAmount: 50000, decisionCount: 1 },
+	],
+	notableDecisions: [
+		{
+			title: "Sale Street Road Repairs",
+			amount: 50000,
+			status: "approved" as const,
+			bodyName: "Ellettsville Town Council",
+			bodySlug: "ellettsville-town-council",
+			date: "2026-03-23",
+		},
+	],
+};
+
+describe("LandingPage", () => {
+	it("renders hero section with site title", () => {
+		render(<LandingPage data={emptyData} />);
+
+		expect(screen.getByText("Civic Mirror")).toBeDefined();
+	});
+
+	it("shows empty state when no meetings exist", () => {
+		render(<LandingPage data={emptyData} />);
+
+		expect(screen.getByText(/no meetings/i)).toBeDefined();
+	});
+
+	it("renders meeting cards when meetings exist", () => {
+		render(<LandingPage data={populatedData} />);
+
+		expect(screen.getByText("March 23, 2026")).toBeDefined();
+	});
+
+	it("renders fiscal summary section", () => {
+		render(<LandingPage data={populatedData} />);
+
+		expect(screen.getByText("Fiscal Overview")).toBeDefined();
+	});
+
+	it("renders body filter options", () => {
+		render(<LandingPage data={populatedData} />);
+
+		const select = screen.getByRole("combobox");
+		expect(select).toBeDefined();
+	});
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,86 +1,160 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { FiscalSummary } from "#/components/FiscalSummary.tsx";
+import { MeetingCard } from "#/components/MeetingCard.tsx";
+import type {
+	FiscalByBody,
+	FiscalByCategory,
+	FiscalByTimePeriod,
+	MeetingCardData,
+	NotableFiscalDecision,
+} from "#/db/queries.ts";
+import {
+	aggregateFiscalByBody,
+	aggregateFiscalByCategory,
+	aggregateFiscalByTimePeriod,
+	listGoverningBodies,
+	listNotableFiscalDecisions,
+	listRecentMeetings,
+} from "#/server/meetings.ts";
 
-export const Route = createFileRoute("/")({ component: App });
+type LandingData = {
+	meetings: MeetingCardData[];
+	bodies: Array<{ name: string; slug: string; type: string }>;
+	fiscalByBody: FiscalByBody[];
+	fiscalByCategory: FiscalByCategory[];
+	fiscalByTimePeriod: FiscalByTimePeriod[];
+	notableDecisions: NotableFiscalDecision[];
+};
 
-function App() {
+export const Route = createFileRoute("/")({
+	validateSearch: (search: Record<string, unknown>) => ({
+		body: (search.body as string) || undefined,
+	}),
+	loaderDeps: ({ search }) => ({ body: search.body }),
+	loader: async ({ deps }): Promise<LandingData> => {
+		const [
+			meetings,
+			bodies,
+			fiscalByBody,
+			fiscalByCategory,
+			fiscalByTimePeriod,
+			notableDecisions,
+		] = await Promise.all([
+			listRecentMeetings({ data: { bodySlug: deps.body } }),
+			listGoverningBodies(),
+			aggregateFiscalByBody(),
+			aggregateFiscalByCategory(),
+			aggregateFiscalByTimePeriod(),
+			listNotableFiscalDecisions({ data: {} }),
+		]);
+		return {
+			meetings,
+			bodies,
+			fiscalByBody,
+			fiscalByCategory,
+			fiscalByTimePeriod,
+			notableDecisions,
+		};
+	},
+	head: () => ({
+		meta: [{ title: "Civic Mirror — Local Government Transparency" }],
+	}),
+	component: LandingPageRoute,
+});
+
+function LandingPageRoute() {
+	const data = Route.useLoaderData();
+	const { body } = Route.useSearch();
+	const navigate = Route.useNavigate();
+
+	return (
+		<LandingPage
+			data={data}
+			selectedBody={body}
+			onBodyChange={(slug) => navigate({ search: { body: slug || undefined } })}
+		/>
+	);
+}
+
+export function LandingPage({
+	data,
+	selectedBody,
+	onBodyChange,
+}: {
+	data: LandingData;
+	selectedBody?: string;
+	onBodyChange?: (slug: string) => void;
+}) {
 	return (
 		<main className="page-wrap px-4 pb-8 pt-14">
+			{/* Hero */}
 			<section className="island-shell rise-in relative overflow-hidden rounded-[2rem] px-6 py-10 sm:px-10 sm:py-14">
 				<div className="pointer-events-none absolute -left-20 -top-24 h-56 w-56 rounded-full bg-[radial-gradient(circle,rgba(79,184,178,0.32),transparent_66%)]" />
 				<div className="pointer-events-none absolute -bottom-20 -right-20 h-56 w-56 rounded-full bg-[radial-gradient(circle,rgba(47,106,74,0.18),transparent_66%)]" />
-				<p className="island-kicker mb-3">TanStack Start Base Template</p>
+				<p className="island-kicker mb-3">Ellettsville & Monroe County</p>
 				<h1 className="display-title mb-5 max-w-3xl text-4xl leading-[1.02] font-bold tracking-tight text-[var(--sea-ink)] sm:text-6xl">
-					Start simple, ship quickly.
+					Civic Mirror
 				</h1>
-				<p className="mb-8 max-w-2xl text-base text-[var(--sea-ink-soft)] sm:text-lg">
-					This base starter intentionally keeps things light: two routes, clean
-					structure, and the essentials you need to build from scratch.
+				<p className="mb-0 max-w-2xl text-base text-[var(--sea-ink-soft)] sm:text-lg">
+					AI-powered summaries of local government meetings. Stay informed about
+					what your elected officials are deciding — in 5 minutes, not 5 hours.
 				</p>
-				<div className="flex flex-wrap gap-3">
-					<a
-						href="/about"
-						className="rounded-full border border-[rgba(50,143,151,0.3)] bg-[rgba(79,184,178,0.14)] px-5 py-2.5 text-sm font-semibold text-[var(--lagoon-deep)] no-underline transition hover:-translate-y-0.5 hover:bg-[rgba(79,184,178,0.24)]"
-					>
-						About This Starter
-					</a>
-					<a
-						href="https://tanstack.com/router"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="rounded-full border border-[rgba(23,58,64,0.2)] bg-white/50 px-5 py-2.5 text-sm font-semibold text-[var(--sea-ink)] no-underline transition hover:-translate-y-0.5 hover:border-[rgba(23,58,64,0.35)]"
-					>
-						Router Guide
-					</a>
+			</section>
+
+			{/* Body Filter + Meeting Feed */}
+			<section className="mt-8">
+				<div className="mb-4 flex items-center justify-between">
+					<h2 className="text-lg font-semibold text-[var(--sea-ink)]">
+						Recent Meetings
+					</h2>
+					{data.bodies.length > 0 && (
+						<select
+							value={selectedBody ?? ""}
+							onChange={(e) => onBodyChange?.(e.target.value)}
+							className="rounded-lg border border-[var(--line)] bg-[var(--surface-strong)] px-3 py-1.5 text-sm text-[var(--sea-ink)]"
+						>
+							<option value="">All Bodies</option>
+							{data.bodies.map((b) => (
+								<option key={b.slug} value={b.slug}>
+									{b.name}
+								</option>
+							))}
+						</select>
+					)}
 				</div>
+
+				{data.meetings.length === 0 ? (
+					<div className="island-shell rounded-2xl p-6 text-center">
+						<p className="text-sm text-[var(--sea-ink-soft)]">
+							No meetings available yet. Check back after the pipeline processes
+							its first batch.
+						</p>
+					</div>
+				) : (
+					<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+						{data.meetings.map((m, index) => (
+							<div
+								key={m.id}
+								className="rise-in"
+								style={{
+									animationDelay: `${index * 60 + 80}ms`,
+								}}
+							>
+								<MeetingCard meeting={m} />
+							</div>
+						))}
+					</div>
+				)}
 			</section>
 
-			<section className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-				{[
-					[
-						"Type-Safe Routing",
-						"Routes and links stay in sync across every page.",
-					],
-					[
-						"Server Functions",
-						"Call server code from your UI without creating API boilerplate.",
-					],
-					[
-						"Streaming by Default",
-						"Ship progressively rendered responses for faster experiences.",
-					],
-					[
-						"Tailwind Native",
-						"Design quickly with utility-first styling and reusable tokens.",
-					],
-				].map(([title, desc], index) => (
-					<article
-						key={title}
-						className="island-shell feature-card rise-in rounded-2xl p-5"
-						style={{ animationDelay: `${index * 90 + 80}ms` }}
-					>
-						<h2 className="mb-2 text-base font-semibold text-[var(--sea-ink)]">
-							{title}
-						</h2>
-						<p className="m-0 text-sm text-[var(--sea-ink-soft)]">{desc}</p>
-					</article>
-				))}
-			</section>
-
-			<section className="island-shell mt-8 rounded-2xl p-6">
-				<p className="island-kicker mb-2">Quick Start</p>
-				<ul className="m-0 list-disc space-y-2 pl-5 text-sm text-[var(--sea-ink-soft)]">
-					<li>
-						Edit <code>src/routes/index.tsx</code> to customize the home page.
-					</li>
-					<li>
-						Update <code>src/components/Header.tsx</code> and{" "}
-						<code>src/components/Footer.tsx</code> for brand links.
-					</li>
-					<li>
-						Add routes in <code>src/routes</code> and tweak visual tokens in{" "}
-						<code>src/styles.css</code>.
-					</li>
-				</ul>
+			{/* Fiscal Summary */}
+			<section className="rise-in mt-8" style={{ animationDelay: "200ms" }}>
+				<FiscalSummary
+					byBody={data.fiscalByBody}
+					byCategory={data.fiscalByCategory}
+					byTimePeriod={data.fiscalByTimePeriod}
+					notableDecisions={data.notableDecisions}
+				/>
 			</section>
 		</main>
 	);

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,6 +5,7 @@ import type {
 	FiscalByBody,
 	FiscalByCategory,
 	FiscalByTimePeriod,
+	GoverningBodySummary,
 	MeetingCardData,
 	NotableFiscalDecision,
 } from "#/db/queries.ts";
@@ -19,7 +20,7 @@ import {
 
 type LandingData = {
 	meetings: MeetingCardData[];
-	bodies: Array<{ name: string; slug: string; type: string }>;
+	bodies: GoverningBodySummary[];
 	fiscalByBody: FiscalByBody[];
 	fiscalByCategory: FiscalByCategory[];
 	fiscalByTimePeriod: FiscalByTimePeriod[];
@@ -28,7 +29,8 @@ type LandingData = {
 
 export const Route = createFileRoute("/")({
 	validateSearch: (search: Record<string, unknown>) => ({
-		body: (search.body as string) || undefined,
+		body:
+			typeof search.body === "string" ? search.body || undefined : undefined,
 	}),
 	loaderDeps: ({ search }) => ({ body: search.body }),
 	loader: async ({ deps }): Promise<LandingData> => {

--- a/src/server/meetings.test.ts
+++ b/src/server/meetings.test.ts
@@ -1,0 +1,194 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { describe, expect, it } from "vitest";
+import {
+	aggregateFiscalByBodyQuery,
+	aggregateFiscalByCategoryQuery,
+	aggregateFiscalByTimePeriodQuery,
+	listGoverningBodiesQuery,
+	listNotableFiscalDecisionsQuery,
+	listRecentMeetingsQuery,
+} from "#/db/queries.ts";
+import * as schema from "#/db/schema.ts";
+
+/**
+ * Server functions are thin wrappers over query functions.
+ * These tests verify the query functions are correctly integrated
+ * with a seeded database — the server function RPC wiring is
+ * tested via TanStack Start's integration layer.
+ */
+
+function createTestDb() {
+	const sqlite = new Database(":memory:");
+	const db = drizzle(sqlite, { schema });
+	migrate(db, { migrationsFolder: "./drizzle" });
+	return db;
+}
+
+function seedFullScenario(db: ReturnType<typeof createTestDb>) {
+	const council = db
+		.insert(schema.governingBodies)
+		.values({
+			name: "Ellettsville Town Council",
+			slug: "ellettsville-town-council",
+			type: "town",
+		})
+		.returning()
+		.get();
+
+	const school = db
+		.insert(schema.governingBodies)
+		.values({
+			name: "RBBSC School Board",
+			slug: "rbbsc-school-board",
+			type: "school",
+		})
+		.returning()
+		.get();
+
+	// Council meeting with fiscal decisions
+	const m1 = db
+		.insert(schema.meetings)
+		.values({ bodyId: council.id, date: "2026-03-23", meetingType: "regular" })
+		.returning()
+		.get();
+
+	db.insert(schema.summaries)
+		.values({
+			meetingId: m1.id,
+			highlights: ["Approved road repairs", "Discussed park budget"],
+			prose: "Town Council met to discuss infrastructure.",
+			model: "gemini-2.5-flash",
+		})
+		.run();
+
+	db.insert(schema.fiscalDecisions)
+		.values({
+			meetingId: m1.id,
+			title: "Sale Street Road Repairs",
+			description: "Funding for road repairs",
+			amount: 50000,
+			originalAmount: "$50,000",
+			budgetCategory: "infrastructure",
+			status: "approved",
+			confidence: 0.95,
+			isRecurring: false,
+		})
+		.run();
+
+	// School board meeting
+	const m2 = db
+		.insert(schema.meetings)
+		.values({ bodyId: school.id, date: "2026-03-20", meetingType: "regular" })
+		.returning()
+		.get();
+
+	db.insert(schema.summaries)
+		.values({
+			meetingId: m2.id,
+			highlights: ["New textbook budget approved"],
+			prose: "School board approved textbook purchases.",
+			model: "gemini-2.5-flash",
+		})
+		.run();
+
+	db.insert(schema.fiscalDecisions)
+		.values({
+			meetingId: m2.id,
+			title: "Textbook Purchase",
+			description: "Annual textbook order",
+			amount: 15000,
+			originalAmount: "$15,000",
+			budgetCategory: "education",
+			status: "approved",
+			confidence: 0.9,
+			isRecurring: true,
+		})
+		.run();
+
+	return { council, school, m1, m2 };
+}
+
+describe("server function integration", () => {
+	it("listRecentMeetings returns all meetings with fiscal rollups", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = listRecentMeetingsQuery(db);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].date).toBe("2026-03-23");
+		expect(result[0].totalSpending).toBe(50000);
+		expect(result[1].date).toBe("2026-03-20");
+		expect(result[1].totalSpending).toBe(15000);
+	});
+
+	it("listRecentMeetings filters by body slug", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = listRecentMeetingsQuery(db, "rbbsc-school-board");
+
+		expect(result).toHaveLength(1);
+		expect(result[0].bodyName).toBe("RBBSC School Board");
+	});
+
+	it("aggregateFiscalByBody returns correct totals per body", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = aggregateFiscalByBodyQuery(db);
+
+		expect(result).toHaveLength(2);
+		const council = result.find(
+			(r) => r.bodySlug === "ellettsville-town-council",
+		);
+		expect(council?.totalAmount).toBe(50000);
+	});
+
+	it("aggregateFiscalByCategory returns correct totals per category", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = aggregateFiscalByCategoryQuery(db);
+
+		const infra = result.find((r) => r.budgetCategory === "infrastructure");
+		const edu = result.find((r) => r.budgetCategory === "education");
+		expect(infra?.totalAmount).toBe(50000);
+		expect(edu?.totalAmount).toBe(15000);
+	});
+
+	it("aggregateFiscalByTimePeriod groups by month", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = aggregateFiscalByTimePeriodQuery(db);
+
+		expect(result).toHaveLength(1); // both in 2026-03
+		expect(result[0].period).toBe("2026-03");
+		expect(result[0].totalAmount).toBe(65000);
+	});
+
+	it("listNotableFiscalDecisions returns highest amounts first", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = listNotableFiscalDecisionsQuery(db);
+
+		expect(result[0].title).toBe("Sale Street Road Repairs");
+		expect(result[0].amount).toBe(50000);
+		expect(result[1].title).toBe("Textbook Purchase");
+	});
+
+	it("listGoverningBodies returns all bodies alphabetically", () => {
+		const db = createTestDb();
+		seedFullScenario(db);
+
+		const result = listGoverningBodiesQuery(db);
+
+		expect(result).toHaveLength(2);
+		expect(result[0].name).toBe("Ellettsville Town Council");
+		expect(result[1].name).toBe("RBBSC School Board");
+	});
+});

--- a/src/server/meetings.ts
+++ b/src/server/meetings.ts
@@ -1,14 +1,15 @@
 import { createServerFn } from "@tanstack/react-start";
 import { db } from "#/db/index.ts";
-import { getMeetingByBodyAndDateQuery } from "#/db/queries.ts";
+import {
+	aggregateFiscalByBodyQuery,
+	aggregateFiscalByCategoryQuery,
+	aggregateFiscalByTimePeriodQuery,
+	getMeetingByBodyAndDateQuery,
+	listGoverningBodiesQuery,
+	listNotableFiscalDecisionsQuery,
+	listRecentMeetingsQuery,
+} from "#/db/queries.ts";
 
-/**
- * Server function to load a meeting's full detail by governing body slug and date.
- *
- * Delegates to the shared `getMeetingByBodyAndDateQuery` from db/queries,
- * keeping the query logic in one place. The server function is a thin wrapper
- * that bridges TanStack Start's RPC layer to the query function.
- */
 export const getMeetingByBodyAndDate = createServerFn({
 	method: "GET",
 })
@@ -16,3 +17,43 @@ export const getMeetingByBodyAndDate = createServerFn({
 	.handler(async ({ data }) => {
 		return getMeetingByBodyAndDateQuery(db, data.bodySlug, data.date);
 	});
+
+export const listRecentMeetings = createServerFn({
+	method: "GET",
+})
+	.inputValidator((input: { bodySlug?: string; limit?: number }) => input)
+	.handler(async ({ data }) => {
+		return listRecentMeetingsQuery(db, data.bodySlug, data.limit);
+	});
+
+export const aggregateFiscalByBody = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	return aggregateFiscalByBodyQuery(db);
+});
+
+export const aggregateFiscalByCategory = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	return aggregateFiscalByCategoryQuery(db);
+});
+
+export const aggregateFiscalByTimePeriod = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	return aggregateFiscalByTimePeriodQuery(db);
+});
+
+export const listNotableFiscalDecisions = createServerFn({
+	method: "GET",
+})
+	.inputValidator((input: { limit?: number }) => input)
+	.handler(async ({ data }) => {
+		return listNotableFiscalDecisionsQuery(db, data.limit);
+	});
+
+export const listGoverningBodies = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	return listGoverningBodiesQuery(db);
+});


### PR DESCRIPTION
## Summary

Adds the Finalsite CMS scraper for RBB School Board meeting documents and builds the full landing page intelligence layer: recent meetings feed with body filtering, high-level fiscal summary (by body, category, and time period), and notable fiscal decisions display. All backed by server-side rendered TanStack Start routes with 67 passing tests.

## PRD

Part of #1

## Slices

- [x] #2 — Tracer Bullet: Schema + eGov Pipeline + Meeting Detail Page
- [x] #3 — YouTube Transcription Pipeline
- [x] #4 — Finalsite Scraper
- [x] #5 — Landing Page + Meeting Feed + High-Level Spending
- [ ] #6 — Railway Deployment
- [ ] #7 — Detailed Spending Dashboard
- [ ] #8 — Pipeline Orchestrator + CLI + Alerts
- [ ] #9 — QA: Full Manual Verification

## Key Decisions

- Used individual queries (not JOINs) for landing page data, matching the existing `getMeetingByBodyAndDateQuery` pattern — readability over query count, fine for SQLite
- Body filter implemented via URL search params (`?body=slug`) rather than client state, making filtered views shareable/bookmarkable
- `FiscalSummary` renders text/tables (no chart library) per PRD spec — charts live on the `/spending` page in #7
- `Header.tsx` links updated to pass `search={{ body: undefined }}` for type safety after adding `validateSearch` to the index route