### PR TITLE
Swap Drizzle driver from better-sqlite3 to @libsql/client

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "@effect/cli": "^0.75.0",
     "@effect/platform": "^0.96.0",
     "@effect/platform-node": "^0.106.0",
-    "@effect/sql": "^0.51.0",
-    "@effect/sql-sqlite-node": "^0.52.0",
+    "@libsql/client": "^0.17.2",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",
     "@tanstack/react-query": "latest",
@@ -40,7 +39,6 @@
     "@tanstack/react-start": "latest",
     "@tanstack/router-plugin": "^1.132.0",
     "ai": "^6.0.153",
-    "better-sqlite3": "^12.6.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-kit": "^0.31.9",
@@ -62,7 +60,6 @@
     "@tanstack/devtools-vite": "latest",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
-    "@types/better-sqlite3": "^7.6.0",
     "@types/jsdom": "^28.0.1",
     "@types/node": "^22.10.2",
     "@types/react": "^19.2.0",
@@ -81,7 +78,6 @@
     "onlyBuiltDependencies": [
       "esbuild",
       "lightningcss",
-      "better-sqlite3",
       "lefthook"
     ]
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,12 +23,9 @@ importers:
       '@effect/platform-node':
         specifier: ^0.106.0
         version: 0.106.0(@effect/cluster@0.58.0(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql':
-        specifier: ^0.51.0
-        version: 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/sql-sqlite-node':
-        specifier: ^0.52.0
-        version: 0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)
+      '@libsql/client':
+        specifier: ^0.17.2
+        version: 0.17.2
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -59,9 +56,6 @@ importers:
       ai:
         specifier: ^6.0.153
         version: 6.0.153(zod@4.3.6)
-      better-sqlite3:
-        specifier: ^12.6.2
-        version: 12.8.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -73,7 +67,7 @@ importers:
         version: 0.31.10
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
+        version: 0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)
       effect:
         specifier: ^3.21.0
         version: 3.21.0
@@ -120,9 +114,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@types/better-sqlite3':
-        specifier: ^7.6.0
-        version: 7.6.13
       '@types/jsdom':
         specifier: ^28.0.1
         version: 28.0.1
@@ -484,14 +475,6 @@ packages:
     resolution: {integrity: sha512-VFeJ16cZUXqiIzG9UHOVKGuiBPJ7fV+0lEbJU6xi12JnnxXe/19BQPpOwiRawCUbPOR3/xIURDUgGxU+Ft0pvQ==}
     peerDependencies:
       '@effect/platform': ^0.96.0
-      effect: ^3.21.0
-
-  '@effect/sql-sqlite-node@0.52.0':
-    resolution: {integrity: sha512-yijDbly4MwxAPebvd2ZBI62qDpGdXKL96drMzflXDnjEh2JiVr/xVyy1VB0JsVxqw8IJ9TUIgOvAJWQ88oVMXA==}
-    peerDependencies:
-      '@effect/experimental': ^0.60.0
-      '@effect/platform': ^0.96.0
-      '@effect/sql': ^0.51.0
       effect: ^3.21.0
 
   '@effect/sql@0.51.0':
@@ -991,6 +974,63 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@libsql/client@0.17.2':
+    resolution: {integrity: sha512-0aw0S3iQMHvOxfRt5j1atoCCPMT3gjsB2PS8/uxSM1DcDn39xqz6RlgSMxtP8I3JsxIXAFuw7S41baLEw0Zi+Q==}
+
+  '@libsql/core@0.17.2':
+    resolution: {integrity: sha512-L8qv12HZ/jRBcETVR3rscP0uHNxh+K3EABSde6scCw7zfOdiLqO3MAkJaeE1WovPsjXzsN/JBoZED4+7EZVT3g==}
+
+  '@libsql/darwin-arm64@0.5.29':
+    resolution: {integrity: sha512-K+2RIB1OGFPYQbfay48GakLhqf3ArcbHqPFu7EZiaUcRgFcdw8RoltsMyvbj5ix2fY0HV3Q3Ioa/ByvQdaSM0A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@libsql/darwin-x64@0.5.29':
+    resolution: {integrity: sha512-OtT+KFHsKFy1R5FVadr8FJ2Bb1mghtXTyJkxv0trocq7NuHntSki1eUbxpO5ezJesDvBlqFjnWaYYY516QNLhQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@libsql/hrana-client@0.9.0':
+    resolution: {integrity: sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==}
+
+  '@libsql/isomorphic-ws@0.1.5':
+    resolution: {integrity: sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==}
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    resolution: {integrity: sha512-CD4n4zj7SJTHso4nf5cuMoWoMSS7asn5hHygsDuhRl8jjjCTT3yE+xdUvI4J7zsyb53VO5ISh4cwwOtf6k2UhQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    resolution: {integrity: sha512-2Z9qBVpEJV7OeflzIR3+l5yAd4uTOLxklScYTwpZnkm2vDSGlC1PRlueLaufc4EFITkLKXK2MWBpexuNJfMVcg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    resolution: {integrity: sha512-gURBqaiXIGGwFNEaUj8Ldk7Hps4STtG+31aEidCk5evMMdtsdfL3HPCpvys+ZF/tkOs2MWlRWoSq7SOuCE9k3w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    resolution: {integrity: sha512-fwgYZ0H8mUkyVqXZHF3mT/92iIh1N94Owi/f66cPVNsk9BdGKq5gVpoKO+7UxaNzuEH1roJp2QEwsCZMvBLpqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    resolution: {integrity: sha512-y14V0vY0nmMC6G0pHeJcEarcnGU2H6cm21ZceRkacWHvQAEhAG0latQkCtoS2njFOXiYIg+JYPfAoWKbi82rkg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/linux-x64-musl@0.5.29':
+    resolution: {integrity: sha512-gquqwA/39tH4pFl+J9n3SOMSymjX+6kZ3kWgY3b94nXFTwac9bnFNMffIomgvlFaC4ArVqMnOZD3nuJ3H3VO1w==}
+    cpu: [x64]
+    os: [linux]
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    resolution: {integrity: sha512-4/0CvEdhi6+KjMxMaVbFM2n2Z44escBRoEYpR+gZg64DdetzGnYm8mcNLcoySaDJZNaBd6wz5DNdgRmcI4hXcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -1020,6 +1060,9 @@ packages:
     resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
     cpu: [x64]
     os: [win32]
+
+  '@neon-rs/load@0.0.4':
+    resolution: {integrity: sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==}
 
   '@oozcitak/dom@2.0.2':
     resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
@@ -1676,6 +1719,9 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@vercel/oidc@3.1.0':
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
@@ -1852,6 +1898,9 @@ packages:
   cookie-es@2.0.1:
     resolution: {integrity: sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==}
 
+  cross-fetch@4.1.0:
+    resolution: {integrity: sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -1874,6 +1923,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -1909,6 +1962,10 @@ packages:
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+    engines: {node: '>=8'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -2123,6 +2180,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
 
@@ -2132,6 +2193,10 @@ packages:
 
   find-my-way-ts@0.1.6:
     resolution: {integrity: sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2235,6 +2300,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2326,6 +2394,11 @@ packages:
   lefthook@2.1.5:
     resolution: {integrity: sha512-yB9IFWurFllusbPZqvG0EavTmpNXPya2MuO7Li7YT78xAj3uCQ3AgmW9TVUbTTsSMhsegbiAMRpwfEk2TP1P0A==}
     hasBin: true
+
+  libsql@0.5.29:
+    resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
+    os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2469,6 +2542,24 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
     hasBin: true
@@ -2541,6 +2632,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  promise-limit@2.7.0:
+    resolution: {integrity: sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2761,6 +2855,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -2926,6 +3023,13 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -2949,6 +3053,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -3330,14 +3437,6 @@ snapshots:
       effect: 3.21.0
       msgpackr: 1.11.9
 
-  '@effect/sql-sqlite-node@0.52.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
-    dependencies:
-      '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      '@effect/platform': 0.96.0(effect@3.21.0)
-      '@effect/sql': 0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
-      better-sqlite3: 12.8.0
-      effect: 3.21.0
-
   '@effect/sql@0.51.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)':
     dependencies:
       '@effect/experimental': 0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0)
@@ -3609,6 +3708,68 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@libsql/client@0.17.2':
+    dependencies:
+      '@libsql/core': 0.17.2
+      '@libsql/hrana-client': 0.9.0
+      js-base64: 3.7.8
+      libsql: 0.5.29
+      promise-limit: 2.7.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/core@0.17.2':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@libsql/darwin-arm64@0.5.29':
+    optional: true
+
+  '@libsql/darwin-x64@0.5.29':
+    optional: true
+
+  '@libsql/hrana-client@0.9.0':
+    dependencies:
+      '@libsql/isomorphic-ws': 0.1.5
+      cross-fetch: 4.1.0
+      js-base64: 3.7.8
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@libsql/isomorphic-ws@0.1.5':
+    dependencies:
+      '@types/ws': 8.18.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@libsql/linux-arm-gnueabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm-musleabihf@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-arm64-musl@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-gnu@0.5.29':
+    optional: true
+
+  '@libsql/linux-x64-musl@0.5.29':
+    optional: true
+
+  '@libsql/win32-x64-msvc@0.5.29':
+    optional: true
+
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -3626,6 +3787,8 @@ snapshots:
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
+
+  '@neon-rs/load@0.0.4': {}
 
   '@oozcitak/dom@2.0.2':
     dependencies:
@@ -4235,6 +4398,7 @@ snapshots:
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -4265,6 +4429,10 @@ snapshots:
       csstype: 3.2.3
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
 
   '@vercel/oidc@3.1.0': {}
 
@@ -4366,7 +4534,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  base64-js@1.5.1: {}
+  base64-js@1.5.1:
+    optional: true
 
   baseline-browser-mapping@2.10.16: {}
 
@@ -4374,6 +4543,7 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bidi-js@1.0.3:
     dependencies:
@@ -4384,12 +4554,14 @@ snapshots:
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   boolbase@1.0.0: {}
 
@@ -4411,6 +4583,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   cac@6.7.14: {}
 
@@ -4463,7 +4636,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -4474,6 +4648,12 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie-es@2.0.1: {}
+
+  cross-fetch@4.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   css-select@5.2.2:
     dependencies:
@@ -4501,6 +4681,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -4519,12 +4701,16 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-eql@5.0.2: {}
 
-  deep-extend@0.6.0: {}
+  deep-extend@0.6.0:
+    optional: true
 
   dequal@2.0.3: {}
+
+  detect-libc@2.0.2: {}
 
   detect-libc@2.1.2: {}
 
@@ -4559,8 +4745,9 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
+  drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0):
     optionalDependencies:
+      '@libsql/client': 0.17.2
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       better-sqlite3: 12.8.0
@@ -4580,6 +4767,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -4687,7 +4875,8 @@ snapshots:
 
   eventsource-parser@3.0.6: {}
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.3.0: {}
 
@@ -4703,7 +4892,13 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
-  file-uri-to-path@1.0.0: {}
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  file-uri-to-path@1.0.0:
+    optional: true
 
   fill-range@7.1.1:
     dependencies:
@@ -4711,7 +4906,12 @@ snapshots:
 
   find-my-way-ts@0.1.6: {}
 
-  fs-constants@1.0.0: {}
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
+  fs-constants@1.0.0:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -4722,7 +4922,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -4772,11 +4973,14 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
-  inherits@2.0.4: {}
+  inherits@2.0.4:
+    optional: true
 
-  ini@1.3.8: {}
+  ini@1.3.8:
+    optional: true
 
   ini@4.1.3: {}
 
@@ -4797,6 +5001,8 @@ snapshots:
   isbot@5.1.37: {}
 
   jiti@2.6.1: {}
+
+  js-base64@3.7.8: {}
 
   js-tokens@4.0.0: {}
 
@@ -4889,6 +5095,21 @@ snapshots:
       lefthook-windows-arm64: 2.1.5
       lefthook-windows-x64: 2.1.5
 
+  libsql@0.5.29:
+    dependencies:
+      '@neon-rs/load': 0.0.4
+      detect-libc: 2.0.2
+    optionalDependencies:
+      '@libsql/darwin-arm64': 0.5.29
+      '@libsql/darwin-x64': 0.5.29
+      '@libsql/linux-arm-gnueabihf': 0.5.29
+      '@libsql/linux-arm-musleabihf': 0.5.29
+      '@libsql/linux-arm64-gnu': 0.5.29
+      '@libsql/linux-arm64-musl': 0.5.29
+      '@libsql/linux-x64-gnu': 0.5.29
+      '@libsql/linux-x64-musl': 0.5.29
+      '@libsql/win32-x64-msvc': 0.5.29
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -4960,11 +5181,14 @@ snapshots:
 
   mime@3.0.0: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
-  minimist@1.2.8: {}
+  minimist@1.2.8:
+    optional: true
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -4988,13 +5212,27 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   node-abi@3.89.0:
     dependencies:
       semver: 7.7.4
+    optional: true
 
   node-addon-api@7.1.1: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
@@ -5012,6 +5250,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -5067,6 +5306,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
+    optional: true
 
   prettier@3.8.1: {}
 
@@ -5076,10 +5316,13 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  promise-limit@2.7.0: {}
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -5091,6 +5334,7 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+    optional: true
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -5108,6 +5352,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -5163,7 +5408,8 @@ snapshots:
 
   rou3@0.8.1: {}
 
-  safe-buffer@5.2.1: {}
+  safe-buffer@5.2.1:
+    optional: true
 
   safer-buffer@2.1.2: {}
 
@@ -5175,7 +5421,8 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.4: {}
+  semver@7.7.4:
+    optional: true
 
   seroval-plugins@1.5.2(seroval@1.5.2):
     dependencies:
@@ -5187,13 +5434,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   solid-js@1.9.12:
     dependencies:
@@ -5226,8 +5475,10 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-literal@3.1.0:
     dependencies:
@@ -5252,6 +5503,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -5260,6 +5512,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   tiny-invariant@1.3.3: {}
 
@@ -5294,6 +5547,8 @@ snapshots:
     dependencies:
       tldts: 7.0.28
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -5314,6 +5569,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   tw-animate-css@1.4.0: {}
 
@@ -5448,6 +5704,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -5468,12 +5728,18 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   ws@8.20.0: {}
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,11 @@
-import { drizzle } from "drizzle-orm/better-sqlite3";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
 
 import * as schema from "./schema.ts";
 
-const url = process.env.DATABASE_URL ?? "";
-export const db = drizzle(url, { schema });
+const client = createClient({
+	url: process.env.TURSO_DATABASE_URL ?? "file:dev.db",
+	authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+export const db = drizzle(client, { schema });

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -1,6 +1,6 @@
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { describe, expect, it } from "vitest";
 import * as schema from "#/db/schema.ts";
 import {
@@ -12,18 +12,18 @@ import {
 	listRecentMeetingsQuery,
 } from "./queries.ts";
 
-function createTestDb() {
-	const sqlite = new Database(":memory:");
-	const db = drizzle(sqlite, { schema });
-	migrate(db, { migrationsFolder: "./drizzle" });
+async function createTestDb() {
+	const client = createClient({ url: ":memory:" });
+	const db = drizzle(client, { schema });
+	await migrate(db, { migrationsFolder: "./drizzle" });
 	return db;
 }
 
-function seedBody(
-	db: ReturnType<typeof createTestDb>,
+async function seedBody(
+	db: Awaited<ReturnType<typeof createTestDb>>,
 	overrides: Partial<typeof schema.governingBodies.$inferInsert> = {},
 ) {
-	return db
+	return await db
 		.insert(schema.governingBodies)
 		.values({
 			name: "Ellettsville Town Council",
@@ -35,8 +35,8 @@ function seedBody(
 		.get();
 }
 
-function seedMeetingWithSummary(
-	db: ReturnType<typeof createTestDb>,
+async function seedMeetingWithSummary(
+	db: Awaited<ReturnType<typeof createTestDb>>,
 	bodyId: number,
 	date: string,
 	opts: {
@@ -51,13 +51,14 @@ function seedMeetingWithSummary(
 		}>;
 	} = {},
 ) {
-	const meeting = db
+	const meeting = await db
 		.insert(schema.meetings)
 		.values({ bodyId, date, meetingType: "regular" })
 		.returning()
 		.get();
 
-	db.insert(schema.summaries)
+	await db
+		.insert(schema.summaries)
 		.values({
 			meetingId: meeting.id,
 			highlights: opts.highlights ?? ["Highlight one"],
@@ -67,7 +68,8 @@ function seedMeetingWithSummary(
 		.run();
 
 	for (const fd of opts.fiscalDecisions ?? []) {
-		db.insert(schema.fiscalDecisions)
+		await db
+			.insert(schema.fiscalDecisions)
 			.values({
 				meetingId: meeting.id,
 				title: fd.title,
@@ -86,14 +88,14 @@ function seedMeetingWithSummary(
 }
 
 describe("listRecentMeetingsQuery", () => {
-	it("returns meetings ordered by date descending", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-01-15");
-		seedMeetingWithSummary(db, body.id, "2026-03-23");
-		seedMeetingWithSummary(db, body.id, "2026-02-10");
+	it("returns meetings ordered by date descending", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-01-15");
+		await seedMeetingWithSummary(db, body.id, "2026-03-23");
+		await seedMeetingWithSummary(db, body.id, "2026-02-10");
 
-		const result = listRecentMeetingsQuery(db);
+		const result = await listRecentMeetingsQuery(db);
 
 		expect(result).toHaveLength(3);
 		expect(result[0].date).toBe("2026-03-23");
@@ -101,52 +103,53 @@ describe("listRecentMeetingsQuery", () => {
 		expect(result[2].date).toBe("2026-01-15");
 	});
 
-	it("filters by body slug when provided", () => {
-		const db = createTestDb();
-		const council = seedBody(db);
-		const school = seedBody(db, {
+	it("filters by body slug when provided", async () => {
+		const db = await createTestDb();
+		const council = await seedBody(db);
+		const school = await seedBody(db, {
 			name: "RBBSC School Board",
 			slug: "rbbsc-school-board",
 			type: "school",
 		});
-		seedMeetingWithSummary(db, council.id, "2026-03-23");
-		seedMeetingWithSummary(db, school.id, "2026-03-20");
-		seedMeetingWithSummary(db, council.id, "2026-02-10");
+		await seedMeetingWithSummary(db, council.id, "2026-03-23");
+		await seedMeetingWithSummary(db, school.id, "2026-03-20");
+		await seedMeetingWithSummary(db, council.id, "2026-02-10");
 
-		const result = listRecentMeetingsQuery(db, "rbbsc-school-board");
+		const result = await listRecentMeetingsQuery(db, "rbbsc-school-board");
 
 		expect(result).toHaveLength(1);
 		expect(result[0].bodySlug).toBe("rbbsc-school-board");
 	});
 
-	it("returns empty array for unknown body slug", () => {
-		const db = createTestDb();
-		seedBody(db);
+	it("returns empty array for unknown body slug", async () => {
+		const db = await createTestDb();
+		await seedBody(db);
 
-		const result = listRecentMeetingsQuery(db, "nonexistent-body");
+		const result = await listRecentMeetingsQuery(db, "nonexistent-body");
 
 		expect(result).toHaveLength(0);
 	});
 
-	it("skips meetings without summaries", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23");
+	it("skips meetings without summaries", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23");
 		// Insert a meeting with no summary
-		db.insert(schema.meetings)
+		await db
+			.insert(schema.meetings)
 			.values({ bodyId: body.id, date: "2026-04-01", meetingType: "regular" })
 			.run();
 
-		const result = listRecentMeetingsQuery(db);
+		const result = await listRecentMeetingsQuery(db);
 
 		expect(result).toHaveLength(1);
 		expect(result[0].date).toBe("2026-03-23");
 	});
 
-	it("includes fiscal decision count and total spending", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("includes fiscal decision count and total spending", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{
 					title: "Road Repairs",
@@ -163,43 +166,43 @@ describe("listRecentMeetingsQuery", () => {
 			],
 		});
 
-		const result = listRecentMeetingsQuery(db);
+		const result = await listRecentMeetingsQuery(db);
 
 		expect(result[0].fiscalDecisionCount).toBe(2);
 		expect(result[0].totalSpending).toBe(75000);
 	});
 
-	it("returns empty array when no meetings exist", () => {
-		const db = createTestDb();
+	it("returns empty array when no meetings exist", async () => {
+		const db = await createTestDb();
 
-		const result = listRecentMeetingsQuery(db);
+		const result = await listRecentMeetingsQuery(db);
 
 		expect(result).toHaveLength(0);
 	});
 });
 
 describe("aggregateFiscalByBodyQuery", () => {
-	it("sums spending by governing body", () => {
-		const db = createTestDb();
-		const council = seedBody(db);
-		const school = seedBody(db, {
+	it("sums spending by governing body", async () => {
+		const db = await createTestDb();
+		const council = await seedBody(db);
+		const school = await seedBody(db, {
 			name: "RBBSC School Board",
 			slug: "rbbsc-school-board",
 			type: "school",
 		});
-		seedMeetingWithSummary(db, council.id, "2026-03-23", {
+		await seedMeetingWithSummary(db, council.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "Roads", amount: 50000, originalAmount: "$50,000" },
 			],
 		});
-		seedMeetingWithSummary(db, school.id, "2026-03-20", {
+		await seedMeetingWithSummary(db, school.id, "2026-03-20", {
 			fiscalDecisions: [
 				{ title: "Books", amount: 10000, originalAmount: "$10,000" },
 				{ title: "Computers", amount: 20000, originalAmount: "$20,000" },
 			],
 		});
 
-		const result = aggregateFiscalByBodyQuery(db);
+		const result = await aggregateFiscalByBodyQuery(db);
 
 		expect(result).toHaveLength(2);
 		const councilRow = result.find(
@@ -212,20 +215,20 @@ describe("aggregateFiscalByBodyQuery", () => {
 		expect(schoolRow?.decisionCount).toBe(2);
 	});
 
-	it("returns empty array when no fiscal decisions exist", () => {
-		const db = createTestDb();
+	it("returns empty array when no fiscal decisions exist", async () => {
+		const db = await createTestDb();
 
-		const result = aggregateFiscalByBodyQuery(db);
+		const result = await aggregateFiscalByBodyQuery(db);
 
 		expect(result).toHaveLength(0);
 	});
 });
 
 describe("aggregateFiscalByCategoryQuery", () => {
-	it("sums spending by budget category", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("sums spending by budget category", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{
 					title: "Road Repairs",
@@ -248,7 +251,7 @@ describe("aggregateFiscalByCategoryQuery", () => {
 			],
 		});
 
-		const result = aggregateFiscalByCategoryQuery(db);
+		const result = await aggregateFiscalByCategoryQuery(db);
 
 		const infra = result.find((r) => r.budgetCategory === "infrastructure");
 		const parks = result.find((r) => r.budgetCategory === "parks");
@@ -258,38 +261,38 @@ describe("aggregateFiscalByCategoryQuery", () => {
 		expect(parks?.decisionCount).toBe(1);
 	});
 
-	it("labels null categories as Uncategorized", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("labels null categories as Uncategorized", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "Misc", amount: 5000, originalAmount: "$5,000" },
 			],
 		});
 
-		const result = aggregateFiscalByCategoryQuery(db);
+		const result = await aggregateFiscalByCategoryQuery(db);
 
 		expect(result[0].budgetCategory).toBe("Uncategorized");
 	});
 });
 
 describe("aggregateFiscalByTimePeriodQuery", () => {
-	it("sums spending by month ordered newest first", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-01-15", {
+	it("sums spending by month ordered newest first", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-01-15", {
 			fiscalDecisions: [
 				{ title: "Jan item", amount: 10000, originalAmount: "$10,000" },
 			],
 		});
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "Mar item 1", amount: 50000, originalAmount: "$50,000" },
 				{ title: "Mar item 2", amount: 20000, originalAmount: "$20,000" },
 			],
 		});
 
-		const result = aggregateFiscalByTimePeriodQuery(db);
+		const result = await aggregateFiscalByTimePeriodQuery(db);
 
 		expect(result).toHaveLength(2);
 		expect(result[0].period).toBe("2026-03");
@@ -300,10 +303,10 @@ describe("aggregateFiscalByTimePeriodQuery", () => {
 });
 
 describe("listNotableFiscalDecisionsQuery", () => {
-	it("returns decisions ordered by amount descending", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("returns decisions ordered by amount descending", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "Small", amount: 5000, originalAmount: "$5,000" },
 				{ title: "Big", amount: 100000, originalAmount: "$100,000" },
@@ -311,7 +314,7 @@ describe("listNotableFiscalDecisionsQuery", () => {
 			],
 		});
 
-		const result = listNotableFiscalDecisionsQuery(db);
+		const result = await listNotableFiscalDecisionsQuery(db);
 
 		expect(result[0].title).toBe("Big");
 		expect(result[0].amount).toBe(100000);
@@ -319,25 +322,25 @@ describe("listNotableFiscalDecisionsQuery", () => {
 		expect(result[2].title).toBe("Small");
 	});
 
-	it("includes body name and meeting date", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("includes body name and meeting date", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "Item", amount: 50000, originalAmount: "$50,000" },
 			],
 		});
 
-		const result = listNotableFiscalDecisionsQuery(db);
+		const result = await listNotableFiscalDecisionsQuery(db);
 
 		expect(result[0].bodyName).toBe("Ellettsville Town Council");
 		expect(result[0].date).toBe("2026-03-23");
 	});
 
-	it("respects limit parameter", () => {
-		const db = createTestDb();
-		const body = seedBody(db);
-		seedMeetingWithSummary(db, body.id, "2026-03-23", {
+	it("respects limit parameter", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithSummary(db, body.id, "2026-03-23", {
 			fiscalDecisions: [
 				{ title: "A", amount: 1000, originalAmount: "$1,000" },
 				{ title: "B", amount: 2000, originalAmount: "$2,000" },
@@ -345,23 +348,27 @@ describe("listNotableFiscalDecisionsQuery", () => {
 			],
 		});
 
-		const result = listNotableFiscalDecisionsQuery(db, 2);
+		const result = await listNotableFiscalDecisionsQuery(db, 2);
 
 		expect(result).toHaveLength(2);
 	});
 });
 
 describe("listGoverningBodiesQuery", () => {
-	it("returns all bodies ordered by name", () => {
-		const db = createTestDb();
-		seedBody(db, { name: "Zebra Board", slug: "zebra-board", type: "county" });
-		seedBody(db, {
+	it("returns all bodies ordered by name", async () => {
+		const db = await createTestDb();
+		await seedBody(db, {
+			name: "Zebra Board",
+			slug: "zebra-board",
+			type: "county",
+		});
+		await seedBody(db, {
 			name: "Alpha Council",
 			slug: "alpha-council",
 			type: "town",
 		});
 
-		const result = listGoverningBodiesQuery(db);
+		const result = await listGoverningBodiesQuery(db);
 
 		expect(result).toHaveLength(2);
 		expect(result[0].name).toBe("Alpha Council");

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, sql, sum } from "drizzle-orm";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
 import * as schema from "#/db/schema.ts";
 
 export type MeetingType = "regular" | "special" | "workshop";
@@ -69,14 +69,14 @@ export type GoverningBodySummary = {
  * Lists recent meetings with summary data for the landing page feed.
  * Optionally filtered by body slug. Returns newest first.
  */
-export function listRecentMeetingsQuery(
-	db: BetterSQLite3Database<typeof schema>,
+export async function listRecentMeetingsQuery(
+	db: LibSQLDatabase<typeof schema>,
 	bodySlug?: string,
 	limit = 20,
-): MeetingCardData[] {
+): Promise<MeetingCardData[]> {
 	let bodyFilter: number | undefined;
 	if (bodySlug) {
-		const body = db
+		const body = await db
 			.select()
 			.from(schema.governingBodies)
 			.where(eq(schema.governingBodies.slug, bodySlug))
@@ -85,7 +85,7 @@ export function listRecentMeetingsQuery(
 		bodyFilter = body.id;
 	}
 
-	const meetingRows = db
+	const meetingRows = await db
 		.select()
 		.from(schema.meetings)
 		.where(bodyFilter ? eq(schema.meetings.bodyId, bodyFilter) : undefined)
@@ -95,21 +95,21 @@ export function listRecentMeetingsQuery(
 
 	const result: MeetingCardData[] = [];
 	for (const m of meetingRows) {
-		const body = db
+		const body = await db
 			.select()
 			.from(schema.governingBodies)
 			.where(eq(schema.governingBodies.id, m.bodyId))
 			.get();
 		if (!body) continue;
 
-		const summary = db
+		const summary = await db
 			.select()
 			.from(schema.summaries)
 			.where(eq(schema.summaries.meetingId, m.id))
 			.get();
 		if (!summary) continue;
 
-		const fiscals = db
+		const fiscals = await db
 			.select()
 			.from(schema.fiscalDecisions)
 			.where(eq(schema.fiscalDecisions.meetingId, m.id))
@@ -124,7 +124,10 @@ export function listRecentMeetingsQuery(
 			highlights: summary.highlights as string[],
 			prose: summary.prose,
 			fiscalDecisionCount: fiscals.length,
-			totalSpending: fiscals.reduce((sum, f) => sum + f.amount, 0),
+			totalSpending: fiscals.reduce(
+				(total: number, f: { amount: number }) => total + f.amount,
+				0,
+			),
 		});
 	}
 
@@ -134,10 +137,10 @@ export function listRecentMeetingsQuery(
 /**
  * Aggregates fiscal decision totals by governing body.
  */
-export function aggregateFiscalByBodyQuery(
-	db: BetterSQLite3Database<typeof schema>,
-): FiscalByBody[] {
-	const rows = db
+export async function aggregateFiscalByBodyQuery(
+	db: LibSQLDatabase<typeof schema>,
+): Promise<FiscalByBody[]> {
+	const rows = await db
 		.select({
 			bodyName: schema.governingBodies.name,
 			bodySlug: schema.governingBodies.slug,
@@ -167,10 +170,10 @@ export function aggregateFiscalByBodyQuery(
 /**
  * Aggregates fiscal decision totals by budget category.
  */
-export function aggregateFiscalByCategoryQuery(
-	db: BetterSQLite3Database<typeof schema>,
-): FiscalByCategory[] {
-	const rows = db
+export async function aggregateFiscalByCategoryQuery(
+	db: LibSQLDatabase<typeof schema>,
+): Promise<FiscalByCategory[]> {
+	const rows = await db
 		.select({
 			budgetCategory: schema.fiscalDecisions.budgetCategory,
 			totalAmount: sum(schema.fiscalDecisions.amount),
@@ -190,10 +193,10 @@ export function aggregateFiscalByCategoryQuery(
 /**
  * Aggregates fiscal decision totals by month (YYYY-MM).
  */
-export function aggregateFiscalByTimePeriodQuery(
-	db: BetterSQLite3Database<typeof schema>,
-): FiscalByTimePeriod[] {
-	const rows = db
+export async function aggregateFiscalByTimePeriodQuery(
+	db: LibSQLDatabase<typeof schema>,
+): Promise<FiscalByTimePeriod[]> {
+	const rows = await db
 		.select({
 			period: sql<string>`substr(${schema.meetings.date}, 1, 7)`,
 			totalAmount: sum(schema.fiscalDecisions.amount),
@@ -218,11 +221,11 @@ export function aggregateFiscalByTimePeriodQuery(
 /**
  * Returns the most notable recent fiscal decisions (highest amounts).
  */
-export function listNotableFiscalDecisionsQuery(
-	db: BetterSQLite3Database<typeof schema>,
+export async function listNotableFiscalDecisionsQuery(
+	db: LibSQLDatabase<typeof schema>,
 	limit = 5,
-): NotableFiscalDecision[] {
-	const rows = db
+): Promise<NotableFiscalDecision[]> {
+	const rows = await db
 		.select({
 			title: schema.fiscalDecisions.title,
 			amount: schema.fiscalDecisions.amount,
@@ -257,10 +260,10 @@ export function listNotableFiscalDecisionsQuery(
 /**
  * Lists all governing bodies (for the filter dropdown).
  */
-export function listGoverningBodiesQuery(
-	db: BetterSQLite3Database<typeof schema>,
-): GoverningBodySummary[] {
-	return db
+export async function listGoverningBodiesQuery(
+	db: LibSQLDatabase<typeof schema>,
+): Promise<GoverningBodySummary[]> {
+	const rows = await db
 		.select({
 			name: schema.governingBodies.name,
 			slug: schema.governingBodies.slug,
@@ -268,8 +271,9 @@ export function listGoverningBodiesQuery(
 		})
 		.from(schema.governingBodies)
 		.orderBy(schema.governingBodies.name)
-		.all()
-		.map((r) => ({ ...r, type: r.type as BodyType }));
+		.all();
+
+	return rows.map((r) => ({ ...r, type: r.type as BodyType }));
 }
 
 export type FiscalDecisionDetail = {
@@ -319,12 +323,12 @@ export type MeetingDetail = {
  * Returns `null` at the first missing piece (no body, no meeting, no summary)
  * rather than returning partial data.
  */
-export function getMeetingByBodyAndDateQuery(
-	db: BetterSQLite3Database<typeof schema>,
+export async function getMeetingByBodyAndDateQuery(
+	db: LibSQLDatabase<typeof schema>,
 	slug: string,
 	date: string,
-): MeetingDetail | null {
-	const body = db
+): Promise<MeetingDetail | null> {
+	const body = await db
 		.select()
 		.from(schema.governingBodies)
 		.where(eq(schema.governingBodies.slug, slug))
@@ -332,7 +336,7 @@ export function getMeetingByBodyAndDateQuery(
 
 	if (!body) return null;
 
-	const meeting = db
+	const meeting = await db
 		.select()
 		.from(schema.meetings)
 		.where(
@@ -342,13 +346,13 @@ export function getMeetingByBodyAndDateQuery(
 
 	if (!meeting) return null;
 
-	const docs = db
+	const docs = await db
 		.select()
 		.from(schema.documents)
 		.where(eq(schema.documents.meetingId, meeting.id))
 		.all();
 
-	const summary = db
+	const summary = await db
 		.select()
 		.from(schema.summaries)
 		.where(eq(schema.summaries.meetingId, meeting.id))
@@ -356,13 +360,13 @@ export function getMeetingByBodyAndDateQuery(
 
 	if (!summary) return null;
 
-	const fiscals = db
+	const fiscals = await db
 		.select()
 		.from(schema.fiscalDecisions)
 		.where(eq(schema.fiscalDecisions.meetingId, meeting.id))
 		.all();
 
-	const discussions = db
+	const discussions = await db
 		.select()
 		.from(schema.budgetDiscussions)
 		.where(eq(schema.budgetDiscussions.meetingId, meeting.id))

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,4 +1,5 @@
-import { drizzle } from "drizzle-orm/better-sqlite3";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
 import { governingBodies } from "./schema.ts";
 
 /**
@@ -72,14 +73,22 @@ const GOVERNING_BODIES = [
 	},
 ] as const;
 
-const url = process.env.DATABASE_URL ?? "dev.db";
-const db = drizzle(url);
+const client = createClient({
+	url: process.env.TURSO_DATABASE_URL ?? "file:dev.db",
+	authToken: process.env.TURSO_AUTH_TOKEN,
+});
+const db = drizzle(client);
 
-for (const body of GOVERNING_BODIES) {
-	db.insert(governingBodies)
-		.values(body)
-		.onConflictDoNothing({ target: governingBodies.slug })
-		.run();
+async function seed() {
+	for (const body of GOVERNING_BODIES) {
+		await db
+			.insert(governingBodies)
+			.values(body)
+			.onConflictDoNothing({ target: governingBodies.slug })
+			.run();
+	}
+
+	console.log(`Seeded ${GOVERNING_BODIES.length} governing bodies.`);
 }
 
-console.log(`Seeded ${GOVERNING_BODIES.length} governing bodies.`);
+seed();

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -1,18 +1,39 @@
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { Effect } from "effect";
-import { describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import * as schema from "#/db/schema.ts";
 import { StorageService, StorageServiceLive } from "./StorageService.ts";
 
-function createTestDb() {
-	const sqlite = new Database(":memory:");
-	const db = drizzle(sqlite, { schema });
-	migrate(db, { migrationsFolder: "./drizzle" });
+const tmpFiles: string[] = [];
+
+afterAll(() => {
+	for (const f of tmpFiles) {
+		try {
+			fs.unlinkSync(f);
+		} catch {}
+	}
+});
+
+let dbCounter = 0;
+
+async function createTestDb() {
+	const tmpFile = path.join(
+		os.tmpdir(),
+		`civic-mirror-test-${process.pid}-${dbCounter++}.db`,
+	);
+	tmpFiles.push(tmpFile);
+	const client = createClient({ url: `file:${tmpFile}` });
+	const db = drizzle(client, { schema });
+	await migrate(db, { migrationsFolder: "./drizzle" });
 
 	// Seed one governing body for tests
-	db.insert(schema.governingBodies)
+	await db
+		.insert(schema.governingBodies)
 		.values({
 			name: "Ellettsville Town Council",
 			slug: "ellettsville-town-council",
@@ -69,7 +90,7 @@ const testMeetingInput = {
 describe("StorageService", () => {
 	describe("storeMeeting", () => {
 		it("rolls back all records when any part of the transaction fails", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const badInput = {
 				...testMeetingInput,
 				bodySlug: "nonexistent-body", // will fail lookup
@@ -83,16 +104,16 @@ describe("StorageService", () => {
 			await expect(Effect.runPromise(program)).rejects.toThrow();
 
 			// Nothing should have been written
-			const meetings = db.select().from(schema.meetings).all();
+			const meetings = await db.select().from(schema.meetings).all();
 			expect(meetings).toHaveLength(0);
-			const docs = db.select().from(schema.documents).all();
+			const docs = await db.select().from(schema.documents).all();
 			expect(docs).toHaveLength(0);
-			const summaries = db.select().from(schema.summaries).all();
+			const summaries = await db.select().from(schema.summaries).all();
 			expect(summaries).toHaveLength(0);
 		});
 
 		it("writes meeting, document, summary, fiscal decisions, and budget discussions atomically", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const program = Effect.gen(function* () {
 				const storage = yield* StorageService;
 				return yield* storage.storeMeeting(testMeetingInput);
@@ -105,23 +126,26 @@ describe("StorageService", () => {
 			expect(meeting.date).toBe("2026-03-23");
 
 			// Verify document was stored
-			const docs = db.select().from(schema.documents).all();
+			const docs = await db.select().from(schema.documents).all();
 			expect(docs).toHaveLength(1);
 			expect(docs[0].rawText).toContain("$50,000");
 
 			// Verify summary was stored
-			const summaries = db.select().from(schema.summaries).all();
+			const summaries = await db.select().from(schema.summaries).all();
 			expect(summaries).toHaveLength(1);
 			expect(summaries[0].prose).toContain("Sale Street");
 
 			// Verify fiscal decision was stored
-			const fiscals = db.select().from(schema.fiscalDecisions).all();
+			const fiscals = await db.select().from(schema.fiscalDecisions).all();
 			expect(fiscals).toHaveLength(1);
 			expect(fiscals[0].amount).toBe(50000);
 			expect(fiscals[0].title).toBe("Sale Street Road Repairs");
 
 			// Verify budget discussion was stored
-			const discussions = db.select().from(schema.budgetDiscussions).all();
+			const discussions = await db
+				.select()
+				.from(schema.budgetDiscussions)
+				.all();
 			expect(discussions).toHaveLength(1);
 			expect(discussions[0].topic).toBe("Park pavilion renovation");
 		});
@@ -129,7 +153,7 @@ describe("StorageService", () => {
 
 	describe("getMeetingByBodyAndDate", () => {
 		it("retrieves a full meeting with documents, summary, fiscal decisions, and discussions", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const layer = StorageServiceLive(db);
 
 			// First store a meeting
@@ -163,7 +187,7 @@ describe("StorageService", () => {
 		});
 
 		it("returns null when no meeting exists", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const result = await Effect.runPromise(
 				Effect.gen(function* () {
 					const storage = yield* StorageService;
@@ -180,7 +204,7 @@ describe("StorageService", () => {
 
 	describe("storeTranscript", () => {
 		it("stores a transcript linked to a meeting", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const layer = StorageServiceLive(db);
 
 			// First store a meeting
@@ -213,7 +237,7 @@ describe("StorageService", () => {
 			);
 
 			// Verify transcript was stored
-			const transcripts = db.select().from(schema.transcripts).all();
+			const transcripts = await db.select().from(schema.transcripts).all();
 			expect(transcripts).toHaveLength(1);
 			expect(transcripts[0].source).toBe("captions");
 			expect(transcripts[0].rawText).toContain("Motion to approve");
@@ -224,7 +248,7 @@ describe("StorageService", () => {
 		});
 
 		it("stores a whisper transcript with segments", async () => {
-			const db = createTestDb();
+			const db = await createTestDb();
 			const layer = StorageServiceLive(db);
 
 			const meeting = await Effect.runPromise(
@@ -252,7 +276,7 @@ describe("StorageService", () => {
 				}).pipe(Effect.provide(layer)),
 			);
 
-			const transcripts = db.select().from(schema.transcripts).all();
+			const transcripts = await db.select().from(schema.transcripts).all();
 			expect(transcripts).toHaveLength(1);
 			expect(transcripts[0].source).toBe("whisper");
 			expect(transcripts[0].segments).toEqual([

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -1,5 +1,5 @@
 import { eq } from "drizzle-orm";
-import type { BetterSQLite3Database } from "drizzle-orm/better-sqlite3";
+import type { LibSQLDatabase } from "drizzle-orm/libsql";
 import { Context, Effect, Layer } from "effect";
 import type { MeetingDetail } from "#/db/queries.ts";
 import { getMeetingByBodyAndDateQuery } from "#/db/queries.ts";
@@ -106,16 +106,16 @@ class StorageService extends Context.Tag("StorageService")<
  *     (e.g. opening a DB connection that might be refused).
  *
  * Here we use `Layer.succeed` because the `db` handle is already open (passed in
- * as a closure parameter). Each method wraps its work in `Effect.try`, which
- * catches synchronous exceptions and maps them to typed `DatabaseError` values.
+ * as a closure parameter). Each method wraps its work in `Effect.tryPromise`, which
+ * catches async exceptions and maps them to typed `DatabaseError` values.
  *
  * @param db - An open Drizzle database handle. In tests this is `:memory:` SQLite;
- *             in production it's the file-backed database.
+ *             in production it's the Turso-backed database.
  */
-function StorageServiceLive(db: BetterSQLite3Database<typeof schema>) {
+function StorageServiceLive(db: LibSQLDatabase<typeof schema>) {
 	return Layer.succeed(StorageService, {
 		storeMeeting: (input) =>
-			Effect.try({
+			Effect.tryPromise({
 				try: () => storeMeetingTransaction(db, input),
 				catch: (error) =>
 					new DatabaseError({
@@ -124,7 +124,7 @@ function StorageServiceLive(db: BetterSQLite3Database<typeof schema>) {
 					}),
 			}),
 		getMeetingByBodyAndDate: (slug, date) =>
-			Effect.try({
+			Effect.tryPromise({
 				try: () => getMeetingByBodyAndDateQuery(db, slug, date),
 				catch: (error) =>
 					new DatabaseError({
@@ -133,9 +133,10 @@ function StorageServiceLive(db: BetterSQLite3Database<typeof schema>) {
 					}),
 			}),
 		storeTranscript: (input) =>
-			Effect.try({
-				try: () => {
-					db.insert(schema.transcripts)
+			Effect.tryPromise({
+				try: async () => {
+					await db
+						.insert(schema.transcripts)
 						.values({
 							meetingId: input.meetingId,
 							source: input.source,
@@ -155,21 +156,20 @@ function StorageServiceLive(db: BetterSQLite3Database<typeof schema>) {
 }
 
 /**
- * Effect teaching note: We use a plain synchronous function for the transaction
- * body because better-sqlite3 transactions are synchronous. Effect.tryPromise
- * wraps this at the boundary, converting thrown exceptions into typed
- * DatabaseError values that propagate through the Effect error channel.
+ * Effect teaching note: The transaction body is now async because libsql
+ * (Turso) uses an async driver. Drizzle's transaction API handles this
+ * transparently — the callback receives an async transaction handle.
  *
  * Key invariant: A meeting must never exist with a summary but without its
  * source text. The transaction ensures all-or-nothing writes.
  */
-function storeMeetingTransaction(
-	db: BetterSQLite3Database<typeof schema>,
+async function storeMeetingTransaction(
+	db: LibSQLDatabase<typeof schema>,
 	input: MeetingInput,
-): Meeting {
-	return db.transaction((tx) => {
+): Promise<Meeting> {
+	return await db.transaction(async (tx) => {
 		// Resolve governing body by slug
-		const body = tx
+		const body = await tx
 			.select()
 			.from(schema.governingBodies)
 			.where(eq(schema.governingBodies.slug, input.bodySlug))
@@ -180,7 +180,7 @@ function storeMeetingTransaction(
 		}
 
 		// Insert meeting
-		const meeting = tx
+		const meeting = await tx
 			.insert(schema.meetings)
 			.values({
 				bodyId: body.id,
@@ -192,7 +192,8 @@ function storeMeetingTransaction(
 
 		// Insert documents
 		for (const doc of input.documents) {
-			tx.insert(schema.documents)
+			await tx
+				.insert(schema.documents)
 				.values({
 					meetingId: meeting.id,
 					sourceUrl: doc.sourceUrl,
@@ -203,7 +204,8 @@ function storeMeetingTransaction(
 		}
 
 		// Insert summary
-		tx.insert(schema.summaries)
+		await tx
+			.insert(schema.summaries)
 			.values({
 				meetingId: meeting.id,
 				highlights: input.summary.highlights,
@@ -214,7 +216,8 @@ function storeMeetingTransaction(
 
 		// Insert fiscal decisions
 		for (const fd of input.fiscalDecisions) {
-			tx.insert(schema.fiscalDecisions)
+			await tx
+				.insert(schema.fiscalDecisions)
 				.values({
 					meetingId: meeting.id,
 					title: fd.title,
@@ -236,7 +239,8 @@ function storeMeetingTransaction(
 		// Insert budget discussions
 		if (input.budgetDiscussions) {
 			for (const bd of input.budgetDiscussions) {
-				tx.insert(schema.budgetDiscussions)
+				await tx
+					.insert(schema.budgetDiscussions)
 					.values({
 						meetingId: meeting.id,
 						topic: bd.topic,

--- a/src/server/meetings.test.ts
+++ b/src/server/meetings.test.ts
@@ -1,6 +1,6 @@
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import { describe, expect, it } from "vitest";
 import {
 	aggregateFiscalByBodyQuery,
@@ -19,15 +19,15 @@ import * as schema from "#/db/schema.ts";
  * tested via TanStack Start's integration layer.
  */
 
-function createTestDb() {
-	const sqlite = new Database(":memory:");
-	const db = drizzle(sqlite, { schema });
-	migrate(db, { migrationsFolder: "./drizzle" });
+async function createTestDb() {
+	const client = createClient({ url: ":memory:" });
+	const db = drizzle(client, { schema });
+	await migrate(db, { migrationsFolder: "./drizzle" });
 	return db;
 }
 
-function seedFullScenario(db: ReturnType<typeof createTestDb>) {
-	const council = db
+async function seedFullScenario(db: Awaited<ReturnType<typeof createTestDb>>) {
+	const council = await db
 		.insert(schema.governingBodies)
 		.values({
 			name: "Ellettsville Town Council",
@@ -37,7 +37,7 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 		.returning()
 		.get();
 
-	const school = db
+	const school = await db
 		.insert(schema.governingBodies)
 		.values({
 			name: "RBBSC School Board",
@@ -48,13 +48,14 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 		.get();
 
 	// Council meeting with fiscal decisions
-	const m1 = db
+	const m1 = await db
 		.insert(schema.meetings)
 		.values({ bodyId: council.id, date: "2026-03-23", meetingType: "regular" })
 		.returning()
 		.get();
 
-	db.insert(schema.summaries)
+	await db
+		.insert(schema.summaries)
 		.values({
 			meetingId: m1.id,
 			highlights: ["Approved road repairs", "Discussed park budget"],
@@ -63,7 +64,8 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 		})
 		.run();
 
-	db.insert(schema.fiscalDecisions)
+	await db
+		.insert(schema.fiscalDecisions)
 		.values({
 			meetingId: m1.id,
 			title: "Sale Street Road Repairs",
@@ -78,13 +80,14 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 		.run();
 
 	// School board meeting
-	const m2 = db
+	const m2 = await db
 		.insert(schema.meetings)
 		.values({ bodyId: school.id, date: "2026-03-20", meetingType: "regular" })
 		.returning()
 		.get();
 
-	db.insert(schema.summaries)
+	await db
+		.insert(schema.summaries)
 		.values({
 			meetingId: m2.id,
 			highlights: ["New textbook budget approved"],
@@ -93,7 +96,8 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 		})
 		.run();
 
-	db.insert(schema.fiscalDecisions)
+	await db
+		.insert(schema.fiscalDecisions)
 		.values({
 			meetingId: m2.id,
 			title: "Textbook Purchase",
@@ -111,11 +115,11 @@ function seedFullScenario(db: ReturnType<typeof createTestDb>) {
 }
 
 describe("server function integration", () => {
-	it("listRecentMeetings returns all meetings with fiscal rollups", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("listRecentMeetings returns all meetings with fiscal rollups", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = listRecentMeetingsQuery(db);
+		const result = await listRecentMeetingsQuery(db);
 
 		expect(result).toHaveLength(2);
 		expect(result[0].date).toBe("2026-03-23");
@@ -124,21 +128,21 @@ describe("server function integration", () => {
 		expect(result[1].totalSpending).toBe(15000);
 	});
 
-	it("listRecentMeetings filters by body slug", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("listRecentMeetings filters by body slug", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = listRecentMeetingsQuery(db, "rbbsc-school-board");
+		const result = await listRecentMeetingsQuery(db, "rbbsc-school-board");
 
 		expect(result).toHaveLength(1);
 		expect(result[0].bodyName).toBe("RBBSC School Board");
 	});
 
-	it("aggregateFiscalByBody returns correct totals per body", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("aggregateFiscalByBody returns correct totals per body", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = aggregateFiscalByBodyQuery(db);
+		const result = await aggregateFiscalByBodyQuery(db);
 
 		expect(result).toHaveLength(2);
 		const council = result.find(
@@ -147,11 +151,11 @@ describe("server function integration", () => {
 		expect(council?.totalAmount).toBe(50000);
 	});
 
-	it("aggregateFiscalByCategory returns correct totals per category", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("aggregateFiscalByCategory returns correct totals per category", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = aggregateFiscalByCategoryQuery(db);
+		const result = await aggregateFiscalByCategoryQuery(db);
 
 		const infra = result.find((r) => r.budgetCategory === "infrastructure");
 		const edu = result.find((r) => r.budgetCategory === "education");
@@ -159,33 +163,33 @@ describe("server function integration", () => {
 		expect(edu?.totalAmount).toBe(15000);
 	});
 
-	it("aggregateFiscalByTimePeriod groups by month", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("aggregateFiscalByTimePeriod groups by month", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = aggregateFiscalByTimePeriodQuery(db);
+		const result = await aggregateFiscalByTimePeriodQuery(db);
 
 		expect(result).toHaveLength(1); // both in 2026-03
 		expect(result[0].period).toBe("2026-03");
 		expect(result[0].totalAmount).toBe(65000);
 	});
 
-	it("listNotableFiscalDecisions returns highest amounts first", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("listNotableFiscalDecisions returns highest amounts first", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = listNotableFiscalDecisionsQuery(db);
+		const result = await listNotableFiscalDecisionsQuery(db);
 
 		expect(result[0].title).toBe("Sale Street Road Repairs");
 		expect(result[0].amount).toBe(50000);
 		expect(result[1].title).toBe("Textbook Purchase");
 	});
 
-	it("listGoverningBodies returns all bodies alphabetically", () => {
-		const db = createTestDb();
-		seedFullScenario(db);
+	it("listGoverningBodies returns all bodies alphabetically", async () => {
+		const db = await createTestDb();
+		await seedFullScenario(db);
 
-		const result = listGoverningBodiesQuery(db);
+		const result = await listGoverningBodiesQuery(db);
 
 		expect(result).toHaveLength(2);
 		expect(result[0].name).toBe("Ellettsville Town Council");

--- a/src/server/meetings.ts
+++ b/src/server/meetings.ts
@@ -15,7 +15,7 @@ export const getMeetingByBodyAndDate = createServerFn({
 })
 	.inputValidator((input: { bodySlug: string; date: string }) => input)
 	.handler(async ({ data }) => {
-		return getMeetingByBodyAndDateQuery(db, data.bodySlug, data.date);
+		return await getMeetingByBodyAndDateQuery(db, data.bodySlug, data.date);
 	});
 
 export const listRecentMeetings = createServerFn({
@@ -23,25 +23,25 @@ export const listRecentMeetings = createServerFn({
 })
 	.inputValidator((input: { bodySlug?: string; limit?: number }) => input)
 	.handler(async ({ data }) => {
-		return listRecentMeetingsQuery(db, data.bodySlug, data.limit);
+		return await listRecentMeetingsQuery(db, data.bodySlug, data.limit);
 	});
 
 export const aggregateFiscalByBody = createServerFn({
 	method: "GET",
 }).handler(async () => {
-	return aggregateFiscalByBodyQuery(db);
+	return await aggregateFiscalByBodyQuery(db);
 });
 
 export const aggregateFiscalByCategory = createServerFn({
 	method: "GET",
 }).handler(async () => {
-	return aggregateFiscalByCategoryQuery(db);
+	return await aggregateFiscalByCategoryQuery(db);
 });
 
 export const aggregateFiscalByTimePeriod = createServerFn({
 	method: "GET",
 }).handler(async () => {
-	return aggregateFiscalByTimePeriodQuery(db);
+	return await aggregateFiscalByTimePeriodQuery(db);
 });
 
 export const listNotableFiscalDecisions = createServerFn({
@@ -49,11 +49,11 @@ export const listNotableFiscalDecisions = createServerFn({
 })
 	.inputValidator((input: { limit?: number }) => input)
 	.handler(async ({ data }) => {
-		return listNotableFiscalDecisionsQuery(db, data.limit);
+		return await listNotableFiscalDecisionsQuery(db, data.limit);
 	});
 
 export const listGoverningBodies = createServerFn({
 	method: "GET",
 }).handler(async () => {
-	return listGoverningBodiesQuery(db);
+	return await listGoverningBodiesQuery(db);
 });


### PR DESCRIPTION
## Summary

Swap the database driver from synchronous `better-sqlite3` to async `@libsql/client` across the entire codebase. This enables free-tier deployment via Vercel + Turso ($0/month) instead of Railway ($5-7/month), while keeping all existing query logic and test coverage intact.

## PRD

Closes #14

## Slices

- [x] #15 — Drizzle driver swap: better-sqlite3 → @libsql/client
- [ ] #16 — Vercel deployment + environment config
- [ ] #17 — GitHub Actions weekly pipeline workflow
- [ ] #18 — QA: Vercel + Turso deployment verification

## Key Decisions

- **StorageService tests use file-based temp DBs** instead of `:memory:` — `@libsql/client` with `:memory:` silently loses state in vitest's worker context. Other test files work fine with `:memory:`. Temp files are cleaned up in `afterAll`.
- **`@effect/sql-sqlite-node` removed** — was in `package.json` but never imported anywhere. Confirmed unused.
- **`better-sqlite3` fully removed** — not kept as a dev dependency since tests now use the same `@libsql/client` driver as production (no driver divergence).

## Test plan

- [x] All 67 tests pass with `@libsql/client` driver
- [x] TypeScript compiles clean
- [x] Biome lint passes on `src/`