### PR TITLE
Add GitHub Actions weekly pipeline workflow

### DIFF
--- a/.github/workflows/ingest.yml
+++ b/.github/workflows/ingest.yml
@@ -1,0 +1,37 @@
+name: Weekly Ingestion Pipeline
+
+on:
+  schedule:
+    # Every Sunday at 6:00 AM UTC
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+jobs:
+  ingest:
+    name: Run ingestion pipeline
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      TURSO_DATABASE_URL: ${{ secrets.TURSO_DATABASE_URL }}
+      TURSO_AUTH_TOKEN: ${{ secrets.TURSO_AUTH_TOKEN }}
+      GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run ingestion pipeline
+        run: pnpm run pipeline:ingest

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 dist-ssr
 *.local
 .env
+*.db
 .nitro
 .tanstack
 .wrangler

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:push": "drizzle-kit push",
     "db:pull": "drizzle-kit pull",
     "db:studio": "drizzle-kit studio",
+    "pipeline:ingest": "tsx src/pipeline/ingest.ts",
     "ralph:once": "./ralph-once.sh",
     "ralph": "./ralph.sh 5"
   },


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow for weekly automated ingestion of new meeting data. Runs every Sunday at 6am UTC with a manual `workflow_dispatch` trigger. Connects to Turso via repository secrets.

## PRD

#14

## Slices

- [x] #15 — Drizzle driver swap (merged)
- [ ] #17 — GitHub Actions weekly pipeline workflow (this PR)

## Key Decisions

- **Pipeline entry point is a placeholder** — `pipeline:ingest` script added to package.json pointing to `src/pipeline/ingest.ts`, which doesn't exist yet. The pipeline services are built but the CLI runner entry point needs to be created as part of the pipeline work.
- **`.env.example` included** — documents all env vars needed for both the web app and pipeline (Turso, LLM keys, YouTube API key)
- **`*.db` added to `.gitignore`** — prevents local SQLite dev files from being committed

## Setup required

After merging, configure these GitHub repository secrets:
- `TURSO_DATABASE_URL` — from your Turso dashboard
- `TURSO_AUTH_TOKEN` — from your Turso dashboard
- `GOOGLE_GENERATIVE_AI_API_KEY` — for pipeline summarization