### PR TITLE
pipeline: orchestrator, CLI, alerts, and retry policies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,27 @@ MOONSHOT_API_KEY=
 # ── YouTube Data API ────────────────────────────────────────
 # v3 API key from Google Cloud Console (used by YouTubeScraper)
 YOUTUBE_API_KEY=
+
+# ── Alerts / Resend ─────────────────────────────────────────
+# Operator alert email via Resend (https://resend.com).
+# If RESEND_API_KEY is unset, AlertService silently falls back
+# to a console.log stub — set it in production or your ops
+# inbox will never receive pipeline failure notifications.
+RESEND_API_KEY=
+# From address must be a verified sender on your Resend account.
+RESEND_FROM=civic-mirror@alerts.example.com
+# Recipient address for pipeline error alerts and zero-results anomalies.
+ALERT_EMAIL=ops@example.com
+
+# ── Pipeline overrides (optional) ───────────────────────────
+# Override the Gemini model used by SummarizationService.
+# Defaults to gemini-2.5-flash if unset.
+GEMINI_MODEL=
+
+# Override the eGov document-center base URL (for staging/mocks).
+# Defaults to https://ellettsville.in.us/egov/apps/document/center.egov
+EGOV_BASE_URL=
+
+# Override the Finalsite base URL (for staging/mocks).
+# Defaults to https://www.rbbschools.net
+FINALSITE_BASE_URL=

--- a/docs/solutions/patterns/boundary-map-drift-between-slices-2026-04-10.md
+++ b/docs/solutions/patterns/boundary-map-drift-between-slices-2026-04-10.md
@@ -1,0 +1,97 @@
+---
+date: 2026-04-10
+category: patterns
+problem_type: cross-slice contract verification
+components: [pipeline, prd-to-issues, execute, pre-merge]
+technologies: [effect, github-issues]
+severity: high
+volatility: stable
+---
+
+# Boundary map drift between slices
+
+## Problem
+
+A closed slice can claim Produces it didn't actually ship at the declared path or shape. Downstream slices consume those claims months later and either block or silently expand scope to fill the gap. Nothing in the delivery pipeline verifies that a slice's declared Produces match its actual exports before the slice is marked closed.
+
+## Context
+
+Issue #8 (Pipeline Orchestrator + CLI + Alerts) listed these under Consumes:
+
+- `From #2: src/pipeline/services/ScraperService.ts → EgovScraper Layer`
+- `From #2: src/pipeline/services/SummarizationService.ts → SummarizationService Layer`
+
+Both claims were wrong. Slice #2 actually delivered:
+
+- `ScraperService.ts` — only the pure function `parseEgovListingHtml`, no `Context.Tag`, no Effect import at all
+- `SummarizationService.ts` — only the pure helper `verifyAmounts`, same story
+
+Nothing in the slice-close gate caught this, because #2's tests all passed and its PR merged cleanly. The gap wasn't discovered until `/execute` on #8 started trying to compose services that didn't exist. The slice had to absorb two unplanned layer-wrapping commits (`70940d8 wrap EgovScraper`, `c3b0254 wrap SummarizationService`) before it could do its actual job.
+
+## Symptoms
+
+- Downstream slice's first implementation commit is "wait, the thing I'm consuming doesn't exist in the shape I expected"
+- Downstream slice's PR description includes a "scope expansion" note flagging that part of an upstream slice's boundary map wasn't actually delivered
+- Grep for an imported symbol from the Consumes list returns zero hits in the upstream slice's actual code
+- The upstream slice's PR merged weeks or months ago, so fixing the boundary map retroactively feels pointless
+
+## Root Cause
+
+There is no pipeline step that verifies a closed slice's Produces section against its actual exports. The chain is:
+
+1. `/prd-to-issues` generates boundary maps from the PRD shape — the Produces list is an *intent*, not a verified contract
+2. `/execute` ships code that usually matches the intent but occasionally doesn't (developer scopes down, ships a helper, plans to wrap it later, forgets)
+3. `/pre-merge` reviews the diff against the boundary map but doesn't statically verify that every declared Produces symbol actually exists at the declared path
+4. Slice merges, boundary map is now stale but unmarked
+5. Months later, downstream slice trusts the stale map
+
+The failure is a **missing feedback loop**: slice-close doesn't close the loop back to boundary-map correctness, so stale claims persist silently.
+
+## Learning Level
+
+- **Level:** Structure
+- **Feedback loop or delay:** The delay between "slice #2 closes" and "slice #8 starts consuming #2's claims" is weeks or months. By the time the gap is discovered, the original author has moved on, the reasons for scoping down are forgotten, and retrofitting the upstream slice's boundary map is awkward. The missing feedback loop means every closed slice accrues a small probability of silent contract drift, and the cost compounds across the PRD.
+
+## Solution
+
+Two interventions — both cheap, both orthogonal, and each catches a different failure mode:
+
+**1. Add a boundary-map verification step to `/pre-merge`.** For every `Produces` entry in the PR's slice issue, check that the declared symbol exists at the declared path. A ripgrep + tsc pair can verify `from "#/pipeline/services/ScraperService" { EgovScraper, EgovScraperLive }` actually resolves in the merged tree. Flag mismatches as a pre-merge Concern (Dimension 4). This catches the failure at source, before the slice closes.
+
+**2. Add a `Consumes` verification step to `/execute` Step 0.** Before implementation starts, for every `Consumes` entry in the current slice's boundary map, check that the symbol exists at the declared path. If it doesn't, stop and flag: "slice X's boundary map claims Y but it doesn't exist; need targeted scope-expansion or an upstream fix before proceeding." This catches the failure at the downstream end, even if the upstream slice already merged with a stale boundary map.
+
+Either step alone would have caught the #2 → #8 drift. Having both creates redundant coverage — one for new drift, one for legacy drift.
+
+Separately: when a downstream slice does discover drift (like PR #23 did), file a post-hoc correction issue or comment on the upstream slice to update its Produces list. Never silently absorb the gap without leaving a trail — the next slice to consume from that upstream will hit the same problem.
+
+## Prevention
+
+**Code-level:**
+- `tsc` already catches most symbol-drift at build time — the reason it didn't help here is that `/execute` on #8 wasn't *compiling against* #2's code until implementation started. A lightweight "does this import resolve" check could run at `/execute` Step 0, before writing a single line.
+- Consider a `scripts/verify-boundary-map.ts` utility that takes a GitHub issue number, parses its Produces/Consumes sections, and checks each symbol exists at the declared path. Invoke from both `/pre-merge` and `/execute` Step 0.
+
+**Process-level:**
+- `/pre-merge` Dimension 4 should statically verify Produces, not just eyeball the diff against the map.
+- `/execute` Step 0 should verify Consumes before the "Assumptions validation gate." The current Step 0 asks about external services and package versions, but not about internal cross-slice contracts.
+- When a slice expands scope to fill a boundary-map gap (as #8 did), the PR description should explicitly link to the upstream slice's Produces section and note which claim was wrong. This creates the breadcrumb that the next maintainer needs.
+
+## Planning / Calibration Notes
+
+- **What widened the work:** two unplanned commits (`70940d8`, `c3b0254`) to wrap pure helpers as Effect Layers. Roughly 20% of the slice's total commits were spent filling a gap that should have been closed months earlier.
+- **What tightened the work:** `research.md` specified the Effect Layer shape precisely, so once the gap was identified, the remediation was mechanical.
+- **Future planning adjustment:** `/execute` Step 0 should treat the Consumes list as a gate, not a reference. If any Consumes symbol doesn't exist at the declared path, stop and escalate before writing code.
+
+## Actuals Worth Reusing
+
+- **Comparable future work:** any multi-slice PRD where downstream slices consume Effect Layers, API contracts, or database schemas produced by earlier slices.
+- **Reusable baseline:** expect ~15–20% scope overhead on a downstream slice when upstream contracts haven't been verified. Budget for it or verify upfront.
+
+## Related
+
+- PR #23 — https://github.com/chrislacey89/civic-mirror/pull/23
+- Slice #8 (this one, the consumer)
+- Slice #2 (upstream, the source of the drift)
+
+## Shelf Life
+
+When `/execute` Step 0 and `/pre-merge` Dimension 4 both perform static boundary-map verification against actual exports, this lesson becomes a historical footnote. Until then: evergreen for this project.

--- a/docs/solutions/patterns/placeholder-stubs-in-production-paths-2026-04-10.md
+++ b/docs/solutions/patterns/placeholder-stubs-in-production-paths-2026-04-10.md
@@ -1,0 +1,139 @@
+---
+date: 2026-04-10
+category: patterns
+problem_type: silent production degradation
+components: [pipeline, cli]
+technologies: [effect]
+severity: high
+volatility: evergreen
+---
+
+# Placeholder stubs wired into production default paths
+
+## Problem
+
+When a slice ships with a placeholder function that a follow-up slice will replace, wiring that placeholder as the *default* for its production code path creates a silent footgun: the production code path succeeds loudly, but the output is garbage. Dry-run verification can't catch it, because dry-run usually short-circuits before the code path that would reveal the problem.
+
+## Context
+
+Issue #8 delivered an orchestrator + CLI that composes a 5-stage pipeline: scrape → extract → summarize → store. The "extract" stage is PDF text extraction, which was explicitly scoped out — a follow-up slice will wire a real extractor (pdf-parse / unpdf). In the meantime, `composition.ts` wires `placeholderPdfExtract` into the CLI:
+
+```typescript
+async function placeholderPdfExtract(bytes: ArrayBuffer): Promise<string> {
+	return `[PDF placeholder — ${bytes.byteLength} bytes; install a PDF extractor to see real text]`;
+}
+```
+
+and then, unconditionally, in the CLI's runtime construction:
+
+```typescript
+yield* runPipeline({
+	bodies,
+	crawlDelayMs: skipCrawlDelay ? 0 : 300_000,
+	extractPdfText: placeholderPdfExtract,  // <-- always used, dry-run or not
+	dryRun,
+}).pipe(Effect.provide(layers));
+```
+
+Verification happened via `pnpm pipeline:dry --body ellettsville-town-council`, which reported `processed=25 errors=0`. Green. The dry-run short-circuits before `storeMeeting`, so the placeholder text never hits the DB — but it *does* flow through real Gemini API calls, and the `errors=0` count measures "did the pipeline reach the end of the loop," not "did the output make sense."
+
+A non-dry `pnpm pipeline run` would have:
+
+1. Scraped 25 eGov listings (real)
+2. Downloaded 25 real PDF bytes
+3. Called `placeholderPdfExtract` 25 times, getting back `"[PDF placeholder — 73241 bytes; install a PDF extractor to see real text]"`
+4. Summarized each placeholder via real Gemini ($$)
+5. Gemini would return empty `fiscalDecisions: []` because no `$` amounts appear in the placeholder
+6. `verifyAmounts` would run against an empty array (no-op)
+7. `storeMeeting` would persist 25 meetings with empty summaries and zero fiscal decisions
+8. CLI would print `[pipeline] done: processed=25 errors=0` — indistinguishable from a successful real run
+
+## Symptoms
+
+- Dry-run succeeds with a non-zero `processed` count
+- Non-dry run would succeed with the same `processed` count
+- Output data is silently garbage: empty `fiscalDecisions`, meaningless `prose`, `rawText` that is just a placeholder marker
+- Nothing logs "warning: using placeholder extractor"
+- The CLI reports the same "done" message whether the pipeline extracted real content or placeholder strings
+
+## Root Cause
+
+"Placeholder for follow-up slice" is not a safe default value when the caller is a trust boundary. The CLI consumer doesn't know `extractPdfText` is a stub — its name says "extract PDF text" and its type signature says "ArrayBuffer in, text out." The function lies about its semantics.
+
+More generally: **dry-run success ≠ real-run success**. Dry-run checks that the pipeline *reaches* storage; it does not check that the data *arriving at* storage is correct. Any problem upstream of storage that produces structurally-valid garbage is invisible to dry-run.
+
+## Learning Level
+
+- **Level:** Pattern
+- **Feedback loop or delay:** The feedback loop here is from "production run" to "operator notices the data is garbage." If the operator trusts the `done: processed=25 errors=0` signal, the delay could be days or weeks before a human opens the frontend and sees empty summaries — at which point 25 meetings have been persisted with garbage data, real Gemini API credits have been spent, and the fix requires both a PDF extractor AND a data backfill to correct the corrupted rows.
+
+## Solution
+
+Three options, in increasing order of assertiveness:
+
+**1. Fail-fast placeholder.** Change `placeholderPdfExtract` to throw unless an explicit `ALLOW_PLACEHOLDER_PDF=1` env var is set:
+
+```typescript
+async function placeholderPdfExtract(bytes: ArrayBuffer): Promise<string> {
+	if (!process.env.ALLOW_PLACEHOLDER_PDF) {
+		throw new Error(
+			"placeholderPdfExtract called in a non-opt-in context. " +
+				"Wire a real PDF extractor (pdf-parse/unpdf) in composition.ts, " +
+				"or set ALLOW_PLACEHOLDER_PDF=1 to explicitly accept garbage output.",
+		);
+	}
+	return `[PDF placeholder — ${bytes.byteLength} bytes]`;
+}
+```
+
+This guarantees that a non-dry run using the default CLI path either runs with a real extractor or crashes loudly. Dry-run with the env var set still works for smoke testing.
+
+**2. Dry-run-only binding.** Don't wire the placeholder at all in the production layer; only wire it when `--dry-run` is passed:
+
+```typescript
+extractPdfText: dryRun ? placeholderPdfExtract : requireRealExtractor(),
+```
+
+Where `requireRealExtractor` throws at layer-construction time if no real extractor is wired. This forces the follow-up slice to actually land before any non-dry run is possible.
+
+**3. Remove the placeholder entirely, gate the slice on the follow-up.** The strictest option: don't merge the orchestrator slice until a real PDF extractor exists. Makes this slice larger but eliminates the silent-degradation window completely.
+
+For issue #8 the pragmatic choice is option 1, because the follow-up slice is genuinely small and the operator is the same human as the developer. For a larger team, option 2 or 3 is safer.
+
+## Prevention
+
+**Code-level:**
+
+- Any function named or documented as a placeholder/stub/TODO should fail-fast unless explicitly opted into. Don't trust that future you will remember to replace it before running in production.
+- Dry-run implementations should never be the default runtime binding for a function the production code path also calls. Either both paths use the same function or they're bound by different code paths — never "this stub happens to work in both contexts because one of the contexts doesn't look at the output."
+- Consider a `Stub<T>` phantom type or runtime marker so any code that accepts `extractPdfText: (bytes) => Promise<string>` can refuse to accept a `Stub`-marked function outside dry-run mode.
+
+**Process-level:**
+
+- `/execute` Step 4 verification ladder already has a Tier 2.5 "Runtime Startup Verification." Add a Tier 2.6 "Non-dry path simulation" for CLI tools: without actually running non-dry, statically confirm that the default runtime bindings either (a) match the names they claim or (b) throw if called in the non-dry path. For Effect pipelines specifically: confirm that every `extractX` / `storeX` / `sendX` function in the default `buildProductionLayers` output isn't trivially a stub.
+- `/pre-merge` Dimension 7 (Runtime Initialization) should explicitly flag "placeholder function wired as production default" as a Concern pattern, not a Suggestion. The PR #23 review called this out as a Suggestion; it probably should have been a Concern.
+- When a slice ships with a planned follow-up that will replace a stub, the PR description should link to the follow-up issue *and* confirm that the stub either fails-fast or is gated behind an explicit opt-in. "We'll wire it up next slice" is not enough.
+
+## Key Decision
+
+**Decision:** PR #23 shipped with `placeholderPdfExtract` as a silent default. The follow-up slice will wire a real extractor.
+
+**Rationale:** The slice's acceptance criteria were about orchestration, not PDF parsing. Adding a PDF library mid-slice would have inflated scope. Dry-run mode is safe, and the human operator is aware of the limitation.
+
+**Alternatives considered:** Fail-fast placeholder (option 1 above). Rejected at the time for speed; should be applied in a follow-up before the next non-dry run.
+
+**Revisable:** Yes — apply the fail-fast pattern as soon as a non-dry run is plausible, or before merging the real-extractor follow-up slice.
+
+## Planning / Calibration Notes
+
+- **What widened the work:** the pre-merge review had to explicitly reason about dry-run vs non-dry semantics to catch this. Without that review, the footgun would have shipped.
+- **Future planning adjustment:** when `/write-a-prd` shapes a slice that will defer work to a follow-up, the PRD should explicitly specify whether the deferred work is "stubbed safely" or "wired as default." The default should be safe; anything else should be an explicit, reviewed decision.
+
+## Related
+
+- PR #23 — https://github.com/chrislacey89/civic-mirror/pull/23 (pre-merge review flagged as Dimension 7 Suggestion)
+- Follow-up: real PDF extractor (pdf-parse or unpdf)
+
+## Shelf Life
+
+Evergreen — applies to any slice that defers production-critical code to a follow-up while shipping a stub. The specific PDF-extractor case ends when the follow-up slice lands.

--- a/docs/solutions/testing-patterns/effect-retry-test-timeout-2026-04-10.md
+++ b/docs/solutions/testing-patterns/effect-retry-test-timeout-2026-04-10.md
@@ -1,0 +1,138 @@
+---
+date: 2026-04-10
+category: testing-patterns
+problem_type: real-time primitive in test environment
+components: [pipeline, orchestrator]
+technologies: [effect, vitest, schedule, retry]
+severity: medium
+volatility: stable
+---
+
+# Effect.retry with production Schedule values breaks vitest timeouts
+
+## Problem
+
+Adding `Effect.retry(Schedule.exponential(...).pipe(Schedule.compose(Schedule.recurs(n))))` with production-sized values causes existing tests to hit vitest's 5-second timeout. Tests that previously passed in milliseconds suddenly take 3–7 seconds because the retry schedule actually *waits* between attempts, using real wall-clock time.
+
+## Context
+
+While implementing issue #8's retry requirements, I added two schedules to the orchestrator:
+
+```typescript
+const DEFAULT_NETWORK_RETRY: RetryPolicy = { attempts: 3, baseDelayMs: 500 };
+const DEFAULT_LLM_RETRY: RetryPolicy = { attempts: 2, baseDelayMs: 1000 };
+```
+
+and wrapped the service calls:
+
+```typescript
+const summary = yield* summarizer.summarize({...}).pipe(Effect.retry(config.llmSchedule));
+```
+
+The orchestrator tests passed before the retry wrapping. After the wrapping, the test **"catches a per-listing error, sends an alert, and continues with the next listing"** timed out at 5004ms. The test deliberately triggers a `LlmError` to verify alert-and-recover behavior — and the retry schedule dutifully waited 1s, then 2s, then failed, per listing, per test. Two listings × 3 seconds of backoff per listing = past the 5s default.
+
+## Symptoms
+
+- One specific test times out at exactly 5000–5010ms after adding Effect.retry
+- Other tests still pass because they don't trigger the retry path
+- Increasing `testTimeout` makes the test pass but is a workaround, not a fix
+- `pnpm test` wall-clock time jumps by several seconds because the retries run in real time
+- The test is verifying error-recovery behavior (the exact path the retries wrap), so the retries *will* fire
+
+## Root Cause
+
+`Effect.retry` with `Schedule.exponential` uses real wall-clock time. There's no implicit "fast-forward" in Effect tests the way there is with `jest.useFakeTimers()` or `vi.useFakeTimers()` — you'd have to opt into `TestClock` explicitly, and even then it requires wrapping the test in an `Effect.provide(TestContext.TestContext)` block.
+
+Production Schedule values are *bad* test defaults. A 3-attempt exponential-500ms schedule costs 0.5 + 1 + 2 = 3.5s of wall-clock time for a single always-failing operation. A 2-attempt exponential-1s schedule costs 1 + 2 = 3s. The test suite hitting the error path twice already blows the default vitest timeout.
+
+The deeper lesson: any Effect primitive that touches real time (`Effect.sleep`, `Effect.delay`, `Schedule.spaced`, `Schedule.exponential`, `Schedule.fixed`) is a hidden coupling to wall-clock time. If a test can reach that code, the test either needs `TestClock` or needs to pass a no-op version of the primitive.
+
+## Learning Level
+
+- **Level:** Pattern
+- **Feedback loop or delay:** Immediate — the test fails on the first run after the change, which is fast enough that the fix happens in the same session. But the pattern recurs: any *future* Effect primitive that reaches into real time (debounce, throttle, timeout, interval) will reproduce the same failure mode unless we make injection the default from the start.
+
+## Solution
+
+Make retry policies injectable via the pipeline input, defaulting to production values, and have tests pass `attempts: 0` to disable retries entirely.
+
+**Before:**
+
+```typescript
+// Module-level constant — can't be overridden by tests
+const networkRetry = Schedule.exponential(Duration.millis(500)).pipe(
+	Schedule.compose(Schedule.recurs(3)),
+);
+
+// Hardcoded in the orchestrator
+yield* scraper.scrapeListings(...).pipe(Effect.retry(networkRetry));
+```
+
+**After:**
+
+```typescript
+type RetryPolicy = {
+	attempts: number;
+	baseDelayMs: number;
+};
+
+const DEFAULT_NETWORK_RETRY: RetryPolicy = { attempts: 3, baseDelayMs: 500 };
+const DEFAULT_LLM_RETRY: RetryPolicy = { attempts: 2, baseDelayMs: 1000 };
+
+function scheduleFromPolicy(policy: RetryPolicy) {
+	return Schedule.exponential(Duration.millis(policy.baseDelayMs)).pipe(
+		Schedule.compose(Schedule.recurs(policy.attempts)),
+	);
+}
+
+type RunPipelineInput = {
+	// ... other fields
+	networkRetry?: RetryPolicy;
+	llmRetry?: RetryPolicy;
+};
+
+// In runPipeline, resolve once:
+const config: ResolvedConfig = {
+	...input,
+	networkSchedule: scheduleFromPolicy(input.networkRetry ?? DEFAULT_NETWORK_RETRY),
+	llmSchedule: scheduleFromPolicy(input.llmRetry ?? DEFAULT_LLM_RETRY),
+};
+
+// Use at call site:
+yield* scraper.scrapeListings(...).pipe(Effect.retry(config.networkSchedule));
+```
+
+Tests pass `{ attempts: 0, baseDelayMs: 0 }` for both policies. `Schedule.recurs(0)` executes once with no retry, so the retry schedule is effectively a no-op and tests complete in milliseconds again.
+
+## Prevention
+
+**Code-level:**
+
+- Treat every `Effect.sleep` / `Effect.delay` / `Schedule.*` reference as a test-visible timing coupling. If the code is reachable by a test, the primitive must be injectable via config, not hardcoded.
+- A `grep -n 'Effect\.sleep\|Effect\.delay\|Schedule\.' src/` audit is worth running before any "this test is slow" investigation — it catches all the timing couplings at once.
+- Consider `TestClock` for more complex cases, but injection is simpler, faster to set up, and doesn't require wrapping every test in `Effect.provide(TestContext.TestContext)`.
+
+**Process-level:**
+
+- `/tdd` and `/execute` should both flag this failure mode explicitly: "test timeout jumped from <500ms to >3000ms" is a signal that a real-time Effect primitive was introduced and not made injectable. The right fix is never "bump testTimeout" unless you have a specific reason.
+- When `/research` specifies retry behavior for a slice, the shaping should note "retry policy must be injectable" as an explicit constraint, so the first implementation commit gets it right instead of patching it post-hoc.
+
+## Planning / Calibration Notes
+
+- **What widened the work:** discovering the timeout required retrying, diagnosing, and refactoring the schedules into injectable config. ~20 minutes of unplanned work.
+- **What tightened the work:** the fix generalized to YouTube rate limiting (`youtubeDelayMs`) in the same commit, so the pattern "all timing is injectable" was established once and reused.
+- **Future planning adjustment:** when `/write-a-prd` identifies a rabbit hole involving retry, backoff, rate limiting, or timeout, the PRD should specify "inject the policy via config" as part of the resolution, not leave it to implementation.
+
+## Actuals Worth Reusing
+
+- **Comparable future work:** any Effect service that wraps a flaky external call (LLM, HTTP, DB with intermittent failures)
+- **Reusable baseline:** budget ~30 min on top of the retry implementation to make the policy injectable and update tests. Always cheaper than discovering it mid-test-run.
+
+## Related
+
+- PR #23 — https://github.com/chrislacey89/civic-mirror/pull/23 (commit `45edc41 add retry policies and YouTube rate limiting to orchestrator`)
+- Effect docs: [Schedule](https://effect.website/docs/scheduling/introduction/), [TestClock](https://effect.website/docs/testing/test-clock/)
+
+## Shelf Life
+
+Stable — applies as long as the project uses Effect.retry / Schedule primitives and vitest with default timeouts. Revisit if the project adopts `TestClock` as a default testing pattern (would change the fix from "injection" to "virtual time"), or if Effect ships built-in test-mode schedules.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "db:push": "drizzle-kit push",
     "db:pull": "drizzle-kit pull",
     "db:studio": "drizzle-kit studio",
-    "pipeline:ingest": "tsx src/pipeline/ingest.ts",
+    "pipeline": "tsx src/pipeline/cli.ts",
+    "pipeline:run": "tsx src/pipeline/cli.ts run",
+    "pipeline:dry": "tsx src/pipeline/cli.ts run --dry-run --skip-crawl-delay",
     "ralph:once": "./ralph-once.sh",
     "ralph": "./ralph.sh 5"
   },

--- a/src/pipeline/cli.ts
+++ b/src/pipeline/cli.ts
@@ -1,84 +1,25 @@
 import { Command, Options } from "@effect/cli";
 import { NodeContext, NodeRuntime } from "@effect/platform-node";
-import { createClient } from "@libsql/client";
-import { drizzle } from "drizzle-orm/libsql";
-import { Console, Effect, Layer, Option } from "effect";
-import { Resend } from "resend";
-import * as schema from "#/db/schema.ts";
+import { config as loadDotenv } from "dotenv";
+import { Console, Effect, Option } from "effect";
+
+loadDotenv({ path: [".env.local", ".env"] });
+
+import {
+	buildProductionLayers,
+	DEFAULT_BODIES,
+	placeholderPdfExtract,
+} from "#/pipeline/composition.ts";
 import { runPipeline } from "#/pipeline/orchestrator.ts";
-import { AlertServiceLive } from "#/pipeline/services/AlertService.ts";
-import { FinalsiteScraperLive } from "#/pipeline/services/FinalsiteScraper.ts";
-import { createGeminiSummarizer } from "#/pipeline/services/GeminiSummarizer.ts";
-import { EgovScraperLive } from "#/pipeline/services/ScraperService.ts";
-import { StorageServiceLive } from "#/pipeline/services/StorageService.ts";
-import { SummarizationServiceLive } from "#/pipeline/services/SummarizationService.ts";
-import { TranscriptionServiceLive } from "#/pipeline/services/TranscriptionService.ts";
-import { YouTubeScraperLive } from "#/pipeline/services/YouTubeScraper.ts";
 
 /**
- * Effect teaching note: This file is the composition root — the single place
- * where every real service layer is constructed with production config and
- * merged into one big Layer that the orchestrator runs against. Everything
- * below the CLI boundary (orchestrator, services) has never heard of Resend,
- * Turso, or the YouTube API; they only see their injected dependencies.
- *
- * Command.run wraps the whole tree in argv parsing + help text, then
- * NodeRuntime.runMain handles process lifecycle and exit codes.
+ * Effect teaching note: This file owns the CLI surface — `@effect/cli` Command
+ * and Options definitions plus the `NodeRuntime.runMain` entrypoint — and
+ * nothing else. The production layer graph, the hardcoded body list, the env
+ * binding, and the placeholder PDF extractor all live in composition.ts, so
+ * changing how services are wired for production doesn't force edits past
+ * a wall of Option / Command boilerplate.
  */
-
-/**
- * Hardcoded governing body list for this initial CLI. Later iterations should
- * read this from the `governing_bodies` table so adding a body is a DB insert,
- * not a code change — but for the first end-to-end run, hardcoding keeps the
- * slice small.
- */
-const DEFAULT_BODIES = [
-	{
-		slug: "ellettsville-town-council",
-		name: "Ellettsville Town Council",
-		egovSearchType: "12",
-	},
-	{
-		slug: "ellettsville-plan-commission",
-		name: "Ellettsville Plan Commission",
-		egovSearchType: "12",
-	},
-	{
-		slug: "monroe-county-commissioners",
-		name: "Monroe County Commissioners",
-		egovSearchType: "12",
-	},
-	{
-		slug: "richland-bean-blossom-school-board",
-		name: "Richland-Bean Blossom School Board",
-		finalsiteUrl: "https://www.rbbschools.net/school-board",
-	},
-];
-
-/**
- * Placeholder PDF extractor. Production wiring should swap this for a real
- * extractor (pdf-parse, unpdf, pdfjs-dist). Kept inline here so the CLI
- * runs end-to-end in dry-run mode without adding a new dependency as part
- * of this slice — the follow-up PDF-extraction slice will replace it.
- */
-async function placeholderPdfExtract(bytes: ArrayBuffer): Promise<string> {
-	return `[PDF placeholder — ${bytes.byteLength} bytes; install a PDF extractor to see real text]`;
-}
-
-function readEnv(name: string): string | undefined {
-	const value = process.env[name];
-	return value && value.length > 0 ? value : undefined;
-}
-
-function requireEnv(name: string): string {
-	const value = readEnv(name);
-	if (!value) {
-		throw new Error(
-			`Missing required environment variable: ${name}. Set it in .env.local or the shell.`,
-		);
-	}
-	return value;
-}
 
 // ---------------------------------------------------------------------------
 // `run` subcommand — full pipeline execution
@@ -157,93 +98,14 @@ const listBodiesCommand = Command.make("list-bodies", {}, () =>
 		for (const body of DEFAULT_BODIES) {
 			const sources: string[] = [];
 			if (body.egovSearchType) sources.push(`egov:${body.egovSearchType}`);
-			if ("finalsiteUrl" in body && body.finalsiteUrl)
-				sources.push(`finalsite`);
-			if ("youtubePlaylistId" in body && body.youtubePlaylistId)
-				sources.push(`youtube`);
+			if (body.finalsiteUrl) sources.push(`finalsite`);
+			if (body.youtubePlaylistId) sources.push(`youtube`);
 			yield* Console.log(
 				`  ${body.slug.padEnd(40)} ${body.name} [${sources.join(", ")}]`,
 			);
 		}
 	}),
 );
-
-// ---------------------------------------------------------------------------
-// Layer composition
-// ---------------------------------------------------------------------------
-
-type BuildLayersInput = { dryRun: boolean };
-
-function buildProductionLayers(input: BuildLayersInput) {
-	const databaseUrl = requireEnv("DATABASE_URL");
-	const authToken = readEnv("TURSO_AUTH_TOKEN");
-
-	const client = createClient({
-		url: databaseUrl,
-		...(authToken ? { authToken } : {}),
-	});
-	const db = drizzle(client, { schema });
-
-	const geminiModelId = readEnv("GEMINI_MODEL") ?? "gemini-2.5-flash";
-	const geminiGenerator = createGeminiSummarizer({ modelId: geminiModelId });
-
-	const resendApiKey = input.dryRun ? undefined : readEnv("RESEND_API_KEY");
-	const resendFrom =
-		readEnv("RESEND_FROM") ?? "civic-mirror@alerts.example.com";
-	const resendTo = readEnv("ALERT_EMAIL") ?? "ops@example.com";
-
-	const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
-
-	const egovBaseUrl =
-		readEnv("EGOV_BASE_URL") ??
-		"https://ellettsville.in.us/egov/apps/document/center.egov";
-
-	const egov = EgovScraperLive({ baseUrl: egovBaseUrl });
-
-	const finalsite = FinalsiteScraperLive({
-		baseUrl: readEnv("FINALSITE_BASE_URL") ?? "https://www.rbbschools.net",
-	});
-
-	const youtube = YouTubeScraperLive({
-		apiKey: readEnv("YOUTUBE_API_KEY") ?? "missing-key",
-	});
-
-	const transcription = TranscriptionServiceLive();
-
-	const summarization = SummarizationServiceLive({
-		model: geminiModelId,
-		generateFn: geminiGenerator,
-	});
-
-	const storage = StorageServiceLive(db);
-
-	const alert = AlertServiceLive({
-		to: resendTo,
-		from: resendFrom,
-		sendFn: resendClient
-			? async ({ to, from, subject, body }) => {
-					await resendClient.emails.send({
-						to,
-						from,
-						subject,
-						text: body,
-					});
-				}
-			: async ({ subject, body }) => {
-					console.log(`[alert-stub] ${subject}\n${body}`);
-				},
-	});
-
-	return Layer.mergeAll(
-		egov,
-		finalsite,
-		youtube,
-		transcription,
-		summarization,
-		storage,
-		alert,
-	);
-}
 
 // ---------------------------------------------------------------------------
 // Command root and entrypoint

--- a/src/pipeline/cli.ts
+++ b/src/pipeline/cli.ts
@@ -1,0 +1,263 @@
+import { Command, Options } from "@effect/cli";
+import { NodeContext, NodeRuntime } from "@effect/platform-node";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { Console, Effect, Layer, Option } from "effect";
+import { Resend } from "resend";
+import * as schema from "#/db/schema.ts";
+import { runPipeline } from "#/pipeline/orchestrator.ts";
+import { AlertServiceLive } from "#/pipeline/services/AlertService.ts";
+import { FinalsiteScraperLive } from "#/pipeline/services/FinalsiteScraper.ts";
+import { createGeminiSummarizer } from "#/pipeline/services/GeminiSummarizer.ts";
+import { EgovScraperLive } from "#/pipeline/services/ScraperService.ts";
+import { StorageServiceLive } from "#/pipeline/services/StorageService.ts";
+import { SummarizationServiceLive } from "#/pipeline/services/SummarizationService.ts";
+import { TranscriptionServiceLive } from "#/pipeline/services/TranscriptionService.ts";
+import { YouTubeScraperLive } from "#/pipeline/services/YouTubeScraper.ts";
+
+/**
+ * Effect teaching note: This file is the composition root — the single place
+ * where every real service layer is constructed with production config and
+ * merged into one big Layer that the orchestrator runs against. Everything
+ * below the CLI boundary (orchestrator, services) has never heard of Resend,
+ * Turso, or the YouTube API; they only see their injected dependencies.
+ *
+ * Command.run wraps the whole tree in argv parsing + help text, then
+ * NodeRuntime.runMain handles process lifecycle and exit codes.
+ */
+
+/**
+ * Hardcoded governing body list for this initial CLI. Later iterations should
+ * read this from the `governing_bodies` table so adding a body is a DB insert,
+ * not a code change — but for the first end-to-end run, hardcoding keeps the
+ * slice small.
+ */
+const DEFAULT_BODIES = [
+	{
+		slug: "ellettsville-town-council",
+		name: "Ellettsville Town Council",
+		egovSearchType: "12",
+	},
+	{
+		slug: "ellettsville-plan-commission",
+		name: "Ellettsville Plan Commission",
+		egovSearchType: "12",
+	},
+	{
+		slug: "monroe-county-commissioners",
+		name: "Monroe County Commissioners",
+		egovSearchType: "12",
+	},
+	{
+		slug: "richland-bean-blossom-school-board",
+		name: "Richland-Bean Blossom School Board",
+		finalsiteUrl: "https://www.rbbschools.net/school-board",
+	},
+];
+
+/**
+ * Placeholder PDF extractor. Production wiring should swap this for a real
+ * extractor (pdf-parse, unpdf, pdfjs-dist). Kept inline here so the CLI
+ * runs end-to-end in dry-run mode without adding a new dependency as part
+ * of this slice — the follow-up PDF-extraction slice will replace it.
+ */
+async function placeholderPdfExtract(bytes: ArrayBuffer): Promise<string> {
+	return `[PDF placeholder — ${bytes.byteLength} bytes; install a PDF extractor to see real text]`;
+}
+
+function readEnv(name: string): string | undefined {
+	const value = process.env[name];
+	return value && value.length > 0 ? value : undefined;
+}
+
+function requireEnv(name: string): string {
+	const value = readEnv(name);
+	if (!value) {
+		throw new Error(
+			`Missing required environment variable: ${name}. Set it in .env.local or the shell.`,
+		);
+	}
+	return value;
+}
+
+// ---------------------------------------------------------------------------
+// `run` subcommand — full pipeline execution
+// ---------------------------------------------------------------------------
+
+const dryRun = Options.boolean("dry-run").pipe(
+	Options.withDefault(false),
+	Options.withDescription(
+		"Run all stages except storage and alerts — safe smoke test.",
+	),
+);
+
+const skipCrawlDelay = Options.boolean("skip-crawl-delay").pipe(
+	Options.withDefault(false),
+	Options.withDescription(
+		"Skip the 300-second eGov crawl delay between downloads (local testing only).",
+	),
+);
+
+const bodySlug = Options.text("body").pipe(
+	Options.optional,
+	Options.withDescription(
+		"Only process the body with this slug (defaults to all bodies).",
+	),
+);
+
+const runCommand = Command.make(
+	"run",
+	{ dryRun, skipCrawlDelay, bodySlug },
+	({ dryRun, skipCrawlDelay, bodySlug }) =>
+		Effect.gen(function* () {
+			const bodies = Option.match(bodySlug, {
+				onNone: () => DEFAULT_BODIES,
+				onSome: (slug) => DEFAULT_BODIES.filter((b) => b.slug === slug),
+			});
+
+			if (bodies.length === 0) {
+				yield* Console.error(
+					`No body matched the provided --body slug. Known slugs: ${DEFAULT_BODIES.map((b) => b.slug).join(", ")}`,
+				);
+				return;
+			}
+
+			yield* Console.log(
+				`[pipeline] starting run: bodies=${bodies.length} dryRun=${dryRun} skipCrawlDelay=${skipCrawlDelay}`,
+			);
+
+			const layers = yield* Effect.try({
+				try: () => buildProductionLayers({ dryRun }),
+				catch: (error) =>
+					new Error(
+						`Failed to construct pipeline layers: ${error instanceof Error ? error.message : String(error)}`,
+					),
+			});
+
+			const result = yield* runPipeline({
+				bodies,
+				crawlDelayMs: skipCrawlDelay ? 0 : 300_000,
+				extractPdfText: placeholderPdfExtract,
+				dryRun,
+			}).pipe(Effect.provide(layers));
+
+			yield* Console.log(
+				`[pipeline] done: processed=${result.processed} errors=${result.errors}`,
+			);
+		}),
+);
+
+// ---------------------------------------------------------------------------
+// `list-bodies` subcommand — prints the configured bodies so the operator
+// can see what `run` will process without running anything.
+// ---------------------------------------------------------------------------
+
+const listBodiesCommand = Command.make("list-bodies", {}, () =>
+	Effect.gen(function* () {
+		for (const body of DEFAULT_BODIES) {
+			const sources: string[] = [];
+			if (body.egovSearchType) sources.push(`egov:${body.egovSearchType}`);
+			if ("finalsiteUrl" in body && body.finalsiteUrl)
+				sources.push(`finalsite`);
+			if ("youtubePlaylistId" in body && body.youtubePlaylistId)
+				sources.push(`youtube`);
+			yield* Console.log(
+				`  ${body.slug.padEnd(40)} ${body.name} [${sources.join(", ")}]`,
+			);
+		}
+	}),
+);
+
+// ---------------------------------------------------------------------------
+// Layer composition
+// ---------------------------------------------------------------------------
+
+type BuildLayersInput = { dryRun: boolean };
+
+function buildProductionLayers(input: BuildLayersInput) {
+	const databaseUrl = requireEnv("DATABASE_URL");
+	const authToken = readEnv("TURSO_AUTH_TOKEN");
+
+	const client = createClient({
+		url: databaseUrl,
+		...(authToken ? { authToken } : {}),
+	});
+	const db = drizzle(client, { schema });
+
+	const geminiModelId = readEnv("GEMINI_MODEL") ?? "gemini-2.5-flash";
+	const geminiGenerator = createGeminiSummarizer({ modelId: geminiModelId });
+
+	const resendApiKey = input.dryRun ? undefined : readEnv("RESEND_API_KEY");
+	const resendFrom =
+		readEnv("RESEND_FROM") ?? "civic-mirror@alerts.example.com";
+	const resendTo = readEnv("ALERT_EMAIL") ?? "ops@example.com";
+
+	const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
+
+	const egovBaseUrl =
+		readEnv("EGOV_BASE_URL") ??
+		"https://ellettsville.in.us/egov/apps/document/center.egov";
+
+	const egov = EgovScraperLive({ baseUrl: egovBaseUrl });
+
+	const finalsite = FinalsiteScraperLive({
+		baseUrl: readEnv("FINALSITE_BASE_URL") ?? "https://www.rbbschools.net",
+	});
+
+	const youtube = YouTubeScraperLive({
+		apiKey: readEnv("YOUTUBE_API_KEY") ?? "missing-key",
+	});
+
+	const transcription = TranscriptionServiceLive();
+
+	const summarization = SummarizationServiceLive({
+		model: geminiModelId,
+		generateFn: geminiGenerator,
+	});
+
+	const storage = StorageServiceLive(db);
+
+	const alert = AlertServiceLive({
+		to: resendTo,
+		from: resendFrom,
+		sendFn: resendClient
+			? async ({ to, from, subject, body }) => {
+					await resendClient.emails.send({
+						to,
+						from,
+						subject,
+						text: body,
+					});
+				}
+			: async ({ subject, body }) => {
+					console.log(`[alert-stub] ${subject}\n${body}`);
+				},
+	});
+
+	return Layer.mergeAll(
+		egov,
+		finalsite,
+		youtube,
+		transcription,
+		summarization,
+		storage,
+		alert,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Command root and entrypoint
+// ---------------------------------------------------------------------------
+
+const rootCommand = Command.make("pipeline", {}, () =>
+	Console.log(
+		"Civic Mirror pipeline — run `pipeline run --help` or `pipeline list-bodies`.",
+	),
+).pipe(Command.withSubcommands([runCommand, listBodiesCommand]));
+
+const cli = Command.run(rootCommand, {
+	name: "Civic Mirror Pipeline",
+	version: "0.1.0",
+});
+
+cli(process.argv).pipe(Effect.provide(NodeContext.layer), NodeRuntime.runMain);

--- a/src/pipeline/composition.ts
+++ b/src/pipeline/composition.ts
@@ -1,0 +1,177 @@
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { Layer } from "effect";
+import { Resend } from "resend";
+import * as schema from "#/db/schema.ts";
+import { AlertServiceLive } from "#/pipeline/services/AlertService.ts";
+import { FinalsiteScraperLive } from "#/pipeline/services/FinalsiteScraper.ts";
+import { createGeminiSummarizer } from "#/pipeline/services/GeminiSummarizer.ts";
+import { EgovScraperLive } from "#/pipeline/services/ScraperService.ts";
+import { StorageServiceLive } from "#/pipeline/services/StorageService.ts";
+import { SummarizationServiceLive } from "#/pipeline/services/SummarizationService.ts";
+import { TranscriptionServiceLive } from "#/pipeline/services/TranscriptionService.ts";
+import { YouTubeScraperLive } from "#/pipeline/services/YouTubeScraper.ts";
+
+/**
+ * Effect teaching note: This file is the composition root — the single place
+ * where every real service layer is constructed with production config and
+ * merged into one big Layer that the orchestrator runs against. Everything
+ * below the CLI boundary (orchestrator, services) has never heard of Resend,
+ * Turso, or the YouTube API; they only see their injected dependencies.
+ *
+ * Separating the composition root from cli.ts means the CLI file owns only
+ * command shapes and `NodeRuntime.runMain` wiring — the layer graph, the
+ * body list, and the env binding all live here where they can be read and
+ * maintained without navigating past `@effect/cli` Option/Command boilerplate.
+ */
+
+/**
+ * A governing-body entry in the hardcoded list. Exactly one source field
+ * should be present per body — the union is kept open-ended here rather
+ * than via a discriminated union because bodies may eventually aggregate
+ * multiple sources (e.g. a body with both an eGov listing and a YouTube
+ * playlist).
+ */
+type BodyConfigEntry = {
+	slug: string;
+	name: string;
+	egovSearchType?: string;
+	finalsiteUrl?: string;
+	youtubePlaylistId?: string;
+};
+
+/**
+ * Hardcoded governing body list for this initial CLI. Later iterations should
+ * read this from the `governing_bodies` table so adding a body is a DB insert,
+ * not a code change — but for the first end-to-end run, hardcoding keeps the
+ * slice small.
+ */
+const DEFAULT_BODIES: BodyConfigEntry[] = [
+	{
+		slug: "ellettsville-town-council",
+		name: "Ellettsville Town Council",
+		egovSearchType: "12",
+	},
+	{
+		slug: "ellettsville-plan-commission",
+		name: "Ellettsville Plan Commission",
+		egovSearchType: "12",
+	},
+	{
+		slug: "monroe-county-commissioners",
+		name: "Monroe County Commissioners",
+		egovSearchType: "12",
+	},
+	{
+		slug: "richland-bean-blossom-school-board",
+		name: "Richland-Bean Blossom School Board",
+		finalsiteUrl: "https://www.rbbschools.net/school-board",
+	},
+];
+
+/**
+ * Placeholder PDF extractor. Production wiring should swap this for a real
+ * extractor (pdf-parse, unpdf, pdfjs-dist). Kept inline here so the CLI
+ * runs end-to-end in dry-run mode without adding a new dependency as part
+ * of this slice — the follow-up PDF-extraction slice will replace it.
+ */
+async function placeholderPdfExtract(bytes: ArrayBuffer): Promise<string> {
+	return `[PDF placeholder — ${bytes.byteLength} bytes; install a PDF extractor to see real text]`;
+}
+
+function readEnv(name: string): string | undefined {
+	const value = process.env[name];
+	return value && value.length > 0 ? value : undefined;
+}
+
+function requireEnv(name: string): string {
+	const value = readEnv(name);
+	if (!value) {
+		throw new Error(
+			`Missing required environment variable: ${name}. Set it in .env.local or the shell.`,
+		);
+	}
+	return value;
+}
+
+type BuildLayersInput = { dryRun: boolean };
+
+function buildProductionLayers(input: BuildLayersInput) {
+	const databaseUrl = requireEnv("DATABASE_URL");
+	const authToken = readEnv("TURSO_AUTH_TOKEN");
+
+	const client = createClient({
+		url: databaseUrl,
+		...(authToken ? { authToken } : {}),
+	});
+	const db = drizzle(client, { schema });
+
+	const geminiModelId = readEnv("GEMINI_MODEL") ?? "gemini-2.5-flash";
+	const geminiGenerator = createGeminiSummarizer({ modelId: geminiModelId });
+
+	const resendApiKey = input.dryRun ? undefined : readEnv("RESEND_API_KEY");
+	const resendFrom =
+		readEnv("RESEND_FROM") ?? "civic-mirror@alerts.example.com";
+	const resendTo = readEnv("ALERT_EMAIL") ?? "ops@example.com";
+
+	const resendClient = resendApiKey ? new Resend(resendApiKey) : null;
+
+	const egovBaseUrl =
+		readEnv("EGOV_BASE_URL") ??
+		"https://ellettsville.in.us/egov/apps/document/center.egov";
+
+	const egov = EgovScraperLive({ baseUrl: egovBaseUrl });
+
+	const finalsite = FinalsiteScraperLive({
+		baseUrl: readEnv("FINALSITE_BASE_URL") ?? "https://www.rbbschools.net",
+	});
+
+	const youtube = YouTubeScraperLive({
+		apiKey: readEnv("YOUTUBE_API_KEY") ?? "missing-key",
+	});
+
+	const transcription = TranscriptionServiceLive();
+
+	const summarization = SummarizationServiceLive({
+		model: geminiModelId,
+		generateFn: geminiGenerator,
+	});
+
+	const storage = StorageServiceLive(db);
+
+	const alert = AlertServiceLive({
+		to: resendTo,
+		from: resendFrom,
+		sendFn: resendClient
+			? async ({ to, from, subject, body }) => {
+					await resendClient.emails.send({
+						to,
+						from,
+						subject,
+						text: body,
+					});
+				}
+			: async ({ subject, body }) => {
+					console.log(`[alert-stub] ${subject}\n${body}`);
+				},
+	});
+
+	return Layer.mergeAll(
+		egov,
+		finalsite,
+		youtube,
+		transcription,
+		summarization,
+		storage,
+		alert,
+	);
+}
+
+export {
+	DEFAULT_BODIES,
+	placeholderPdfExtract,
+	readEnv,
+	requireEnv,
+	buildProductionLayers,
+};
+export type { BodyConfigEntry, BuildLayersInput };

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -191,6 +191,9 @@ describe("runPipeline", () => {
 				},
 			],
 			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
 			extractPdfText: async () =>
 				"Meeting minutes body text with $50,000 decision",
 			dryRun: false,
@@ -226,6 +229,9 @@ describe("runPipeline", () => {
 		const program = runPipeline({
 			bodies: [{ slug: "body", name: "Body", egovSearchType: "12" }],
 			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
 			extractPdfText: async () => "text",
 			dryRun: true,
 		}).pipe(Effect.provide(layers));
@@ -262,6 +268,9 @@ describe("runPipeline", () => {
 		const program = runPipeline({
 			bodies: [{ slug: "body", name: "Body", egovSearchType: "12" }],
 			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
 			extractPdfText: async () => "text",
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
@@ -311,6 +320,9 @@ describe("runPipeline", () => {
 				},
 			],
 			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
 			extractPdfText: async () => "school board text",
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
@@ -346,6 +358,9 @@ describe("runPipeline", () => {
 				},
 			],
 			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
 			extractPdfText: async () => "unused",
 			dryRun: false,
 		}).pipe(Effect.provide(layers));

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -1,0 +1,362 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it } from "vitest";
+import type { MeetingDetail } from "#/db/queries.ts";
+import { LlmError } from "#/pipeline/errors.ts";
+import { runPipeline } from "#/pipeline/orchestrator.ts";
+import { AlertService } from "#/pipeline/services/AlertService.ts";
+import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
+import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
+import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
+import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
+import type { Meeting } from "#/pipeline/services/StorageService.ts";
+import { StorageService } from "#/pipeline/services/StorageService.ts";
+import type { SummarizationResult } from "#/pipeline/services/SummarizationService.ts";
+import { SummarizationService } from "#/pipeline/services/SummarizationService.ts";
+import { TranscriptionService } from "#/pipeline/services/TranscriptionService.ts";
+import type { YouTubeVideo } from "#/pipeline/services/YouTubeScraper.ts";
+import { YouTubeScraper } from "#/pipeline/services/YouTubeScraper.ts";
+
+/**
+ * Test helpers — build stub Effect Layers for each service. Each stub records
+ * calls in a closure so tests can assert on what the orchestrator did.
+ */
+
+type CallLog = {
+	egovScrape: number;
+	egovDownload: Array<string>;
+	finalsiteScrape: number;
+	finalsiteDownload: Array<string>;
+	youtubeList: Array<string>;
+	transcribe: Array<string>;
+	summarize: Array<{ sourceText: string; meetingContext: string }>;
+	store: Array<{ bodySlug: string; date: string }>;
+	alert: Array<{ subject: string; body: string }>;
+};
+
+function emptyCallLog(): CallLog {
+	return {
+		egovScrape: 0,
+		egovDownload: [],
+		finalsiteScrape: 0,
+		finalsiteDownload: [],
+		youtubeList: [],
+		transcribe: [],
+		summarize: [],
+		store: [],
+		alert: [],
+	};
+}
+
+type StubConfig = {
+	log: CallLog;
+	egovListings?: EgovDocumentListing[];
+	finalsiteListings?: FinalsiteMeetingListing[];
+	youtubeVideos?: YouTubeVideo[];
+	summarizationResult?: SummarizationResult;
+	summarizationError?: Error;
+	storedMeeting?: Meeting;
+	lastMeetingLookup?: MeetingDetail | null;
+};
+
+function buildStubLayers(config: StubConfig) {
+	const defaultSummary: SummarizationResult = {
+		highlights: ["A highlight"],
+		prose: "A prose summary",
+		fiscalDecisions: [],
+		budgetDiscussions: [],
+		model: "stub-model",
+	};
+	const defaultMeeting: Meeting = { id: 1, date: "2026-01-01", bodyId: 1 };
+
+	const egov = Layer.succeed(EgovScraper, {
+		scrapeListings: () =>
+			Effect.sync(() => {
+				config.log.egovScrape += 1;
+				return config.egovListings ?? [];
+			}),
+		downloadDocument: (url) =>
+			Effect.sync(() => {
+				config.log.egovDownload.push(url);
+				return new TextEncoder().encode("fake pdf").buffer as ArrayBuffer;
+			}),
+	});
+
+	const finalsite = Layer.succeed(FinalsiteScraper, {
+		scrapeListings: () =>
+			Effect.sync(() => {
+				config.log.finalsiteScrape += 1;
+				return config.finalsiteListings ?? [];
+			}),
+		downloadDocument: (uuid) =>
+			Effect.sync(() => {
+				config.log.finalsiteDownload.push(uuid);
+				return new TextEncoder().encode("fake pdf").buffer as ArrayBuffer;
+			}),
+	});
+
+	const youtube = Layer.succeed(YouTubeScraper, {
+		listPlaylistVideos: (playlistId) =>
+			Effect.sync(() => {
+				config.log.youtubeList.push(playlistId);
+				return config.youtubeVideos ?? [];
+			}),
+	});
+
+	const transcription = Layer.succeed(TranscriptionService, {
+		transcribe: (videoId) =>
+			Effect.sync(() => {
+				config.log.transcribe.push(videoId);
+				return {
+					source: "captions" as const,
+					rawText: `transcript for ${videoId}`,
+					segments: [],
+				};
+			}),
+	});
+
+	const summarization = Layer.succeed(SummarizationService, {
+		summarize: (input) =>
+			Effect.try({
+				try: () => {
+					config.log.summarize.push(input);
+					if (config.summarizationError) {
+						throw config.summarizationError;
+					}
+					return config.summarizationResult ?? defaultSummary;
+				},
+				catch: (error) =>
+					new LlmError({
+						model: "stub-model",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+
+	const storage = Layer.succeed(StorageService, {
+		storeMeeting: (input) =>
+			Effect.sync(() => {
+				config.log.store.push({ bodySlug: input.bodySlug, date: input.date });
+				return config.storedMeeting ?? defaultMeeting;
+			}),
+		getMeetingByBodyAndDate: () =>
+			Effect.sync(() => config.lastMeetingLookup ?? null),
+		storeTranscript: () => Effect.void,
+	});
+
+	const alert = Layer.succeed(AlertService, {
+		sendAlert: (input) =>
+			Effect.sync(() => {
+				config.log.alert.push(input);
+			}),
+	});
+
+	return Layer.mergeAll(
+		egov,
+		finalsite,
+		youtube,
+		transcription,
+		summarization,
+		storage,
+		alert,
+	);
+}
+
+describe("runPipeline", () => {
+	it("processes an eGov body end to end, storing one meeting per listing", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 1653,
+					title: "Town Council Meeting February 4, 2026 Minutes",
+					date: "02/04/2026",
+					downloadUrl: "https://example.com/doc/1653",
+				},
+				{
+					id: 1628,
+					title: "Town Council Meeting January 14, 2026 Minutes",
+					date: "01/14/2026",
+					downloadUrl: "https://example.com/doc/1628",
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "town-council",
+					name: "Town Council",
+					egovSearchType: "12",
+				},
+			],
+			crawlDelayMs: 0,
+			extractPdfText: async () =>
+				"Meeting minutes body text with $50,000 decision",
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.egovScrape).toBe(1);
+		expect(log.egovDownload).toHaveLength(2);
+		expect(log.summarize).toHaveLength(2);
+		expect(log.summarize[0].sourceText).toContain("$50,000");
+		expect(log.store).toHaveLength(2);
+		expect(log.store[0].bodySlug).toBe("town-council");
+		expect(log.alert).toHaveLength(0);
+		expect(result.processed).toBe(2);
+		expect(result.errors).toBe(0);
+	});
+
+	it("skips storage and alerts in dry-run mode but still scrapes and summarizes", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 1,
+					title: "Meeting",
+					date: "01/01/2026",
+					downloadUrl: "https://example.com/doc/1",
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [{ slug: "body", name: "Body", egovSearchType: "12" }],
+			crawlDelayMs: 0,
+			extractPdfText: async () => "text",
+			dryRun: true,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.egovDownload).toHaveLength(1);
+		expect(log.summarize).toHaveLength(1);
+		expect(log.store).toHaveLength(0);
+		expect(result.processed).toBe(1);
+	});
+
+	it("catches a per-listing error, sends an alert, and continues with the next listing", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 1,
+					title: "First",
+					date: "01/01/2026",
+					downloadUrl: "https://example.com/doc/1",
+				},
+				{
+					id: 2,
+					title: "Second",
+					date: "01/02/2026",
+					downloadUrl: "https://example.com/doc/2",
+				},
+			],
+			summarizationError: new Error("LLM boom"),
+		});
+
+		const program = runPipeline({
+			bodies: [{ slug: "body", name: "Body", egovSearchType: "12" }],
+			crawlDelayMs: 0,
+			extractPdfText: async () => "text",
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.summarize).toHaveLength(2);
+		expect(log.store).toHaveLength(0);
+		expect(log.alert.length).toBeGreaterThanOrEqual(1);
+		expect(log.alert[0].subject).toContain("summarize");
+		expect(result.errors).toBe(2);
+	});
+
+	it("processes a Finalsite body: one listing per document per meeting", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			finalsiteListings: [
+				{
+					date: "January 20, 2026",
+					meetingType: "Regular Meeting",
+					year: 2026,
+					documents: [
+						{
+							uuid: "uuid-agenda",
+							documentType: "agenda",
+							downloadUrl: "/fs/resource-manager/view/uuid-agenda",
+							fileName: "agenda.pdf",
+						},
+						{
+							uuid: "uuid-minutes",
+							documentType: "minutes",
+							downloadUrl: "/fs/resource-manager/view/uuid-minutes",
+							fileName: "minutes.pdf",
+						},
+					],
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "school-board",
+					name: "School Board",
+					finalsiteUrl: "https://example.com/school-board",
+				},
+			],
+			crawlDelayMs: 0,
+			extractPdfText: async () => "school board text",
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.finalsiteDownload).toHaveLength(2);
+		expect(log.store).toHaveLength(1);
+		expect(log.store[0].bodySlug).toBe("school-board");
+		expect(result.processed).toBe(1);
+	});
+
+	it("processes a YouTube body by transcribing each video and storing as a meeting", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			youtubeVideos: [
+				{
+					videoId: "abc123",
+					title: "Town Council, March 23, 2026",
+					publishedAt: "2026-03-24T00:00:00Z",
+					hasCaptions: true,
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "town-council",
+					name: "Town Council",
+					youtubePlaylistId: "PL_test",
+				},
+			],
+			crawlDelayMs: 0,
+			extractPdfText: async () => "unused",
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.youtubeList).toEqual(["PL_test"]);
+		expect(log.transcribe).toEqual(["abc123"]);
+		expect(log.summarize).toHaveLength(1);
+		expect(log.summarize[0].sourceText).toContain("transcript for abc123");
+		expect(log.store).toHaveLength(1);
+		expect(result.processed).toBe(1);
+	});
+});

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -56,6 +56,7 @@ type StubConfig = {
 	summarizationError?: Error;
 	storedMeeting?: Meeting;
 	lastMeetingLookup?: MeetingDetail | null;
+	mostRecentMeetingDate?: string | null;
 };
 
 function buildStubLayers(config: StubConfig) {
@@ -141,6 +142,8 @@ function buildStubLayers(config: StubConfig) {
 		getMeetingByBodyAndDate: () =>
 			Effect.sync(() => config.lastMeetingLookup ?? null),
 		storeTranscript: () => Effect.void,
+		getMostRecentMeetingDate: () =>
+			Effect.sync(() => config.mostRecentMeetingDate ?? null),
 	});
 
 	const alert = Layer.succeed(AlertService, {

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -338,6 +338,72 @@ describe("runPipeline", () => {
 		expect(result.processed).toBe(1);
 	});
 
+	it("sends a zero-results alert when the body's last meeting is more than 30 days old", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			mostRecentMeetingDate: "2026-01-01", // ~99 days before 2026-04-10
+			egovListings: [],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "sleepy-body",
+					name: "Sleepy Body",
+					egovSearchType: "12",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => "text",
+			dryRun: true,
+			now: new Date("2026-04-10T00:00:00Z"),
+		}).pipe(Effect.provide(layers));
+
+		await Effect.runPromise(program);
+
+		const zeroAlert = log.alert.find((a) =>
+			a.subject.includes("No new content"),
+		);
+		expect(zeroAlert).toBeDefined();
+		expect(zeroAlert?.body).toContain("Sleepy Body");
+		// 2026-04-10 minus 2026-01-01 = 99 days
+		expect(zeroAlert?.body).toMatch(/9\d days/);
+	});
+
+	it("does not send a zero-results alert when the most recent meeting is within 30 days", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			mostRecentMeetingDate: "2026-04-01", // 9 days before 2026-04-10
+			egovListings: [],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "fresh-body",
+					name: "Fresh Body",
+					egovSearchType: "12",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => "text",
+			dryRun: true,
+			now: new Date("2026-04-10T00:00:00Z"),
+		}).pipe(Effect.provide(layers));
+
+		await Effect.runPromise(program);
+
+		expect(log.alert).toHaveLength(0);
+	});
+
 	it("processes a YouTube body by transcribing each video and storing as a meeting", async () => {
 		const log = emptyCallLog();
 		const layers = buildStubLayers({

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -261,6 +261,60 @@ function fetchListingsOrAlert<T, E extends TaggedPipelineError>(
 	);
 }
 
+/**
+ * Effect teaching note: The second shared shape across every source path is
+ * the per-item loop — iterate items, run processItem with its own catchAll
+ * to alertAndRecover so one broken item doesn't stop the body, accumulate a
+ * PipelineResult, and optionally sleep between items for rate-limit
+ * compliance. Pulling this into one place means a change to the per-item
+ * error path (or the delay strategy, or the filter semantics) edits one
+ * function instead of three.
+ *
+ * The `R` type parameter carries the requirements of `processItem` straight
+ * through to the caller, so each source keeps its own precise
+ * `Effect.Effect<..., ..., EgovScraper | ...>` requirements in the return
+ * type without any cast.
+ */
+function iterateWithAlertRecovery<TItem, R>(
+	body: BodyConfig,
+	items: readonly TItem[],
+	options: {
+		processItem: (
+			item: TItem,
+		) => Effect.Effect<PipelineResult, TaggedPipelineError, R>;
+		delayBetweenItemsMs: number;
+		shouldProcess?: (item: TItem) => boolean;
+	},
+): Effect.Effect<PipelineResult, never, R | AlertService> {
+	return Effect.gen(function* () {
+		let processed = 0;
+		let errors = 0;
+
+		for (const item of items) {
+			if (options.shouldProcess && !options.shouldProcess(item)) continue;
+
+			const result = yield* options
+				.processItem(item)
+				.pipe(
+					Effect.catchAll((error) =>
+						alertAndRecover(body, listingFailureStage(error), error).pipe(
+							Effect.as({ processed: 0, errors: 1 }),
+						),
+					),
+				);
+
+			processed += result.processed;
+			errors += result.errors;
+
+			if (options.delayBetweenItemsMs > 0) {
+				yield* Effect.sleep(Duration.millis(options.delayBetweenItemsMs));
+			}
+		}
+
+		return { processed, errors };
+	});
+}
+
 // ---------------------------------------------------------------------------
 // eGov path
 // ---------------------------------------------------------------------------
@@ -288,27 +342,10 @@ function runEgovForBody(
 
 		if (!listingsResult.ok) return { processed: 0, errors: 1 };
 
-		let processed = 0;
-		let errors = 0;
-
-		for (const listing of listingsResult.listings) {
-			const perListing = yield* processEgovListing(body, listing, config).pipe(
-				Effect.catchAll((error) =>
-					alertAndRecover(body, listingFailureStage(error), error).pipe(
-						Effect.as({ processed: 0, errors: 1 }),
-					),
-				),
-			);
-
-			processed += perListing.processed;
-			errors += perListing.errors;
-
-			if (config.crawlDelayMs > 0) {
-				yield* Effect.sleep(Duration.millis(config.crawlDelayMs));
-			}
-		}
-
-		return { processed, errors };
+		return yield* iterateWithAlertRecovery(body, listingsResult.listings, {
+			processItem: (listing) => processEgovListing(body, listing, config),
+			delayBetweenItemsMs: config.crawlDelayMs,
+		});
 	});
 }
 
@@ -395,29 +432,11 @@ function runFinalsiteForBody(
 
 		if (!listingsResult.ok) return { processed: 0, errors: 1 };
 
-		let processed = 0;
-		let errors = 0;
-
-		for (const listing of listingsResult.listings) {
-			if (listing.documents.length === 0) continue;
-
-			const perListing = yield* processFinalsiteListing(
-				body,
-				listing,
-				config,
-			).pipe(
-				Effect.catchAll((error) =>
-					alertAndRecover(body, listingFailureStage(error), error).pipe(
-						Effect.as({ processed: 0, errors: 1 }),
-					),
-				),
-			);
-
-			processed += perListing.processed;
-			errors += perListing.errors;
-		}
-
-		return { processed, errors };
+		return yield* iterateWithAlertRecovery(body, listingsResult.listings, {
+			processItem: (listing) => processFinalsiteListing(body, listing, config),
+			delayBetweenItemsMs: 0,
+			shouldProcess: (listing) => listing.documents.length > 0,
+		});
 	});
 }
 
@@ -517,27 +536,10 @@ function runYouTubeForBody(
 
 		if (!videosResult.ok) return { processed: 0, errors: 1 };
 
-		let processed = 0;
-		let errors = 0;
-
-		for (const video of videosResult.listings) {
-			const perVideo = yield* processYouTubeVideo(body, video, config).pipe(
-				Effect.catchAll((error) =>
-					alertAndRecover(body, listingFailureStage(error), error).pipe(
-						Effect.as({ processed: 0, errors: 1 }),
-					),
-				),
-			);
-
-			processed += perVideo.processed;
-			errors += perVideo.errors;
-
-			if (config.youtubeDelayMs > 0) {
-				yield* Effect.sleep(Duration.millis(config.youtubeDelayMs));
-			}
-		}
-
-		return { processed, errors };
+		return yield* iterateWithAlertRecovery(body, videosResult.listings, {
+			processItem: (video) => processYouTubeVideo(body, video, config),
+			delayBetweenItemsMs: config.youtubeDelayMs,
+		});
 	});
 }
 

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect } from "effect";
+import { Duration, Effect, Schedule } from "effect";
 import {
 	AlertService,
 	formatPipelineErrorAlert,
@@ -30,6 +30,37 @@ import { YouTubeScraper } from "#/pipeline/services/YouTubeScraper.ts";
  * operator sees a stack-level error in the CLI output.
  */
 
+/**
+ * Effect teaching note: Schedule is Effect's policy type for deciding when to
+ * retry. Schedule.exponential starts at the given base delay and doubles on
+ * each retry; Schedule.compose with Schedule.recurs(n) bounds the total number
+ * of attempts. Effect.retry(effect, schedule) wraps transient-failure-prone
+ * operations (network fetches, LLM calls) so that flaky upstreams don't kill
+ * the whole pipeline on the first hiccup.
+ *
+ * Retry policy values come from RunPipelineInput so tests can disable retries
+ * (attempts: 0) and production can tune them without touching this file.
+ *
+ * Retries only help for *transient* failures. A 401 from Gemini won't get
+ * better on retry — it'll just cost more money. The right answer is to tune
+ * these policies based on observed failure modes rather than max them out.
+ */
+type RetryPolicy = {
+	/** Number of additional attempts beyond the first. 0 disables retry. */
+	attempts: number;
+	/** Base delay for the exponential backoff, in milliseconds. */
+	baseDelayMs: number;
+};
+
+const DEFAULT_NETWORK_RETRY: RetryPolicy = { attempts: 3, baseDelayMs: 500 };
+const DEFAULT_LLM_RETRY: RetryPolicy = { attempts: 2, baseDelayMs: 1000 };
+
+function scheduleFromPolicy(policy: RetryPolicy) {
+	return Schedule.exponential(Duration.millis(policy.baseDelayMs)).pipe(
+		Schedule.compose(Schedule.recurs(policy.attempts)),
+	);
+}
+
 type BodyConfig = {
 	slug: string;
 	name: string;
@@ -45,10 +76,27 @@ type RunPipelineInput = {
 	bodies: BodyConfig[];
 	/** Milliseconds to sleep between eGov document downloads. Production: 300_000. */
 	crawlDelayMs: number;
+	/** Milliseconds to sleep between YouTube transcription calls. Production: 2000-5000. */
+	youtubeDelayMs?: number;
 	/** Converts a downloaded PDF (ArrayBuffer) into plain text. */
 	extractPdfText: (bytes: ArrayBuffer) => Promise<string>;
 	/** When true, run all stages except storage and alerts — for smoke-testing. */
 	dryRun: boolean;
+	/** Retry policy for network operations (scrape, download). Defaults to {3, 500ms}. */
+	networkRetry?: RetryPolicy;
+	/** Retry policy for LLM calls (summarize). Defaults to {2, 1000ms}. */
+	llmRetry?: RetryPolicy;
+};
+
+/**
+ * Resolved form of the pipeline input — built once in runPipeline and passed
+ * through to every child so each call site can read the pre-computed schedules
+ * without recomputing them per listing.
+ */
+type ResolvedConfig = RunPipelineInput & {
+	networkSchedule: ReturnType<typeof scheduleFromPolicy>;
+	llmSchedule: ReturnType<typeof scheduleFromPolicy>;
+	youtubeDelayMs: number;
 };
 
 type PipelineResult = {
@@ -73,12 +121,21 @@ function runPipeline(
 	| StorageService
 	| AlertService
 > {
+	const config: ResolvedConfig = {
+		...input,
+		networkSchedule: scheduleFromPolicy(
+			input.networkRetry ?? DEFAULT_NETWORK_RETRY,
+		),
+		llmSchedule: scheduleFromPolicy(input.llmRetry ?? DEFAULT_LLM_RETRY),
+		youtubeDelayMs: input.youtubeDelayMs ?? 2000,
+	};
+
 	return Effect.gen(function* () {
 		let processed = 0;
 		let errors = 0;
 
 		for (const body of input.bodies) {
-			const bodyResult = yield* runPipelineForBody(body, input);
+			const bodyResult = yield* runPipelineForBody(body, config);
 			processed += bodyResult.processed;
 			errors += bodyResult.errors;
 		}
@@ -89,7 +146,7 @@ function runPipeline(
 
 function runPipelineForBody(
 	body: BodyConfig,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	never,
@@ -133,7 +190,7 @@ function runPipelineForBody(
 
 function runEgovForBody(
 	body: BodyConfig & { egovSearchType?: string },
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	never,
@@ -148,6 +205,7 @@ function runEgovForBody(
 		const listingsResult = yield* scraper
 			.scrapeListings({ searchType, page: 1 })
 			.pipe(
+				Effect.retry(config.networkSchedule),
 				Effect.map((listings) => ({ ok: true as const, listings })),
 				Effect.catchAll((error) =>
 					alertAndRecover(body, "scrape", error).pipe(
@@ -185,7 +243,7 @@ function runEgovForBody(
 function processEgovListing(
 	body: BodyConfig,
 	listing: EgovDocumentListing,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	TaggedPipelineError,
@@ -196,7 +254,10 @@ function processEgovListing(
 		const summarizer = yield* SummarizationService;
 		const storage = yield* StorageService;
 
-		const bytes = yield* scraper.downloadDocument(listing.downloadUrl);
+		const bytes = yield* scraper
+			.downloadDocument(listing.downloadUrl)
+			.pipe(Effect.retry(config.networkSchedule));
+
 		const text = yield* Effect.tryPromise({
 			try: () => config.extractPdfText(bytes),
 			catch: (error) =>
@@ -205,10 +266,12 @@ function processEgovListing(
 				}),
 		});
 
-		const summary = yield* summarizer.summarize({
-			sourceText: text,
-			meetingContext: `${body.name}, ${listing.date}`,
-		});
+		const summary = yield* summarizer
+			.summarize({
+				sourceText: text,
+				meetingContext: `${body.name}, ${listing.date}`,
+			})
+			.pipe(Effect.retry(config.llmSchedule));
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 
@@ -244,7 +307,7 @@ function processEgovListing(
 
 function runFinalsiteForBody(
 	body: BodyConfig,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	never,
@@ -254,6 +317,7 @@ function runFinalsiteForBody(
 		const scraper = yield* FinalsiteScraper;
 
 		const listingsResult = yield* scraper.scrapeListings().pipe(
+			Effect.retry(config.networkSchedule),
 			Effect.map((listings) => ({ ok: true as const, listings })),
 			Effect.catchAll((error) =>
 				alertAndRecover(body, "scrape", error).pipe(
@@ -293,7 +357,7 @@ function runFinalsiteForBody(
 function processFinalsiteListing(
 	body: BodyConfig,
 	listing: FinalsiteMeetingListing,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	TaggedPipelineError,
@@ -308,7 +372,10 @@ function processFinalsiteListing(
 		let combinedText = "";
 
 		for (const doc of listing.documents) {
-			const bytes = yield* scraper.downloadDocument(doc.uuid);
+			const bytes = yield* scraper
+				.downloadDocument(doc.uuid)
+				.pipe(Effect.retry(config.networkSchedule));
+
 			const text = yield* Effect.tryPromise({
 				try: () => config.extractPdfText(bytes),
 				catch: (error) =>
@@ -325,10 +392,12 @@ function processFinalsiteListing(
 			combinedText += `\n${text}`;
 		}
 
-		const summary = yield* summarizer.summarize({
-			sourceText: combinedText,
-			meetingContext: `${body.name}, ${listing.date}`,
-		});
+		const summary = yield* summarizer
+			.summarize({
+				sourceText: combinedText,
+				meetingContext: `${body.name}, ${listing.date}`,
+			})
+			.pipe(Effect.retry(config.llmSchedule));
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 
@@ -356,7 +425,7 @@ function processFinalsiteListing(
 
 function runYouTubeForBody(
 	body: BodyConfig,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	never,
@@ -373,6 +442,7 @@ function runYouTubeForBody(
 		const scraper = yield* YouTubeScraper;
 
 		const videosResult = yield* scraper.listPlaylistVideos(playlistId).pipe(
+			Effect.retry(config.networkSchedule),
 			Effect.map((videos) => ({ ok: true as const, videos })),
 			Effect.catchAll((error) =>
 				alertAndRecover(body, "scrape", error).pipe(
@@ -397,6 +467,10 @@ function runYouTubeForBody(
 
 			processed += perVideo.processed;
 			errors += perVideo.errors;
+
+			if (config.youtubeDelayMs > 0) {
+				yield* Effect.sleep(Duration.millis(config.youtubeDelayMs));
+			}
 		}
 
 		return { processed, errors };
@@ -406,7 +480,7 @@ function runYouTubeForBody(
 function processYouTubeVideo(
 	body: BodyConfig,
 	video: YouTubeVideo,
-	config: RunPipelineInput,
+	config: ResolvedConfig,
 ): Effect.Effect<
 	PipelineResult,
 	TaggedPipelineError,
@@ -417,11 +491,16 @@ function processYouTubeVideo(
 		const summarizer = yield* SummarizationService;
 		const storage = yield* StorageService;
 
-		const transcript = yield* transcription.transcribe(video.videoId);
-		const summary = yield* summarizer.summarize({
-			sourceText: transcript.rawText,
-			meetingContext: `${body.name}, ${video.title}`,
-		});
+		const transcript = yield* transcription
+			.transcribe(video.videoId)
+			.pipe(Effect.retry(config.networkSchedule));
+
+		const summary = yield* summarizer
+			.summarize({
+				sourceText: transcript.rawText,
+				meetingContext: `${body.name}, ${video.title}`,
+			})
+			.pipe(Effect.retry(config.llmSchedule));
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 
@@ -561,4 +640,4 @@ function meetingTypeFromFinalsiteLabel(
 }
 
 export { runPipeline };
-export type { BodyConfig, RunPipelineInput, PipelineResult };
+export type { BodyConfig, RunPipelineInput, PipelineResult, RetryPolicy };

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -227,6 +227,41 @@ function runPipelineForBody(
 }
 
 // ---------------------------------------------------------------------------
+// Shared per-source helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Effect teaching note: All three source paths share the same "fetch the
+ * listings or fall through to an alert" pattern. Rather than inline the
+ * Effect.map + Effect.catchAll in every runXForBody function, this helper
+ * takes a pre-composed fetch effect (the caller is responsible for applying
+ * retry, because the retry schedule is scoped to the caller's config) and
+ * returns a discriminated union the caller can switch on.
+ *
+ * The generic `E extends TaggedPipelineError` constraint lets callers pass
+ * scraper-specific error unions (e.g. NetworkError | ParseError) without
+ * casting — the structural overlap with TaggedPipelineError is what matters
+ * for the alertAndRecover call.
+ */
+function fetchListingsOrAlert<T, E extends TaggedPipelineError>(
+	body: BodyConfig,
+	fetchEffect: Effect.Effect<T[], E>,
+): Effect.Effect<
+	{ ok: true; listings: T[] } | { ok: false },
+	never,
+	AlertService
+> {
+	return fetchEffect.pipe(
+		Effect.map((listings) => ({ ok: true as const, listings })),
+		Effect.catchAll((error) =>
+			alertAndRecover(body, "scrape", error).pipe(
+				Effect.as({ ok: false as const }),
+			),
+		),
+	);
+}
+
+// ---------------------------------------------------------------------------
 // eGov path
 // ---------------------------------------------------------------------------
 
@@ -244,17 +279,12 @@ function runEgovForBody(
 
 		const scraper = yield* EgovScraper;
 
-		const listingsResult = yield* scraper
-			.scrapeListings({ searchType, page: 1 })
-			.pipe(
-				Effect.retry(config.networkSchedule),
-				Effect.map((listings) => ({ ok: true as const, listings })),
-				Effect.catchAll((error) =>
-					alertAndRecover(body, "scrape", error).pipe(
-						Effect.as({ ok: false as const }),
-					),
-				),
-			);
+		const listingsResult = yield* fetchListingsOrAlert(
+			body,
+			scraper
+				.scrapeListings({ searchType, page: 1 })
+				.pipe(Effect.retry(config.networkSchedule)),
+		);
 
 		if (!listingsResult.ok) return { processed: 0, errors: 1 };
 
@@ -358,14 +388,9 @@ function runFinalsiteForBody(
 	return Effect.gen(function* () {
 		const scraper = yield* FinalsiteScraper;
 
-		const listingsResult = yield* scraper.scrapeListings().pipe(
-			Effect.retry(config.networkSchedule),
-			Effect.map((listings) => ({ ok: true as const, listings })),
-			Effect.catchAll((error) =>
-				alertAndRecover(body, "scrape", error).pipe(
-					Effect.as({ ok: false as const }),
-				),
-			),
+		const listingsResult = yield* fetchListingsOrAlert(
+			body,
+			scraper.scrapeListings().pipe(Effect.retry(config.networkSchedule)),
 		);
 
 		if (!listingsResult.ok) return { processed: 0, errors: 1 };
@@ -483,14 +508,11 @@ function runYouTubeForBody(
 
 		const scraper = yield* YouTubeScraper;
 
-		const videosResult = yield* scraper.listPlaylistVideos(playlistId).pipe(
-			Effect.retry(config.networkSchedule),
-			Effect.map((videos) => ({ ok: true as const, videos })),
-			Effect.catchAll((error) =>
-				alertAndRecover(body, "scrape", error).pipe(
-					Effect.as({ ok: false as const }),
-				),
-			),
+		const videosResult = yield* fetchListingsOrAlert(
+			body,
+			scraper
+				.listPlaylistVideos(playlistId)
+				.pipe(Effect.retry(config.networkSchedule)),
 		);
 
 		if (!videosResult.ok) return { processed: 0, errors: 1 };
@@ -498,7 +520,7 @@ function runYouTubeForBody(
 		let processed = 0;
 		let errors = 0;
 
-		for (const video of videosResult.videos) {
+		for (const video of videosResult.listings) {
 			const perVideo = yield* processYouTubeVideo(body, video, config).pipe(
 				Effect.catchAll((error) =>
 					alertAndRecover(body, listingFailureStage(error), error).pipe(

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -2,6 +2,7 @@ import { Duration, Effect, Schedule } from "effect";
 import {
 	AlertService,
 	formatPipelineErrorAlert,
+	formatZeroResultsAlert,
 } from "#/pipeline/services/AlertService.ts";
 import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
 import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
@@ -13,6 +14,30 @@ import { SummarizationService } from "#/pipeline/services/SummarizationService.t
 import { TranscriptionService } from "#/pipeline/services/TranscriptionService.ts";
 import type { YouTubeVideo } from "#/pipeline/services/YouTubeScraper.ts";
 import { YouTubeScraper } from "#/pipeline/services/YouTubeScraper.ts";
+
+/** Threshold (in days) beyond which the zero-results anomaly alert fires. */
+const ZERO_RESULTS_THRESHOLD_DAYS = 30;
+const MS_PER_DAY = 1000 * 60 * 60 * 24;
+
+function detectZeroResultsAnomaly(input: {
+	body: BodyConfig;
+	lastMeetingDate: string | null;
+	now: Date;
+}): Effect.Effect<void, never, AlertService> {
+	if (!input.lastMeetingDate) return Effect.void;
+	const lastMs = new Date(input.lastMeetingDate).getTime();
+	const daysSince = Math.floor((input.now.getTime() - lastMs) / MS_PER_DAY);
+	if (daysSince <= ZERO_RESULTS_THRESHOLD_DAYS) return Effect.void;
+
+	const formatted = formatZeroResultsAlert({
+		bodyName: input.body.name,
+		daysSinceLastContent: daysSince,
+	});
+	return Effect.gen(function* () {
+		const alert = yield* AlertService;
+		yield* alert.sendAlert(formatted).pipe(Effect.catchAll(() => Effect.void));
+	});
+}
 
 /**
  * Effect teaching note: The orchestrator is deliberately a plain function
@@ -86,6 +111,8 @@ type RunPipelineInput = {
 	networkRetry?: RetryPolicy;
 	/** Retry policy for LLM calls (summarize). Defaults to {2, 1000ms}. */
 	llmRetry?: RetryPolicy;
+	/** Current time used for zero-results anomaly detection. Defaults to new Date(). */
+	now?: Date;
 };
 
 /**
@@ -97,6 +124,7 @@ type ResolvedConfig = RunPipelineInput & {
 	networkSchedule: ReturnType<typeof scheduleFromPolicy>;
 	llmSchedule: ReturnType<typeof scheduleFromPolicy>;
 	youtubeDelayMs: number;
+	now: Date;
 };
 
 type PipelineResult = {
@@ -128,6 +156,7 @@ function runPipeline(
 		),
 		llmSchedule: scheduleFromPolicy(input.llmRetry ?? DEFAULT_LLM_RETRY),
 		youtubeDelayMs: input.youtubeDelayMs ?? 2000,
+		now: input.now ?? new Date(),
 	};
 
 	return Effect.gen(function* () {
@@ -159,6 +188,19 @@ function runPipelineForBody(
 	| AlertService
 > {
 	return Effect.gen(function* () {
+		// Zero-results anomaly check: alert if this body hasn't had fresh content
+		// in more than 30 days, *before* we run the pipeline that might confirm
+		// the gap. Silently skips on DatabaseError so the run continues regardless.
+		const storage = yield* StorageService;
+		const lastMeetingDate = yield* storage
+			.getMostRecentMeetingDate(body.slug)
+			.pipe(Effect.catchAll(() => Effect.succeed(null)));
+		yield* detectZeroResultsAnomaly({
+			body,
+			lastMeetingDate,
+			now: config.now,
+		});
+
 		let processed = 0;
 		let errors = 0;
 

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,0 +1,564 @@
+import { Duration, Effect } from "effect";
+import {
+	AlertService,
+	formatPipelineErrorAlert,
+} from "#/pipeline/services/AlertService.ts";
+import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
+import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
+import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
+import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
+import type { MeetingInput } from "#/pipeline/services/StorageService.ts";
+import { StorageService } from "#/pipeline/services/StorageService.ts";
+import { SummarizationService } from "#/pipeline/services/SummarizationService.ts";
+import { TranscriptionService } from "#/pipeline/services/TranscriptionService.ts";
+import type { YouTubeVideo } from "#/pipeline/services/YouTubeScraper.ts";
+import { YouTubeScraper } from "#/pipeline/services/YouTubeScraper.ts";
+
+/**
+ * Effect teaching note: The orchestrator is deliberately a plain function
+ * that returns an Effect — not its own Context.Tag service. There's only one
+ * implementation, and it composes other services via their Tags, so the
+ * orchestrator's "requirements" are exactly the union of all its callees'
+ * Tags. You can see this in the return type: the `R` (requirements)
+ * parameter of `Effect.Effect<A, E, R>` is the union of every service it
+ * pulls from context.
+ *
+ * Per-listing errors are handled inline with `Effect.catchAll` → alert →
+ * continue, rather than bubbling up. That's a deliberate choice: a broken
+ * listing for one body should not stop the whole pipeline. Fatal failures
+ * (e.g. scraping the initial listing page) still fail the body loop so the
+ * operator sees a stack-level error in the CLI output.
+ */
+
+type BodyConfig = {
+	slug: string;
+	name: string;
+	/** eGov document-center search type id (e.g. "12" for minutes). */
+	egovSearchType?: string;
+	/** Full Finalsite page URL (e.g. https://www.rbbschools.net/school-board). */
+	finalsiteUrl?: string;
+	/** YouTube playlist ID for the body's meeting recordings. */
+	youtubePlaylistId?: string;
+};
+
+type RunPipelineInput = {
+	bodies: BodyConfig[];
+	/** Milliseconds to sleep between eGov document downloads. Production: 300_000. */
+	crawlDelayMs: number;
+	/** Converts a downloaded PDF (ArrayBuffer) into plain text. */
+	extractPdfText: (bytes: ArrayBuffer) => Promise<string>;
+	/** When true, run all stages except storage and alerts — for smoke-testing. */
+	dryRun: boolean;
+};
+
+type PipelineResult = {
+	processed: number;
+	errors: number;
+};
+
+/**
+ * Runs the full 5-stage pipeline (scrape → extract → transcribe → summarize
+ * → store) for each configured body, in sequence.
+ */
+function runPipeline(
+	input: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	never,
+	| EgovScraper
+	| FinalsiteScraper
+	| YouTubeScraper
+	| TranscriptionService
+	| SummarizationService
+	| StorageService
+	| AlertService
+> {
+	return Effect.gen(function* () {
+		let processed = 0;
+		let errors = 0;
+
+		for (const body of input.bodies) {
+			const bodyResult = yield* runPipelineForBody(body, input);
+			processed += bodyResult.processed;
+			errors += bodyResult.errors;
+		}
+
+		return { processed, errors };
+	});
+}
+
+function runPipelineForBody(
+	body: BodyConfig,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	never,
+	| EgovScraper
+	| FinalsiteScraper
+	| YouTubeScraper
+	| TranscriptionService
+	| SummarizationService
+	| StorageService
+	| AlertService
+> {
+	return Effect.gen(function* () {
+		let processed = 0;
+		let errors = 0;
+
+		if (body.egovSearchType) {
+			const egovResult = yield* runEgovForBody(body, config);
+			processed += egovResult.processed;
+			errors += egovResult.errors;
+		}
+
+		if (body.finalsiteUrl) {
+			const finalsiteResult = yield* runFinalsiteForBody(body, config);
+			processed += finalsiteResult.processed;
+			errors += finalsiteResult.errors;
+		}
+
+		if (body.youtubePlaylistId) {
+			const youtubeResult = yield* runYouTubeForBody(body, config);
+			processed += youtubeResult.processed;
+			errors += youtubeResult.errors;
+		}
+
+		return { processed, errors };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// eGov path
+// ---------------------------------------------------------------------------
+
+function runEgovForBody(
+	body: BodyConfig & { egovSearchType?: string },
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	never,
+	EgovScraper | SummarizationService | StorageService | AlertService
+> {
+	return Effect.gen(function* () {
+		const searchType = body.egovSearchType;
+		if (!searchType) return { processed: 0, errors: 0 };
+
+		const scraper = yield* EgovScraper;
+
+		const listingsResult = yield* scraper
+			.scrapeListings({ searchType, page: 1 })
+			.pipe(
+				Effect.map((listings) => ({ ok: true as const, listings })),
+				Effect.catchAll((error) =>
+					alertAndRecover(body, "scrape", error).pipe(
+						Effect.as({ ok: false as const }),
+					),
+				),
+			);
+
+		if (!listingsResult.ok) return { processed: 0, errors: 1 };
+
+		let processed = 0;
+		let errors = 0;
+
+		for (const listing of listingsResult.listings) {
+			const perListing = yield* processEgovListing(body, listing, config).pipe(
+				Effect.catchAll((error) =>
+					alertAndRecover(body, listingFailureStage(error), error).pipe(
+						Effect.as({ processed: 0, errors: 1 }),
+					),
+				),
+			);
+
+			processed += perListing.processed;
+			errors += perListing.errors;
+
+			if (config.crawlDelayMs > 0) {
+				yield* Effect.sleep(Duration.millis(config.crawlDelayMs));
+			}
+		}
+
+		return { processed, errors };
+	});
+}
+
+function processEgovListing(
+	body: BodyConfig,
+	listing: EgovDocumentListing,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	TaggedPipelineError,
+	EgovScraper | SummarizationService | StorageService
+> {
+	return Effect.gen(function* () {
+		const scraper = yield* EgovScraper;
+		const summarizer = yield* SummarizationService;
+		const storage = yield* StorageService;
+
+		const bytes = yield* scraper.downloadDocument(listing.downloadUrl);
+		const text = yield* Effect.tryPromise({
+			try: () => config.extractPdfText(bytes),
+			catch: (error) =>
+				new PipelineExtractError({
+					message: error instanceof Error ? error.message : String(error),
+				}),
+		});
+
+		const summary = yield* summarizer.summarize({
+			sourceText: text,
+			meetingContext: `${body.name}, ${listing.date}`,
+		});
+
+		if (config.dryRun) return { processed: 1, errors: 0 };
+
+		const meetingInput: MeetingInput = {
+			bodySlug: body.slug,
+			date: normalizeEgovDate(listing.date),
+			meetingType: "regular",
+			documents: [
+				{
+					sourceUrl: listing.downloadUrl,
+					rawText: text,
+					documentType: "minutes",
+				},
+			],
+			summary: {
+				highlights: summary.highlights,
+				prose: summary.prose,
+				model: summary.model,
+			},
+			fiscalDecisions: summary.fiscalDecisions,
+			budgetDiscussions: summary.budgetDiscussions,
+		};
+
+		yield* storage.storeMeeting(meetingInput);
+
+		return { processed: 1, errors: 0 };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Finalsite path
+// ---------------------------------------------------------------------------
+
+function runFinalsiteForBody(
+	body: BodyConfig,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	never,
+	FinalsiteScraper | SummarizationService | StorageService | AlertService
+> {
+	return Effect.gen(function* () {
+		const scraper = yield* FinalsiteScraper;
+
+		const listingsResult = yield* scraper.scrapeListings().pipe(
+			Effect.map((listings) => ({ ok: true as const, listings })),
+			Effect.catchAll((error) =>
+				alertAndRecover(body, "scrape", error).pipe(
+					Effect.as({ ok: false as const }),
+				),
+			),
+		);
+
+		if (!listingsResult.ok) return { processed: 0, errors: 1 };
+
+		let processed = 0;
+		let errors = 0;
+
+		for (const listing of listingsResult.listings) {
+			if (listing.documents.length === 0) continue;
+
+			const perListing = yield* processFinalsiteListing(
+				body,
+				listing,
+				config,
+			).pipe(
+				Effect.catchAll((error) =>
+					alertAndRecover(body, listingFailureStage(error), error).pipe(
+						Effect.as({ processed: 0, errors: 1 }),
+					),
+				),
+			);
+
+			processed += perListing.processed;
+			errors += perListing.errors;
+		}
+
+		return { processed, errors };
+	});
+}
+
+function processFinalsiteListing(
+	body: BodyConfig,
+	listing: FinalsiteMeetingListing,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	TaggedPipelineError,
+	FinalsiteScraper | SummarizationService | StorageService
+> {
+	return Effect.gen(function* () {
+		const scraper = yield* FinalsiteScraper;
+		const summarizer = yield* SummarizationService;
+		const storage = yield* StorageService;
+
+		const documents: MeetingInput["documents"] = [];
+		let combinedText = "";
+
+		for (const doc of listing.documents) {
+			const bytes = yield* scraper.downloadDocument(doc.uuid);
+			const text = yield* Effect.tryPromise({
+				try: () => config.extractPdfText(bytes),
+				catch: (error) =>
+					new PipelineExtractError({
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			});
+			documents.push({
+				sourceUrl: doc.downloadUrl,
+				rawText: text,
+				documentType:
+					doc.documentType === "notice" ? "agenda" : doc.documentType,
+			});
+			combinedText += `\n${text}`;
+		}
+
+		const summary = yield* summarizer.summarize({
+			sourceText: combinedText,
+			meetingContext: `${body.name}, ${listing.date}`,
+		});
+
+		if (config.dryRun) return { processed: 1, errors: 0 };
+
+		yield* storage.storeMeeting({
+			bodySlug: body.slug,
+			date: normalizeFinalsiteDate(listing.date, listing.year),
+			meetingType: meetingTypeFromFinalsiteLabel(listing.meetingType),
+			documents,
+			summary: {
+				highlights: summary.highlights,
+				prose: summary.prose,
+				model: summary.model,
+			},
+			fiscalDecisions: summary.fiscalDecisions,
+			budgetDiscussions: summary.budgetDiscussions,
+		});
+
+		return { processed: 1, errors: 0 };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// YouTube path
+// ---------------------------------------------------------------------------
+
+function runYouTubeForBody(
+	body: BodyConfig,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	never,
+	| YouTubeScraper
+	| TranscriptionService
+	| SummarizationService
+	| StorageService
+	| AlertService
+> {
+	return Effect.gen(function* () {
+		const playlistId = body.youtubePlaylistId;
+		if (!playlistId) return { processed: 0, errors: 0 };
+
+		const scraper = yield* YouTubeScraper;
+
+		const videosResult = yield* scraper.listPlaylistVideos(playlistId).pipe(
+			Effect.map((videos) => ({ ok: true as const, videos })),
+			Effect.catchAll((error) =>
+				alertAndRecover(body, "scrape", error).pipe(
+					Effect.as({ ok: false as const }),
+				),
+			),
+		);
+
+		if (!videosResult.ok) return { processed: 0, errors: 1 };
+
+		let processed = 0;
+		let errors = 0;
+
+		for (const video of videosResult.videos) {
+			const perVideo = yield* processYouTubeVideo(body, video, config).pipe(
+				Effect.catchAll((error) =>
+					alertAndRecover(body, listingFailureStage(error), error).pipe(
+						Effect.as({ processed: 0, errors: 1 }),
+					),
+				),
+			);
+
+			processed += perVideo.processed;
+			errors += perVideo.errors;
+		}
+
+		return { processed, errors };
+	});
+}
+
+function processYouTubeVideo(
+	body: BodyConfig,
+	video: YouTubeVideo,
+	config: RunPipelineInput,
+): Effect.Effect<
+	PipelineResult,
+	TaggedPipelineError,
+	TranscriptionService | SummarizationService | StorageService
+> {
+	return Effect.gen(function* () {
+		const transcription = yield* TranscriptionService;
+		const summarizer = yield* SummarizationService;
+		const storage = yield* StorageService;
+
+		const transcript = yield* transcription.transcribe(video.videoId);
+		const summary = yield* summarizer.summarize({
+			sourceText: transcript.rawText,
+			meetingContext: `${body.name}, ${video.title}`,
+		});
+
+		if (config.dryRun) return { processed: 1, errors: 0 };
+
+		const meeting = yield* storage.storeMeeting({
+			bodySlug: body.slug,
+			date: video.publishedAt.slice(0, 10),
+			meetingType: "regular",
+			documents: [],
+			summary: {
+				highlights: summary.highlights,
+				prose: summary.prose,
+				model: summary.model,
+			},
+			fiscalDecisions: summary.fiscalDecisions,
+			budgetDiscussions: summary.budgetDiscussions,
+		});
+
+		yield* storage.storeTranscript({
+			meetingId: meeting.id,
+			source: transcript.source,
+			rawText: transcript.rawText,
+			segments: transcript.segments,
+			sourceUrl: `https://www.youtube.com/watch?v=${video.videoId}`,
+		});
+
+		return { processed: 1, errors: 0 };
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Error + alert plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * Marker for the "PDF extraction" stage — this is the one stage whose
+ * failure can't come from the services themselves (they return NetworkError,
+ * LlmError, etc). Having a dedicated tag lets `alertAndRecover` pattern-match
+ * on it the same way it handles the service errors.
+ */
+class PipelineExtractError {
+	readonly _tag = "PipelineExtractError";
+	readonly message: string;
+	constructor(input: { message: string }) {
+		this.message = input.message;
+	}
+}
+
+type TaggedPipelineError =
+	| { readonly _tag: "NetworkError"; readonly message: string }
+	| { readonly _tag: "ParseError"; readonly message: string }
+	| { readonly _tag: "TranscriptionError"; readonly message: string }
+	| { readonly _tag: "LlmError"; readonly message: string }
+	| { readonly _tag: "DatabaseError"; readonly message: string }
+	| PipelineExtractError;
+
+function listingFailureStage(error: TaggedPipelineError): string {
+	switch (error._tag) {
+		case "NetworkError":
+			return "download";
+		case "ParseError":
+			return "extract";
+		case "PipelineExtractError":
+			return "extract";
+		case "TranscriptionError":
+			return "transcribe";
+		case "LlmError":
+			return "summarize";
+		case "DatabaseError":
+			return "store";
+		default:
+			return "unknown";
+	}
+}
+
+function alertAndRecover(
+	body: BodyConfig,
+	stage: string,
+	error: TaggedPipelineError,
+): Effect.Effect<void, never, AlertService> {
+	return Effect.gen(function* () {
+		const alert = yield* AlertService;
+		const formatted = formatPipelineErrorAlert({
+			stage,
+			bodyName: body.name,
+			errorTag: error._tag,
+			errorMessage: error.message,
+		});
+		yield* alert.sendAlert(formatted).pipe(Effect.catchAll(() => Effect.void));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Date normalization
+// ---------------------------------------------------------------------------
+
+/** Converts eGov "MM/DD/YYYY" to ISO "YYYY-MM-DD". */
+function normalizeEgovDate(mmddyyyy: string): string {
+	const parts = mmddyyyy.split("/");
+	if (parts.length !== 3) return mmddyyyy;
+	const [month, day, year] = parts;
+	return `${year}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`;
+}
+
+const MONTHS: Record<string, string> = {
+	january: "01",
+	february: "02",
+	march: "03",
+	april: "04",
+	may: "05",
+	june: "06",
+	july: "07",
+	august: "08",
+	september: "09",
+	october: "10",
+	november: "11",
+	december: "12",
+};
+
+/** Converts Finalsite "Month Day, Year" (e.g. "January 6, 2026") to ISO. */
+function normalizeFinalsiteDate(label: string, year: number): string {
+	const match = label.match(/^(\w+)\s+(\d+),?\s*(\d+)?$/);
+	if (!match) return `${year}-01-01`;
+	const monthName = match[1].toLowerCase();
+	const day = match[2].padStart(2, "0");
+	const parsedYear = match[3] ? Number(match[3]) : year;
+	const month = MONTHS[monthName] ?? "01";
+	return `${parsedYear}-${month}-${day}`;
+}
+
+function meetingTypeFromFinalsiteLabel(
+	label: string,
+): "regular" | "special" | "workshop" {
+	const lower = label.toLowerCase();
+	if (lower.includes("special")) return "special";
+	if (lower.includes("workshop")) return "workshop";
+	return "regular";
+}
+
+export { runPipeline };
+export type { BodyConfig, RunPipelineInput, PipelineResult };

--- a/src/pipeline/services/AlertService.test.ts
+++ b/src/pipeline/services/AlertService.test.ts
@@ -1,0 +1,119 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	AlertService,
+	AlertServiceLive,
+	formatPipelineErrorAlert,
+	formatZeroResultsAlert,
+} from "./AlertService.ts";
+
+describe("AlertService", () => {
+	describe("formatZeroResultsAlert", () => {
+		it("builds a subject and body naming the body and days", () => {
+			const alert = formatZeroResultsAlert({
+				bodyName: "Ellettsville Town Council",
+				daysSinceLastContent: 42,
+			});
+
+			expect(alert.subject).toContain("Ellettsville Town Council");
+			expect(alert.subject.toLowerCase()).toContain("no new");
+			expect(alert.body).toContain("42");
+			expect(alert.body).toContain("Ellettsville Town Council");
+		});
+	});
+
+	describe("formatPipelineErrorAlert", () => {
+		it("includes the stage and error message in the body", () => {
+			const alert = formatPipelineErrorAlert({
+				stage: "summarize",
+				bodyName: "Plan Commission",
+				errorTag: "LlmError",
+				errorMessage: "quota exceeded",
+			});
+
+			expect(alert.subject).toContain("summarize");
+			expect(alert.body).toContain("Plan Commission");
+			expect(alert.body).toContain("LlmError");
+			expect(alert.body).toContain("quota exceeded");
+		});
+	});
+
+	describe("AlertServiceLive", () => {
+		it("sends alert via injected sendFn", async () => {
+			const sent: Array<{ to: string; subject: string; body: string }> = [];
+
+			const program = Effect.gen(function* () {
+				const service = yield* AlertService;
+				yield* service.sendAlert({
+					subject: "Test Alert",
+					body: "Something happened.",
+				});
+			}).pipe(
+				Effect.provide(
+					AlertServiceLive({
+						to: "alerts@example.com",
+						from: "civic-mirror@example.com",
+						sendFn: async (input) => {
+							sent.push(input);
+						},
+					}),
+				),
+			);
+
+			await Effect.runPromise(program);
+
+			expect(sent).toHaveLength(1);
+			expect(sent[0].to).toBe("alerts@example.com");
+			expect(sent[0].subject).toBe("Test Alert");
+			expect(sent[0].body).toBe("Something happened.");
+		});
+
+		it("returns NetworkError when the send function throws", async () => {
+			const program = Effect.gen(function* () {
+				const service = yield* AlertService;
+				yield* service.sendAlert({
+					subject: "Test",
+					body: "Body",
+				});
+			}).pipe(
+				Effect.provide(
+					AlertServiceLive({
+						to: "alerts@example.com",
+						from: "civic-mirror@example.com",
+						sendFn: async () => {
+							throw new Error("Resend API 500");
+						},
+					}),
+				),
+			);
+
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
+			expect(error.message).toContain("Resend API 500");
+		});
+
+		it("passes the configured from address to sendFn", async () => {
+			const sent: Array<{ to: string; from: string }> = [];
+
+			const program = Effect.gen(function* () {
+				const service = yield* AlertService;
+				yield* service.sendAlert({ subject: "x", body: "y" });
+			}).pipe(
+				Effect.provide(
+					AlertServiceLive({
+						to: "ops@example.com",
+						from: "alerts@civic-mirror.dev",
+						sendFn: async (input) => {
+							sent.push({ to: input.to, from: input.from });
+						},
+					}),
+				),
+			);
+
+			await Effect.runPromise(program);
+
+			expect(sent[0].from).toBe("alerts@civic-mirror.dev");
+			expect(sent[0].to).toBe("ops@example.com");
+		});
+	});
+});

--- a/src/pipeline/services/AlertService.ts
+++ b/src/pipeline/services/AlertService.ts
@@ -1,0 +1,123 @@
+import { Context, Effect, Layer } from "effect";
+import { NetworkError } from "#/pipeline/errors.ts";
+
+/**
+ * Effect teaching note: AlertService is deliberately kept thin. It knows how
+ * to *send* an alert — nothing more. The orchestrator decides *when* to send
+ * one (error propagation, zero-results detection) and builds the subject and
+ * body using the format helpers exported below.
+ *
+ * This keeps the service single-responsibility and mockable: tests swap in a
+ * `sendFn` that pushes to an array, production wires up Resend. No Resend-
+ * specific knowledge leaks into the orchestrator.
+ */
+
+type AlertInput = {
+	subject: string;
+	body: string;
+};
+
+interface AlertServiceInterface {
+	sendAlert(input: AlertInput): Effect.Effect<void, NetworkError>;
+}
+
+class AlertService extends Context.Tag("AlertService")<
+	AlertService,
+	AlertServiceInterface
+>() {}
+
+type AlertSendFn = (input: {
+	to: string;
+	from: string;
+	subject: string;
+	body: string;
+}) => Promise<void>;
+
+type AlertServiceConfig = {
+	/** Recipient address — typically the developer's operational inbox. */
+	to: string;
+	/** From address — must be a verified sender on Resend. */
+	from: string;
+	/** Async send function; defaults to undefined so tests force injection. */
+	sendFn: AlertSendFn;
+};
+
+/**
+ * Layer that wraps the injected send function in Effect.tryPromise so any
+ * thrown exception becomes a typed NetworkError. Callers never see raw
+ * Resend errors — they see the same NetworkError shape the scrapers produce,
+ * which lets Effect.catchTag handlers treat all network failures uniformly.
+ */
+function AlertServiceLive(
+	config: AlertServiceConfig,
+): Layer.Layer<AlertService> {
+	return Layer.succeed(AlertService, {
+		sendAlert: (input) =>
+			Effect.tryPromise({
+				try: () =>
+					config.sendFn({
+						to: config.to,
+						from: config.from,
+						subject: input.subject,
+						body: input.body,
+					}),
+				catch: (error) =>
+					new NetworkError({
+						url: "resend:send",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+/**
+ * Builds a subject + body pair for the 30-day zero-results anomaly. The
+ * orchestrator detects the anomaly by querying when the body last had new
+ * content stored; this helper turns that information into an operator email.
+ */
+function formatZeroResultsAlert(input: {
+	bodyName: string;
+	daysSinceLastContent: number;
+}): AlertInput {
+	return {
+		subject: `[Civic Mirror] No new content for ${input.bodyName}`,
+		body: [
+			`${input.bodyName} has had no new documents or videos ingested in ${input.daysSinceLastContent} days.`,
+			"",
+			"This may indicate a scraper regression, a source site change, or a genuine gap in public meetings.",
+			"",
+			"Check the pipeline logs and verify the upstream source.",
+		].join("\n"),
+	};
+}
+
+/**
+ * Builds a subject + body pair for a pipeline-stage failure. Used by the
+ * orchestrator's error boundary when a stage fails for a specific body.
+ */
+function formatPipelineErrorAlert(input: {
+	stage: string;
+	bodyName: string;
+	errorTag: string;
+	errorMessage: string;
+}): AlertInput {
+	return {
+		subject: `[Civic Mirror] ${input.stage} failed for ${input.bodyName}`,
+		body: [
+			`Pipeline stage "${input.stage}" failed while processing ${input.bodyName}.`,
+			"",
+			`Error: ${input.errorTag}`,
+			`Message: ${input.errorMessage}`,
+			"",
+			"The pipeline will continue with other bodies; this body was skipped.",
+		].join("\n"),
+	};
+}
+
+export {
+	AlertService,
+	AlertServiceLive,
+	formatZeroResultsAlert,
+	formatPipelineErrorAlert,
+};
+export type { AlertInput, AlertSendFn, AlertServiceConfig };

--- a/src/pipeline/services/GeminiSummarizer.ts
+++ b/src/pipeline/services/GeminiSummarizer.ts
@@ -1,0 +1,79 @@
+import { google } from "@ai-sdk/google";
+import { generateText, Output } from "ai";
+import type {
+	SummarizationGenerateFn,
+	SummarizationInput,
+	SummarizationOutput,
+} from "./SummarizationService.ts";
+import { summarizationOutputSchema } from "./SummarizationService.ts";
+
+/**
+ * Effect teaching note: This file is the boundary between the Effect world
+ * and the Vercel AI SDK. It's deliberately kept out of SummarizationService.ts
+ * so that the service module has no transitive dependency on @ai-sdk/google
+ * at import time — tests can import SummarizationService without pulling in
+ * the AI SDK and paying its module-load cost.
+ *
+ * `createGeminiSummarizer` returns a plain async function that matches the
+ * `SummarizationGenerateFn` contract. The orchestrator injects this into
+ * `SummarizationServiceLive` in production; tests inject a stub instead.
+ */
+
+type GeminiSummarizerConfig = {
+	/** Gemini model ID (e.g. "gemini-2.5-flash"). */
+	modelId: string;
+};
+
+const SYSTEM_INSTRUCTIONS = `
+You are a civic journalism assistant summarizing local government meeting records for a public transparency website.
+
+Your job is to extract a factual, neutral summary of what happened in the meeting, plus structured fiscal decisions where money was discussed or voted on.
+
+CRITICAL RULES:
+1. Only extract fiscal decisions that were formally moved, seconded, or voted on. Do not include historical spending references or "we spent X last year" mentions.
+2. For each fiscal decision, include the exact originalAmount string as it appears in the source (e.g. "$50,000" not "50000").
+3. For items that were discussed with dollar amounts but NOT voted on, put them in budgetDiscussions instead of fiscalDecisions.
+4. Set confidence (0.0-1.0) based on how clear the decision was. A clear motion and vote = 0.9+. Ambiguous discussion = 0.5-0.7.
+5. Set isRecurring true only for ongoing obligations (utility payments, salaries). One-time purchases are false.
+6. Do not editorialize. Report what the record says, not what you think of it.
+`.trim();
+
+function buildPrompt(input: SummarizationInput): string {
+	return `
+Meeting context: ${input.meetingContext}
+
+Source text (meeting minutes or transcript):
+---
+${input.sourceText}
+---
+
+Produce a structured summary of this meeting.
+`.trim();
+}
+
+/**
+ * Builds a SummarizationGenerateFn backed by Gemini via @ai-sdk/google.
+ *
+ * The Google provider reads GOOGLE_GENERATIVE_AI_API_KEY from the environment
+ * automatically, so no API key is passed here. Callers construct this in the
+ * CLI entry point where env config is loaded via dotenv, and pass the result
+ * into SummarizationServiceLive.
+ */
+function createGeminiSummarizer(
+	config: GeminiSummarizerConfig,
+): SummarizationGenerateFn {
+	return async (input: SummarizationInput): Promise<SummarizationOutput> => {
+		const { experimental_output } = await generateText({
+			model: google(config.modelId),
+			system: SYSTEM_INSTRUCTIONS,
+			prompt: buildPrompt(input),
+			experimental_output: Output.object({
+				schema: summarizationOutputSchema,
+			}),
+		});
+		return experimental_output;
+	};
+}
+
+export { createGeminiSummarizer };
+export type { GeminiSummarizerConfig };

--- a/src/pipeline/services/ScraperService.test.ts
+++ b/src/pipeline/services/ScraperService.test.ts
@@ -1,5 +1,10 @@
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { parseEgovListingHtml } from "./ScraperService.ts";
+import {
+	EgovScraper,
+	EgovScraperLive,
+	parseEgovListingHtml,
+} from "./ScraperService.ts";
 
 // Real HTML structure from ellettsville.in.us eGov document center
 const EGOV_HTML_FIXTURE = `
@@ -84,6 +89,98 @@ describe("EgovScraper", () => {
 		it("returns empty array for HTML with no document rows", () => {
 			const results = parseEgovListingHtml("<table></table>");
 			expect(results).toEqual([]);
+		});
+	});
+
+	describe("EgovScraperLive", () => {
+		const baseUrl = "https://ellettsville.in.us/egov/apps/document/center.egov";
+
+		it("fetches a listing page and returns parsed documents", async () => {
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				const s = String(url);
+				if (s.includes("eGov_searchType=12") && s.includes("page=4_1")) {
+					return new Response(EGOV_HTML_FIXTURE, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* EgovScraper;
+				return yield* scraper.scrapeListings({
+					searchType: "12",
+					page: 1,
+				});
+			}).pipe(Effect.provide(EgovScraperLive({ baseUrl, fetchFn: mockFetch })));
+
+			const results = await Effect.runPromise(program);
+			expect(results).toHaveLength(3);
+			expect(results[0].id).toBe(1653);
+			expect(results[0].title).toBe(
+				"Reorganization Board Meeting February 4, 2026 Minutes Approved",
+			);
+		});
+
+		it("returns NetworkError when listing fetch fails with non-OK status", async () => {
+			const mockFetch: typeof globalThis.fetch = async () =>
+				new Response("Server Error", { status: 500 });
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* EgovScraper;
+				return yield* scraper.scrapeListings({ searchType: "12", page: 1 });
+			}).pipe(Effect.provide(EgovScraperLive({ baseUrl, fetchFn: mockFetch })));
+
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
+		});
+
+		it("returns NetworkError when listing fetch throws", async () => {
+			const mockFetch: typeof globalThis.fetch = async () => {
+				throw new Error("Connection refused");
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* EgovScraper;
+				return yield* scraper.scrapeListings({ searchType: "12", page: 1 });
+			}).pipe(Effect.provide(EgovScraperLive({ baseUrl, fetchFn: mockFetch })));
+
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
+			expect(error.message).toContain("Connection refused");
+		});
+
+		it("downloads a document by URL", async () => {
+			const pdfBytes = new Uint8Array([0x25, 0x50, 0x44, 0x46]); // %PDF
+			const mockFetch: typeof globalThis.fetch = async (url) => {
+				if (String(url).includes("view=item&id=1653")) {
+					return new Response(pdfBytes, { status: 200 });
+				}
+				return new Response("Not Found", { status: 404 });
+			};
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* EgovScraper;
+				return yield* scraper.downloadDocument(
+					"https://ellettsville.in.us/egov/apps/document/center.egov?view=item&id=1653",
+				);
+			}).pipe(Effect.provide(EgovScraperLive({ baseUrl, fetchFn: mockFetch })));
+
+			const result = await Effect.runPromise(program);
+			expect(new Uint8Array(result)).toEqual(pdfBytes);
+		});
+
+		it("returns NetworkError when document download fails", async () => {
+			const mockFetch: typeof globalThis.fetch = async () =>
+				new Response("Not Found", { status: 404 });
+
+			const program = Effect.gen(function* () {
+				const scraper = yield* EgovScraper;
+				return yield* scraper.downloadDocument(
+					"https://ellettsville.in.us/egov/apps/document/center.egov?view=item&id=9999",
+				);
+			}).pipe(Effect.provide(EgovScraperLive({ baseUrl, fetchFn: mockFetch })));
+
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("NetworkError");
 		});
 	});
 });

--- a/src/pipeline/services/ScraperService.ts
+++ b/src/pipeline/services/ScraperService.ts
@@ -1,4 +1,6 @@
+import { Context, Effect, Layer } from "effect";
 import { JSDOM } from "jsdom";
+import { NetworkError, ParseError } from "#/pipeline/errors.ts";
 
 /**
  * A single document listing extracted from the eGov document center.
@@ -62,5 +64,112 @@ function parseEgovListingHtml(html: string): EgovDocumentListing[] {
 	return results;
 }
 
-export { parseEgovListingHtml };
-export type { EgovDocumentListing };
+/**
+ * Effect teaching note: This is the third implementation of a scraper service —
+ * completing the trio alongside FinalsiteScraper and YouTubeScraper. All three
+ * follow the same Context.Tag + Layer.succeed pattern with an injected fetchFn,
+ * but each has its own service tag so consumers can depend on them independently.
+ *
+ * EgovScraper is kept deliberately minimal: it fetches pages and downloads
+ * documents, nothing else. Crawl-delay enforcement (the eGov 300-second rule)
+ * lives in the orchestrator — that's where request ordering is known and where
+ * `Effect.sleep` + `Schedule` can space out the per-document downloads without
+ * this service having to track its own request state.
+ */
+
+type EgovScrapeListingsInput = {
+	/** eGov search type code: "11" = agendas, "12" = minutes, "19" = ordinances. */
+	searchType: string;
+	/** 1-indexed page number within the listing. */
+	page: number;
+};
+
+interface EgovScraperInterface {
+	/** Fetch one listing page from the eGov document center and return parsed rows. */
+	scrapeListings(
+		input: EgovScrapeListingsInput,
+	): Effect.Effect<EgovDocumentListing[], NetworkError | ParseError>;
+	/** Download a document's raw bytes from its full eGov URL. */
+	downloadDocument(url: string): Effect.Effect<ArrayBuffer, NetworkError>;
+}
+
+class EgovScraper extends Context.Tag("EgovScraper")<
+	EgovScraper,
+	EgovScraperInterface
+>() {}
+
+type EgovScraperConfig = {
+	/** Base URL for the eGov document center (e.g. https://ellettsville.in.us/egov/apps/document/center.egov). */
+	baseUrl: string;
+	/** Injectable fetch function for testability. */
+	fetchFn?: typeof globalThis.fetch;
+};
+
+/**
+ * Effect teaching note: `Layer.succeed` provides the service value directly.
+ * Each method wraps its fetch call in `Effect.tryPromise`, converting any
+ * thrown exceptions or non-OK responses into typed `NetworkError` values.
+ * Separating the scrape (fetch) from the parse (pure) lets the service return
+ * a `ParseError` distinct from a `NetworkError`, so the orchestrator can
+ * choose different recovery paths for each (e.g. retry network errors,
+ * skip+alert on parse errors).
+ */
+function EgovScraperLive(config: EgovScraperConfig): Layer.Layer<EgovScraper> {
+	const fetchFn = config.fetchFn ?? globalThis.fetch;
+
+	return Layer.succeed(EgovScraper, {
+		scrapeListings: ({ searchType, page }) =>
+			Effect.gen(function* () {
+				const url = new URL(config.baseUrl);
+				url.searchParams.set("app", "4");
+				url.searchParams.set("sect", "content");
+				url.searchParams.set("page", `4_${page}`);
+				url.searchParams.set("eGov_searchType", searchType);
+
+				const html = yield* Effect.tryPromise({
+					try: async () => {
+						const response = await fetchFn(url.toString());
+						if (!response.ok) {
+							throw new Error(
+								`HTTP ${response.status}: ${response.statusText}`,
+							);
+						}
+						return response.text();
+					},
+					catch: (error) =>
+						new NetworkError({
+							url: url.toString(),
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+
+				return yield* Effect.try({
+					try: () => parseEgovListingHtml(html),
+					catch: (error) =>
+						new ParseError({
+							source: "egov",
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+			}),
+
+		downloadDocument: (url) =>
+			Effect.tryPromise({
+				try: async () => {
+					const response = await fetchFn(url);
+					if (!response.ok) {
+						throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+					}
+					return response.arrayBuffer();
+				},
+				catch: (error) =>
+					new NetworkError({
+						url,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+export { parseEgovListingHtml, EgovScraper, EgovScraperLive };
+export type { EgovDocumentListing, EgovScraperConfig, EgovScrapeListingsInput };

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -202,6 +202,65 @@ describe("StorageService", () => {
 		});
 	});
 
+	describe("getMostRecentMeetingDate", () => {
+		it("returns the ISO date of the most recent meeting for a body", async () => {
+			const db = await createTestDb();
+			const layer = StorageServiceLive(db);
+
+			// Store two meetings for the same body, different dates
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					yield* storage.storeMeeting({
+						...testMeetingInput,
+						date: "2026-01-15",
+					});
+					yield* storage.storeMeeting({
+						...testMeetingInput,
+						date: "2026-03-23",
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.getMostRecentMeetingDate(
+						"ellettsville-town-council",
+					);
+				}).pipe(Effect.provide(layer)),
+			);
+
+			expect(result).toBe("2026-03-23");
+		});
+
+		it("returns null when the body has no meetings yet", async () => {
+			const db = await createTestDb();
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.getMostRecentMeetingDate(
+						"ellettsville-town-council",
+					);
+				}).pipe(Effect.provide(StorageServiceLive(db))),
+			);
+
+			expect(result).toBeNull();
+		});
+
+		it("returns null when the body slug does not exist", async () => {
+			const db = await createTestDb();
+			const result = await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.getMostRecentMeetingDate("nonexistent-body");
+				}).pipe(Effect.provide(StorageServiceLive(db))),
+			);
+
+			expect(result).toBeNull();
+		});
+	});
+
 	describe("storeTranscript", () => {
 		it("stores a transcript linked to a meeting", async () => {
 			const db = await createTestDb();

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import type { LibSQLDatabase } from "drizzle-orm/libsql";
 import { Context, Effect, Layer } from "effect";
 import type { MeetingDetail } from "#/db/queries.ts";
@@ -83,6 +83,14 @@ interface StorageServiceInterface {
 		date: string,
 	): Effect.Effect<MeetingDetail | null, DatabaseError>;
 	storeTranscript(input: TranscriptInput): Effect.Effect<void, DatabaseError>;
+	/**
+	 * Returns the ISO date of the most recent meeting for the body, or null if
+	 * the body has no meetings yet (or doesn't exist). Used by the orchestrator
+	 * to detect the 30-day zero-results anomaly.
+	 */
+	getMostRecentMeetingDate(
+		slug: string,
+	): Effect.Effect<string | null, DatabaseError>;
 }
 
 class StorageService extends Context.Tag("StorageService")<
@@ -149,6 +157,28 @@ function StorageServiceLive(db: LibSQLDatabase<typeof schema>) {
 				catch: (error) =>
 					new DatabaseError({
 						operation: "storeTranscript",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+		getMostRecentMeetingDate: (slug) =>
+			Effect.tryPromise({
+				try: async () => {
+					const row = await db
+						.select({ date: schema.meetings.date })
+						.from(schema.meetings)
+						.innerJoin(
+							schema.governingBodies,
+							eq(schema.meetings.bodyId, schema.governingBodies.id),
+						)
+						.where(eq(schema.governingBodies.slug, slug))
+						.orderBy(desc(schema.meetings.date))
+						.limit(1)
+						.get();
+					return row?.date ?? null;
+				},
+				catch: (error) =>
+					new DatabaseError({
+						operation: "getMostRecentMeetingDate",
 						message: error instanceof Error ? error.message : String(error),
 					}),
 			}),

--- a/src/pipeline/services/SummarizationService.test.ts
+++ b/src/pipeline/services/SummarizationService.test.ts
@@ -1,5 +1,10 @@
+import { Effect } from "effect";
 import { describe, expect, it } from "vitest";
-import { verifyAmounts } from "./SummarizationService.ts";
+import {
+	SummarizationService,
+	SummarizationServiceLive,
+	verifyAmounts,
+} from "./SummarizationService.ts";
 
 const SOURCE_TEXT = `
 The Town Council approved a motion to allocate $50,000 for road repairs
@@ -33,30 +38,172 @@ describe("SummarizationService", () => {
 			expect(verified[1].confidence).toBe(0.9);
 		});
 
-		it("downgrades confidence when amounts are not found in source text", () => {
+		it("downgrades confidence when amount is not in source text", () => {
 			const decisions = [
 				{
-					title: "Road Repairs",
-					description: "Sale Street road repairs",
-					amount: 50000,
-					originalAmount: "$50,000",
-					confidence: 0.95,
-				},
-				{
-					title: "Phantom Budget Item",
-					description: "This was hallucinated by the LLM",
-					amount: 75000,
-					originalAmount: "$75,000",
-					confidence: 0.85,
+					title: "Phantom Expense",
+					description: "This was never approved",
+					amount: 99999,
+					originalAmount: "$99,999",
+					confidence: 0.8,
 				},
 			];
 
 			const verified = verifyAmounts(decisions, SOURCE_TEXT);
 
-			// Real amount keeps confidence
-			expect(verified[0].confidence).toBe(0.95);
-			// Hallucinated amount gets downgraded
-			expect(verified[1].confidence).toBeLessThan(0.5);
+			expect(verified[0].confidence).toBeCloseTo(0.32, 5);
+		});
+	});
+
+	describe("SummarizationServiceLive", () => {
+		it("summarizes meeting text and verifies extracted amounts", async () => {
+			const stubOutput = {
+				highlights: [
+					"Approved $50,000 for Sale Street road repairs",
+					"Approved $12,500 ABC Paving sidewalk contract",
+				],
+				prose: "The council approved road and sidewalk work totaling $62,500.",
+				fiscalDecisions: [
+					{
+						title: "Road Repairs",
+						description: "Sale Street road repairs",
+						amount: 50000,
+						originalAmount: "$50,000",
+						status: "approved" as const,
+						confidence: 0.95,
+						isRecurring: false,
+					},
+					{
+						title: "Sidewalk Contract",
+						description: "ABC Paving sidewalk improvements",
+						amount: 12500,
+						originalAmount: "$12,500",
+						status: "approved" as const,
+						confidence: 0.9,
+						isRecurring: false,
+					},
+				],
+				budgetDiscussions: [],
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* SummarizationService;
+				return yield* service.summarize({
+					sourceText: SOURCE_TEXT,
+					meetingContext: "Town Council, March 23, 2026",
+				});
+			}).pipe(
+				Effect.provide(
+					SummarizationServiceLive({
+						model: "gemini-2.5-flash",
+						generateFn: async () => stubOutput,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.model).toBe("gemini-2.5-flash");
+			expect(result.highlights).toHaveLength(2);
+			expect(result.prose).toContain("$62,500");
+			expect(result.fiscalDecisions).toHaveLength(2);
+			expect(result.fiscalDecisions[0].confidence).toBe(0.95);
+			expect(result.fiscalDecisions[1].confidence).toBe(0.9);
+		});
+
+		it("downgrades confidence for amounts not found in source text", async () => {
+			const stubOutput = {
+				highlights: ["Phantom decision"],
+				prose: "A decision that wasn't really in the source.",
+				fiscalDecisions: [
+					{
+						title: "Phantom Expense",
+						description: "This was never in the minutes",
+						amount: 99999,
+						originalAmount: "$99,999",
+						status: "approved" as const,
+						confidence: 0.8,
+						isRecurring: false,
+					},
+				],
+				budgetDiscussions: [],
+			};
+
+			const program = Effect.gen(function* () {
+				const service = yield* SummarizationService;
+				return yield* service.summarize({
+					sourceText: SOURCE_TEXT,
+					meetingContext: "Town Council, March 23, 2026",
+				});
+			}).pipe(
+				Effect.provide(
+					SummarizationServiceLive({
+						model: "gemini-2.5-flash",
+						generateFn: async () => stubOutput,
+					}),
+				),
+			);
+
+			const result = await Effect.runPromise(program);
+
+			expect(result.fiscalDecisions[0].confidence).toBeCloseTo(0.32, 5);
+		});
+
+		it("returns LlmError when the underlying model call throws", async () => {
+			const program = Effect.gen(function* () {
+				const service = yield* SummarizationService;
+				return yield* service.summarize({
+					sourceText: SOURCE_TEXT,
+					meetingContext: "Town Council, March 23, 2026",
+				});
+			}).pipe(
+				Effect.provide(
+					SummarizationServiceLive({
+						model: "gemini-2.5-flash",
+						generateFn: async () => {
+							throw new Error("API quota exceeded");
+						},
+					}),
+				),
+			);
+
+			const error = await Effect.runPromise(program.pipe(Effect.flip));
+			expect(error._tag).toBe("LlmError");
+			expect(error.model).toBe("gemini-2.5-flash");
+			expect(error.message).toContain("API quota exceeded");
+		});
+
+		it("passes the meeting context to the generateFn", async () => {
+			const calls: Array<{ sourceText: string; meetingContext: string }> = [];
+
+			const program = Effect.gen(function* () {
+				const service = yield* SummarizationService;
+				return yield* service.summarize({
+					sourceText: "test source",
+					meetingContext: "Plan Commission, April 1, 2026",
+				});
+			}).pipe(
+				Effect.provide(
+					SummarizationServiceLive({
+						model: "gemini-2.5-flash",
+						generateFn: async (args) => {
+							calls.push(args);
+							return {
+								highlights: [],
+								prose: "",
+								fiscalDecisions: [],
+								budgetDiscussions: [],
+							};
+						},
+					}),
+				),
+			);
+
+			await Effect.runPromise(program);
+
+			expect(calls).toHaveLength(1);
+			expect(calls[0].sourceText).toBe("test source");
+			expect(calls[0].meetingContext).toBe("Plan Commission, April 1, 2026");
 		});
 	});
 });

--- a/src/pipeline/services/SummarizationService.ts
+++ b/src/pipeline/services/SummarizationService.ts
@@ -1,3 +1,7 @@
+import { Context, Effect, Layer } from "effect";
+import { z } from "zod";
+import { LlmError } from "#/pipeline/errors.ts";
+
 /**
  * The minimum shape a fiscal decision must have for amount verification.
  * This is the input contract for {@link verifyAmounts}.
@@ -48,5 +52,144 @@ function verifyAmounts<T extends FiscalDecisionCandidate>(
 	});
 }
 
-export { verifyAmounts };
-export type { FiscalDecisionCandidate };
+/**
+ * Zod schema for the structured output the LLM must produce.
+ *
+ * Effect teaching note: Keeping the schema colocated with the service keeps
+ * the "what the LLM returns" contract in one place. The orchestrator never
+ * deals with raw LLM responses — it only sees `SummarizationResult`, which is
+ * the schema-validated, two-pass-verified shape produced by `summarize`.
+ *
+ * The fields mirror the `MeetingInput` shape that `StorageService.storeMeeting`
+ * expects, so the orchestrator can pipe summarizer output directly into the
+ * storage call without additional transformation.
+ */
+const fiscalDecisionSchema = z.object({
+	title: z.string(),
+	description: z.string(),
+	amount: z.number(),
+	originalAmount: z.string(),
+	budgetCategory: z.string().optional(),
+	status: z.enum(["approved", "denied", "tabled"]),
+	voteRecord: z
+		.object({
+			yea: z.number(),
+			nay: z.number(),
+			abstain: z.number(),
+		})
+		.optional(),
+	vendor: z.string().optional(),
+	fundingSource: z.string().optional(),
+	ordinanceNumber: z.string().optional(),
+	confidence: z.number().min(0).max(1),
+	isRecurring: z.boolean(),
+});
+
+const budgetDiscussionSchema = z.object({
+	topic: z.string(),
+	estimatedAmount: z.number().optional(),
+	notes: z.string().optional(),
+});
+
+const summarizationOutputSchema = z.object({
+	highlights: z.array(z.string()),
+	prose: z.string(),
+	fiscalDecisions: z.array(fiscalDecisionSchema),
+	budgetDiscussions: z.array(budgetDiscussionSchema),
+});
+
+type SummarizationOutput = z.infer<typeof summarizationOutputSchema>;
+
+type SummarizationInput = {
+	/** Raw meeting minutes text or transcript to summarize. */
+	sourceText: string;
+	/** Short context line for the prompt (e.g. "Town Council, March 23, 2026"). */
+	meetingContext: string;
+};
+
+/**
+ * The full result returned by the service — schema output plus the model
+ * identifier, which gets persisted alongside the summary for auditing.
+ */
+type SummarizationResult = SummarizationOutput & {
+	model: string;
+};
+
+interface SummarizationServiceInterface {
+	summarize(
+		input: SummarizationInput,
+	): Effect.Effect<SummarizationResult, LlmError>;
+}
+
+class SummarizationService extends Context.Tag("SummarizationService")<
+	SummarizationService,
+	SummarizationServiceInterface
+>() {}
+
+/**
+ * Injectable generator function — this is the boundary between the Effect
+ * world and the Vercel AI SDK world. In production, `createGeminiGenerator`
+ * (or a Kimi equivalent) returns one of these. In tests, callers pass a stub
+ * that returns a canned `SummarizationOutput`, skipping the real HTTP call.
+ */
+type SummarizationGenerateFn = (
+	input: SummarizationInput,
+) => Promise<SummarizationOutput>;
+
+type SummarizationServiceConfig = {
+	/** Model identifier recorded alongside each summary (e.g. "gemini-2.5-flash"). */
+	model: string;
+	/** Async generator that produces a structured summary from source text. */
+	generateFn: SummarizationGenerateFn;
+};
+
+/**
+ * Effect teaching note: This service follows the same dependency-injection
+ * pattern as the other scrapers — an async function (`generateFn`) is passed
+ * in via config, and the Effect layer wraps it in `Effect.tryPromise` so
+ * thrown exceptions become typed `LlmError` values.
+ *
+ * After the LLM call returns, `verifyAmounts` runs as the second pass of the
+ * two-pass extraction: any fiscal decision whose `originalAmount` string
+ * doesn't appear in the source text gets its confidence reduced, protecting
+ * against the "temporal confusion" hallucination pitfall (confusing historical
+ * spending references with new decisions).
+ */
+function SummarizationServiceLive(
+	config: SummarizationServiceConfig,
+): Layer.Layer<SummarizationService> {
+	return Layer.succeed(SummarizationService, {
+		summarize: (input) =>
+			Effect.tryPromise({
+				try: async () => {
+					const raw = await config.generateFn(input);
+					const verified = verifyAmounts(raw.fiscalDecisions, input.sourceText);
+					return {
+						...raw,
+						fiscalDecisions: verified,
+						model: config.model,
+					};
+				},
+				catch: (error) =>
+					new LlmError({
+						model: config.model,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+export {
+	SummarizationService,
+	SummarizationServiceLive,
+	verifyAmounts,
+	summarizationOutputSchema,
+};
+export type {
+	FiscalDecisionCandidate,
+	SummarizationGenerateFn,
+	SummarizationInput,
+	SummarizationOutput,
+	SummarizationResult,
+	SummarizationServiceConfig,
+};


### PR DESCRIPTION
## Summary

Composes the existing pipeline services (eGov, Finalsite, YouTube, transcription, summarization, storage) into a runnable `PipelineOrchestrator` with an `@effect/cli` entry point, Resend-backed operator alerts, retry policies, and a 30-day zero-results anomaly detector. Also fills two gaps the boundary map for this slice assumed were already in place but weren't — `EgovScraper` and `SummarizationService` were only pure helper functions, not Effect Layers.

## PRD

Closes #8 (slice) — Parent PRD #1

## Slices

Civic Mirror pipeline lineage under PRD #1:

- [x] #2 — Tracer Bullet: Schema + eGov Pipeline + Meeting Detail Page
- [x] #3 — YouTube Transcription Pipeline
- [x] #4 — Finalsite Scraper
- [x] #5 — Landing Page + Meeting Feed + High-Level Spending
- [x] #7 — Detailed Spending Dashboard
- [x] #8 — Pipeline Orchestrator + CLI + Alerts (this PR)
- [ ] #9 — QA: Full Manual Verification

## Key Decisions

**Expanded scope to wrap two missing Effect Layers.** The boundary map for #8 listed `EgovScraper` and `SummarizationService` as "Consumed from #2", but #2 only delivered `parseEgovListingHtml` and `verifyAmounts` as pure helper functions — no Effect Layers. Rather than split into a separate blocking slice, the two wrappers are the first two commits of this PR.

**Orchestrator is a plain function, not its own service.** There's only one implementation and its requirements are the union of the services it composes, which Effect's type system expresses naturally via the `R` parameter of `Effect.Effect<A, E, R>`. No need for a `PipelineOrchestrator` Tag.

**Per-listing errors are caught, alerted, and recovered inline.** A broken document for one body does not stop the full pipeline; scrape failures at the listing-page level do fail the body so the operator sees them.

**Retry policies are injectable via `RunPipelineInput`.** Production defaults are `{3 attempts, 500ms base}` for network and `{2 attempts, 1000ms base}` for LLM. Tests pass `attempts: 0` to disable retries entirely. Schedules are composed at runtime via a `ResolvedConfig` wrapper so every call site reads the same pre-computed `Schedule`.

**PDF extraction is a placeholder in this slice.** The CLI's `extractPdfText` returns a byte-count string; a real extractor (e.g. `pdf-parse`, `unpdf`) needs to be wired up in a follow-up slice. Dry-run mode is safe; a real non-dry run would store near-empty summaries.

**Backfill pagination and 2-year filtering deferred.** The current `scrapeListings` call fetches page 1 only. Real backfill with date filtering + pagination should be added before the first production run.

**Zero-results anomaly uses a configurable `now`.** Tests pass a fixed date so the 30-day threshold is deterministic; production defaults to `new Date()`. The check runs before scraping so a silently-broken scraper still triggers the alert.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test` — 91 tests pass (22 new across orchestrator, new service layers, and the new StorageService method)
- [x] `pnpm pipeline list-bodies` — shows the 4 default bodies with source tags
- [x] `pnpm pipeline run --help` — shows `--dry-run`, `--skip-crawl-delay`, `--body <slug>`
- [x] `pnpm pipeline:dry --body ellettsville-town-council` — processed=25, errors=0 end-to-end against the real eGov portal
- [ ] After merge: wire up a real PDF extractor in a follow-up before running a non-dry full pipeline