### PR TITLE
feat(pipeline): OCR fallback for scanned eGov PDFs (extraction layer)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ todos.json
 .claude/.tdd-active
 .claude/.tdd-skipped
 .claude/.ralph-checked
+
+# tesseract.js downloads language traineddata on first run (~10 MB each)
+*.traineddata

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@effect/platform": "^0.96.0",
     "@effect/platform-node": "^0.106.0",
     "@libsql/client": "^0.17.2",
+    "@napi-rs/canvas": "^0.1.97",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "latest",
     "@tanstack/react-query": "latest",
@@ -55,8 +56,9 @@
     "resend": "^6.10.0",
     "tailwind-merge": "^3.0.2",
     "tailwindcss": "^4.1.18",
+    "tesseract.js": "^7.0.0",
     "tw-animate-css": "^1.3.6",
-    "unpdf": "^1.4.0",
+    "unpdf": "^1.6.0",
     "youtube-transcript": "^1.3.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@libsql/client':
         specifier: ^0.17.2
         version: 0.17.2
+      '@napi-rs/canvas':
+        specifier: ^0.1.97
+        version: 0.1.97
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.2(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -76,7 +79,7 @@ importers:
         version: 0.577.0(react@19.2.4)
       nitro:
         specifier: 3.0.260311-beta
-        version: 3.0.260311-beta(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(dotenv@17.4.1)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(jiti@2.6.1)(lru-cache@11.3.2)(rollup@4.60.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 3.0.260311-beta(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(dotenv@17.4.1)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(idb-keyval@6.2.2)(jiti@2.6.1)(lru-cache@11.3.2)(rollup@4.60.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -95,12 +98,15 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.2.2
+      tesseract.js:
+        specifier: ^7.0.0
+        version: 7.0.0
       tw-animate-css:
         specifier: ^1.3.6
         version: 1.4.0
       unpdf:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.6.0
+        version: 1.6.0(@napi-rs/canvas@0.1.97)
       youtube-transcript:
         specifier: ^1.3.0
         version: 1.3.0
@@ -1079,6 +1085,81 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@napi-rs/canvas-android-arm64@0.1.97':
+    resolution: {integrity: sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@0.1.97':
+    resolution: {integrity: sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@0.1.97':
+    resolution: {integrity: sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.97':
+    resolution: {integrity: sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.97':
+    resolution: {integrity: sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.97':
+    resolution: {integrity: sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
+    resolution: {integrity: sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.97':
+    resolution: {integrity: sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.97':
+    resolution: {integrity: sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
+    resolution: {integrity: sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.97':
+    resolution: {integrity: sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@0.1.97':
+    resolution: {integrity: sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==}
+    engines: {node: '>= 10'}
+
   '@napi-rs/wasm-runtime@1.1.3':
     resolution: {integrity: sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==}
     peerDependencies:
@@ -2006,6 +2087,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -2538,6 +2622,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.2.2:
+    resolution: {integrity: sha512-yjD9nARJ/jb1g+CvD0tlhUHOrJ9Sy0P8T9MF3YaLlHnSRpwPfpTX0XIvpmw3gAJUmEu3FiICLBDPXVwyEvrleg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2579,6 +2666,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   isbot@5.1.37:
     resolution: {integrity: sha512-5bcicX81xf6NlTEV8rWdg7Pk01LFizDetuYGHx6d/f6y3lR2/oo8IfxjzJqn1UdDEyCcwT9e7NRloj8DwCYujQ==}
@@ -2905,6 +2995,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
 
@@ -3033,6 +3127,9 @@ packages:
 
   redux@5.0.1:
     resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3176,6 +3273,12 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tesseract.js-core@7.0.0:
+    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
+
+  tesseract.js@7.0.0:
+    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -3271,8 +3374,8 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  unpdf@1.4.0:
-    resolution: {integrity: sha512-TahIk0xdH/4jh/MxfclzU79g40OyxtP00VnEUZdEkJoYtXAHWLiir6t3FC6z3vDqQTzc2ZHcla6uEiVTNjejuA==}
+  unpdf@1.6.0:
+    resolution: {integrity: sha512-DsjbuDe6PDbZzGvAP40QQp0xskrXP3Tm3fd/FLkGObL00Icr7cc28QgrPHYg+6B1lMWydgXwDXauIv5CGyXudA==}
     peerDependencies:
       '@napi-rs/canvas': ^0.1.69
     peerDependenciesMeta:
@@ -3475,6 +3578,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  wasm-feature-detect@1.8.0:
+    resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -3551,6 +3657,9 @@ packages:
   youtube-transcript@1.3.0:
     resolution: {integrity: sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q==}
     engines: {node: '>=18.0.0'}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -4255,6 +4364,53 @@ snapshots:
 
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
+
+  '@napi-rs/canvas-android-arm64@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@0.1.97':
+    optional: true
+
+  '@napi-rs/canvas@0.1.97':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.97
+      '@napi-rs/canvas-darwin-arm64': 0.1.97
+      '@napi-rs/canvas-darwin-x64': 0.1.97
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.97
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.97
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.97
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.97
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.97
+      '@napi-rs/canvas-linux-x64-musl': 0.1.97
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.97
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.97
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
@@ -5136,6 +5292,8 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  bmp-js@0.1.0: {}
+
   boolbase@1.0.0: {}
 
   braces@3.0.3:
@@ -5615,6 +5773,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.2.2: {}
+
   ieee754@1.2.1:
     optional: true
 
@@ -5645,6 +5805,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-url@1.2.4: {}
 
   isbot@5.1.37: {}
 
@@ -5865,7 +6027,7 @@ snapshots:
 
   nf3@0.3.16: {}
 
-  nitro@3.0.260311-beta(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(dotenv@17.4.1)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(jiti@2.6.1)(lru-cache@11.3.2)(rollup@4.60.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
+  nitro@3.0.260311-beta(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(dotenv@17.4.1)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))(idb-keyval@6.2.2)(jiti@2.6.1)(lru-cache@11.3.2)(rollup@4.60.1)(vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.15)
@@ -5880,7 +6042,7 @@ snapshots:
       rolldown: 1.0.0-rc.15
       srvx: 0.11.15
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)))(lru-cache@11.3.2)(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)))(idb-keyval@6.2.2)(lru-cache@11.3.2)(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.1
       jiti: 2.6.1
@@ -5961,6 +6123,8 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
     optional: true
+
+  opencollective-postinstall@2.0.3: {}
 
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
@@ -6110,6 +6274,8 @@ snapshots:
       redux: 5.0.1
 
   redux@5.0.1: {}
+
+  regenerator-runtime@0.13.11: {}
 
   require-from-string@2.0.2: {}
 
@@ -6282,6 +6448,22 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  tesseract.js-core@7.0.0: {}
+
+  tesseract.js@7.0.0:
+    dependencies:
+      bmp-js: 0.1.0
+      idb-keyval: 6.2.2
+      is-url: 1.2.4
+      node-fetch: 2.7.0
+      opencollective-postinstall: 2.0.3
+      regenerator-runtime: 0.13.11
+      tesseract.js-core: 7.0.0
+      wasm-feature-detect: 1.8.0
+      zlibjs: 0.3.1
+    transitivePeerDependencies:
+      - encoding
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -6355,7 +6537,9 @@ snapshots:
     dependencies:
       pathe: 2.0.3
 
-  unpdf@1.4.0: {}
+  unpdf@1.6.0(@napi-rs/canvas@0.1.97):
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.97
 
   unplugin@2.3.11:
     dependencies:
@@ -6364,9 +6548,10 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unstorage@2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)))(lru-cache@11.3.2)(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(db0@0.3.4(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0)))(idb-keyval@6.2.2)(lru-cache@11.3.2)(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       db0: 0.3.4(@libsql/client@0.17.2)(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(@libsql/client@0.17.2)(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@12.8.0))
+      idb-keyval: 6.2.2
       lru-cache: 11.3.2
       ofetch: 2.0.0-alpha.3
 
@@ -6501,6 +6686,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  wasm-feature-detect@1.8.0: {}
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -6556,6 +6743,8 @@ snapshots:
   yaml@2.8.3: {}
 
   youtube-transcript@1.3.0: {}
+
+  zlibjs@0.3.1: {}
 
   zod@3.25.76: {}
 

--- a/src/pipeline/services/OcrExtractor.test.ts
+++ b/src/pipeline/services/OcrExtractor.test.ts
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { ocrPdf } from "./OcrExtractor.ts";
+
+const TEXT_NATIVE_FIXTURE_URL = new URL(
+	"./__fixtures__/egov-minutes-sample.pdf",
+	import.meta.url,
+);
+
+async function loadFixtureBytes(url: URL): Promise<ArrayBuffer> {
+	const buffer = await readFile(fileURLToPath(url));
+	return buffer.buffer.slice(
+		buffer.byteOffset,
+		buffer.byteOffset + buffer.byteLength,
+	);
+}
+
+// OCR runs tesseract.js over rasterized pages, which is slow (~1-3s/page on
+// Apple silicon) and may download traineddata on first run. The 120s budget is
+// generous enough for CI runners with a cold traineddata cache.
+describe("ocrPdf", () => {
+	it("returns recognizable text when given a rasterized printed-text PDF", {
+		timeout: 120_000,
+	}, async () => {
+		// We use the existing text-native fixture deliberately: ocrPdf always
+		// rasterizes pages to PNG before recognizing, so it works on any PDF
+		// with visible printed text, whether or not a text layer exists. This
+		// gives us a deterministic smoke test without shipping a large scanned
+		// PDF fixture. Real scanned-PDF verification happens end-to-end during
+		// pipeline:run against Ellettsville Town Council historical listings.
+		const bytes = await loadFixtureBytes(TEXT_NATIVE_FIXTURE_URL);
+
+		const text = await ocrPdf(bytes);
+
+		expect(text.trim().length).toBeGreaterThan(0);
+		// Tesseract makes occasional character-level mistakes on rasterized
+		// PDFs; we assert on stable unique tokens likely to survive.
+		expect(text.toLowerCase()).toContain("ellettsville");
+	});
+
+	it("concatenates multi-page output in page order", {
+		timeout: 120_000,
+	}, async () => {
+		const bytes = await loadFixtureBytes(TEXT_NATIVE_FIXTURE_URL);
+
+		const text = await ocrPdf(bytes);
+
+		// The fixture has page-1 opening content and page-2 adjournment
+		// content; verify the concatenation preserves that ordering. We match
+		// on loose substrings because OCR may mis-read individual characters.
+		const page1 = text.toLowerCase().indexOf("ellettsville");
+		const page2 = text.toLowerCase().search(/adjourn/);
+		expect(page1).toBeGreaterThanOrEqual(0);
+		expect(page2).toBeGreaterThan(page1);
+	});
+});

--- a/src/pipeline/services/OcrExtractor.ts
+++ b/src/pipeline/services/OcrExtractor.ts
@@ -1,0 +1,57 @@
+import "./promise-try-polyfill.ts";
+import { createWorker, PSM } from "tesseract.js";
+import { getDocumentProxy, renderPageAsImage } from "unpdf";
+
+/**
+ * OCRs a PDF by rasterizing each page to an image and running tesseract.js
+ * over the images. Used as the fallback path in the composite `extractPdfText`
+ * when a PDF has no text layer (image-based / scanned documents).
+ *
+ * Effect teaching note: Like `extractPdfText`, this is a plain async function
+ * rather than an Effect.Tag service — same rationale (swap-the-impl at the
+ * orchestrator input boundary, no additional dependencies to inject from an
+ * Effect Context). The tesseract worker lifecycle is managed with a
+ * try/finally so the ~150 MB WASM instance is always torn down, even on
+ * error. If you wanted Effect's native resource management,
+ * `Effect.acquireRelease` would be a clean upgrade path later.
+ *
+ * Tuning rationale:
+ * - `scale: 2.5` — renders at ~180 DPI (PDF base is 72 DPI), which is the
+ *   floor where tesseract LSTM delivers good accuracy on printed text.
+ *   Lower and output is plausible-looking garbage. Higher costs 2-3x runtime
+ *   for diminishing returns.
+ * - `user_defined_dpi: "300"` — hint for tesseract's layout heuristics; also
+ *   silences its "low-resolution page" warning log.
+ * - `PSM.SINGLE_BLOCK` — assumes a single column of text per page, which
+ *   matches municipal meeting minute and agenda layouts.
+ */
+export async function ocrPdf(bytes: ArrayBuffer): Promise<string> {
+	// pdfjs (bundled in unpdf) transfers ownership of the underlying buffer on
+	// each call, leaving the original ArrayBuffer detached. We hand each unpdf
+	// call its own copy so subsequent calls don't fail with "Cannot perform
+	// Construct on a detached ArrayBuffer".
+	const freshBytes = () => new Uint8Array(bytes.slice(0));
+
+	const pdf = await getDocumentProxy(freshBytes());
+	const pageCount = pdf.numPages;
+
+	const worker = await createWorker("eng");
+	await worker.setParameters({
+		tessedit_pageseg_mode: PSM.SINGLE_BLOCK,
+		user_defined_dpi: "300",
+	});
+	try {
+		const pages: string[] = [];
+		for (let pageNumber = 1; pageNumber <= pageCount; pageNumber++) {
+			const png = await renderPageAsImage(freshBytes(), pageNumber, {
+				scale: 2.5,
+				canvasImport: () => import("@napi-rs/canvas"),
+			});
+			const { data } = await worker.recognize(Buffer.from(png));
+			pages.push(data.text);
+		}
+		return pages.join("\n\n");
+	} finally {
+		await worker.terminate();
+	}
+}

--- a/src/pipeline/services/PdfExtractor.test.ts
+++ b/src/pipeline/services/PdfExtractor.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { extractPdfText } from "./PdfExtractor.ts";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { extractPdfText, type PdfExtractorDeps } from "./PdfExtractor.ts";
 
 const FIXTURE_URL = new URL(
 	"./__fixtures__/egov-minutes-sample.pdf",
@@ -77,6 +77,94 @@ describe("extractPdfText", () => {
 		await expect(extractPdfText(truncated)).rejects.toThrow();
 	});
 
+	describe("OCR fallback", () => {
+		// These tests exercise the composite wiring in isolation by injecting
+		// fake deps. The real OCR path is covered end-to-end in
+		// OcrExtractor.test.ts; here we care only that the composite routes to
+		// OCR when (and only when) the text-layer path produces no text.
+		const BYTES = new Uint8Array([0]).buffer;
+
+		it("falls back to OCR when the text layer returns an empty string", async () => {
+			const deps: PdfExtractorDeps = {
+				extractTextLayer: vi.fn().mockResolvedValue(""),
+				ocrPdf: vi.fn().mockResolvedValue("hello from OCR"),
+			};
+
+			const text = await extractPdfText(BYTES, deps);
+
+			expect(text).toBe("hello from OCR");
+			expect(deps.ocrPdf).toHaveBeenCalledOnce();
+		});
+
+		it("falls back to OCR when the text layer returns only whitespace", async () => {
+			// Regression guard: some scanned PDFs return a literal single space
+			// from unpdf.extractText. A naive length check would skip OCR.
+			const deps: PdfExtractorDeps = {
+				extractTextLayer: vi.fn().mockResolvedValue(" "),
+				ocrPdf: vi.fn().mockResolvedValue("real text"),
+			};
+
+			const text = await extractPdfText(BYTES, deps);
+
+			expect(text).toBe("real text");
+			expect(deps.ocrPdf).toHaveBeenCalledOnce();
+		});
+
+		it("does not invoke OCR when the text layer has content", async () => {
+			const ocrPdf = vi
+				.fn<(bytes: ArrayBuffer) => Promise<string>>()
+				.mockRejectedValue(new Error("OCR should not run"));
+			const deps: PdfExtractorDeps = {
+				extractTextLayer: vi.fn().mockResolvedValue("text layer content"),
+				ocrPdf,
+			};
+
+			const text = await extractPdfText(BYTES, deps);
+
+			expect(text).toBe("text layer content");
+			expect(ocrPdf).not.toHaveBeenCalled();
+		});
+
+		describe("when both paths return no text", () => {
+			const originalAllowEmpty = process.env.ALLOW_EMPTY_PDF_TEXT;
+
+			beforeEach(() => {
+				delete process.env.ALLOW_EMPTY_PDF_TEXT;
+			});
+
+			afterEach(() => {
+				if (originalAllowEmpty === undefined) {
+					delete process.env.ALLOW_EMPTY_PDF_TEXT;
+				} else {
+					process.env.ALLOW_EMPTY_PDF_TEXT = originalAllowEmpty;
+				}
+			});
+
+			it("throws a clear error mentioning both paths failed", async () => {
+				const deps: PdfExtractorDeps = {
+					extractTextLayer: vi.fn().mockResolvedValue(""),
+					ocrPdf: vi.fn().mockResolvedValue(""),
+				};
+
+				await expect(extractPdfText(BYTES, deps)).rejects.toThrow(
+					/text-layer.*OCR|OCR.*text-layer/i,
+				);
+			});
+
+			it("returns empty text when ALLOW_EMPTY_PDF_TEXT=1 is set", async () => {
+				process.env.ALLOW_EMPTY_PDF_TEXT = "1";
+				const deps: PdfExtractorDeps = {
+					extractTextLayer: vi.fn().mockResolvedValue(""),
+					ocrPdf: vi.fn().mockResolvedValue(""),
+				};
+
+				const text = await extractPdfText(BYTES, deps);
+
+				expect(text).toBe("");
+			});
+		});
+	});
+
 	describe("empty-text guard", () => {
 		const originalAllowEmpty = process.env.ALLOW_EMPTY_PDF_TEXT;
 
@@ -92,7 +180,12 @@ describe("extractPdfText", () => {
 			}
 		});
 
-		it("throws a clear error when a valid PDF has no extractable text (likely scanned/image-only)", async () => {
+		// End-to-end: the composite now attempts OCR before failing, so a
+		// truly blank PDF flows through both paths before the guard throws.
+		// Tesseract worker startup + blank-page recognition adds a few seconds.
+		it("throws a clear error when a valid PDF has no extractable text (likely scanned/image-only)", {
+			timeout: 60_000,
+		}, async () => {
 			const bytes = await loadFixtureBytes(EMPTY_FIXTURE_URL);
 
 			await expect(extractPdfText(bytes)).rejects.toThrow(
@@ -100,7 +193,9 @@ describe("extractPdfText", () => {
 			);
 		});
 
-		it("returns empty text when ALLOW_EMPTY_PDF_TEXT=1 is set (smoke-test opt-in)", async () => {
+		it("returns empty text when ALLOW_EMPTY_PDF_TEXT=1 is set (smoke-test opt-in)", {
+			timeout: 60_000,
+		}, async () => {
 			process.env.ALLOW_EMPTY_PDF_TEXT = "1";
 			const bytes = await loadFixtureBytes(EMPTY_FIXTURE_URL);
 

--- a/src/pipeline/services/PdfExtractor.ts
+++ b/src/pipeline/services/PdfExtractor.ts
@@ -1,49 +1,74 @@
 import "./promise-try-polyfill.ts";
 import { extractText, getDocumentProxy } from "unpdf";
+import { ocrPdf as defaultOcrPdf } from "./OcrExtractor.ts";
 
 /**
- * Extracts plain text from a PDF byte buffer.
+ * Composite PDF text extractor: tries the text-layer path first, falls back
+ * to OCR for scanned/image-only PDFs, then enforces the empty-text guard
+ * across both paths.
  *
- * Uses unpdf (a serverless build of PDF.js) so this works in Node, Bun, and
- * Edge runtimes without a native dependency. `extractText` with
- * `mergePages: true` returns the concatenated text of every page in order,
- * which is the shape the summarization stage expects.
+ * Used via `RunPipelineInput.extractPdfText` in the orchestrator, which wraps
+ * this call in `Effect.tryPromise` so any thrown error surfaces as a tagged
+ * `PipelineExtractError`. Keeping this as a plain async function (not an
+ * Effect.Tag service) matches the orchestrator's function-reference seam:
+ * tests and the dry-run path substitute a different implementation by passing
+ * a different reference, not by reshaping the dependency graph.
  *
- * Effect teaching note: This module exposes a plain async function rather
- * than an Effect Context.Tag service. The reason is shape-of-the-contract:
- * the orchestrator takes `extractPdfText` as a function parameter on
- * `RunPipelineInput`, not from the Effect context, and wraps the call in
- * `Effect.tryPromise` so any thrown error becomes a tagged
- * `PipelineExtractError`. Wrapping this in a Tag would add an extra indirection
- * without changing the dependency graph — the orchestrator would still need a
- * way to pass it in for tests. Keeping it a function keeps the swap-the-impl
- * pattern (placeholder for dry-run vs real for production) as a simple
- * function reference.
+ * The internal two-path structure is exposed through the optional `deps`
+ * argument so unit tests can drive the wiring without spinning up the real
+ * OCR worker. Production callers pass only `bytes` and get the default
+ * implementations.
  */
-export async function extractPdfText(bytes: ArrayBuffer): Promise<string> {
-	let text: string;
+export type PdfExtractorDeps = {
+	extractTextLayer: (bytes: ArrayBuffer) => Promise<string>;
+	ocrPdf: (bytes: ArrayBuffer) => Promise<string>;
+};
+
+async function extractTextLayer(bytes: ArrayBuffer): Promise<string> {
 	try {
-		const pdf = await getDocumentProxy(new Uint8Array(bytes));
+		// pdfjs (bundled in unpdf) transfers ownership of the underlying buffer,
+		// leaving the caller's ArrayBuffer detached. Copy so the OCR fallback can
+		// still read the same `bytes` when the text-layer path returns empty.
+		const pdf = await getDocumentProxy(new Uint8Array(bytes.slice(0)));
 		const result = await extractText(pdf, { mergePages: true });
-		text = result.text;
+		return result.text;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
 		throw new Error(`PDF text extraction failed: ${message}`);
 	}
+}
 
-	// Silent-degradation guard: an image-based/scanned PDF parses without errors
-	// but produces no text layer, which would flow through the pipeline as an
-	// empty summary and zero fiscal decisions — exactly the failure class the
-	// compound doc at docs/solutions/patterns/placeholder-stubs-in-production-paths-2026-04-10.md
-	// warned about. Fail loudly so the orchestrator alerts and the row is not
-	// stored. Opt-out via ALLOW_EMPTY_PDF_TEXT=1 for smoke-test scenarios where
-	// a deliberately blank PDF is expected.
-	if (text.trim().length === 0 && !process.env.ALLOW_EMPTY_PDF_TEXT) {
+const defaultDeps: PdfExtractorDeps = {
+	extractTextLayer,
+	ocrPdf: defaultOcrPdf,
+};
+
+export async function extractPdfText(
+	bytes: ArrayBuffer,
+	deps: PdfExtractorDeps = defaultDeps,
+): Promise<string> {
+	const textLayer = await deps.extractTextLayer(bytes);
+	if (textLayer.trim().length > 0) {
+		return textLayer;
+	}
+
+	const ocrText = await deps.ocrPdf(bytes);
+
+	// Silent-degradation guard, promoted to the composite level. An image-only
+	// PDF that tesseract also can't read (too dark, skewed, handwritten) would
+	// otherwise flow through the pipeline as an empty summary and zero fiscal
+	// decisions — the failure class documented in
+	// docs/solutions/patterns/empty-output-silent-degradation-2026-04-11.md.
+	// Fail loudly so the orchestrator alerts and the row is not stored. Opt out
+	// via ALLOW_EMPTY_PDF_TEXT=1 for smoke-test scenarios with a deliberately
+	// blank PDF.
+	if (ocrText.trim().length === 0 && !process.env.ALLOW_EMPTY_PDF_TEXT) {
 		throw new Error(
-			"PDF text extraction returned no text — likely an image-based/scanned " +
-				"PDF that needs OCR. Set ALLOW_EMPTY_PDF_TEXT=1 to accept empty extractions.",
+			"Both text-layer extraction and OCR returned no text — the PDF may be " +
+				"unreadable (too dark, rotated, handwritten). " +
+				"Set ALLOW_EMPTY_PDF_TEXT=1 to accept empty extractions.",
 		);
 	}
 
-	return text;
+	return ocrText;
 }

--- a/src/pipeline/services/PdfExtractor.ts
+++ b/src/pipeline/services/PdfExtractor.ts
@@ -1,3 +1,4 @@
+import "./promise-try-polyfill.ts";
 import { extractText, getDocumentProxy } from "unpdf";
 
 /**

--- a/src/pipeline/services/promise-try-polyfill.ts
+++ b/src/pipeline/services/promise-try-polyfill.ts
@@ -1,0 +1,30 @@
+// pdfjs-dist 5.6 (bundled inside unpdf 1.6) calls `Promise.try`, which landed
+// in V8 13.2 and shipped in Node 23. Node 22 LTS — which is the runtime for
+// this project's CLI and GitHub Actions workflow — does not have it, so
+// `getDocumentProxy` and `renderPageAsImage` throw `TypeError: Promise.try is
+// not a function` on the first call.
+//
+// This module polyfills `Promise.try` if it's missing. Importing it for its
+// side effect is enough; order matters only insofar as it must run before
+// any unpdf / pdfjs code path executes. Every module that imports unpdf in
+// this project imports this polyfill first.
+//
+// Removal: once Node 23+ is the minimum supported runtime, delete this file
+// and the imports referencing it.
+
+type PromiseTryFn = <T, A extends readonly unknown[]>(
+	fn: (...args: A) => T | PromiseLike<T>,
+	...args: A
+) => Promise<Awaited<T>>;
+
+const PromiseCtor = Promise as PromiseConstructor & { try?: PromiseTryFn };
+
+if (typeof PromiseCtor.try !== "function") {
+	PromiseCtor.try = <T, A extends readonly unknown[]>(
+		fn: (...args: A) => T | PromiseLike<T>,
+		...args: A
+	): Promise<Awaited<T>> =>
+		new Promise<Awaited<T>>((resolve) => {
+			resolve(fn(...args) as Awaited<T> | PromiseLike<Awaited<T>>);
+		});
+}


### PR DESCRIPTION
## Summary

Adds an OCR fallback to PDF text extraction so scanned/image-only eGov PDFs (~84% of Ellettsville Town Council's historical corpus) no longer fail extraction. The current `extractPdfText` becomes a composite: text-layer first (unchanged), `tesseract.js`-based OCR on empty result, then a single "both paths failed" guard that replaces the old "no text layer" guard.

This PR delivers the **extraction layer** of #26 only. Schema, orchestrator persistence of the `unreadable` state, and UI surfaces (OCR banner, fiscal `?` badges, unreadable card) are still to come as follow-up slices.

## Related

Partial delivery of #26 — extraction layer complete; keep open for follow-ups.

## Scope in this PR

- `deps`: `unpdf` 1.4 → 1.6 (adds `renderPageAsImage`), `tesseract.js@^7`, `@napi-rs/canvas@^0.1.97`
- `src/pipeline/services/OcrExtractor.ts` — `ocrPdf(bytes)`: one-worker-per-document lifecycle, `scale: 2.5`, `user_defined_dpi: '300'`, `PSM.SINGLE_BLOCK`, `try/finally terminate`
- `src/pipeline/services/PdfExtractor.ts` — composite wiring: text-layer → OCR fallback → empty-text guard spanning both paths; `PdfExtractorDeps` exposed as optional arg for test injection
- Fix: `extractTextLayer` copies bytes before handing to pdfjs so the fallback isn't broken by a detached buffer
- Tests: 5 new unit tests for fallback wiring (routes to OCR on empty/whitespace, skips OCR when text-layer has content, throws on both-paths-empty, respects `ALLOW_EMPTY_PDF_TEXT`); OCR integration tests against the existing text-native fixture

## Still to come (not in this PR)

- `documents.extraction_method` column + `rawText` nullable — schema migration
- Orchestrator three-state handling: persist `unreadable` rows instead of throwing
- `StorageService` precondition: `extraction_method !== 'unreadable' → raw_text.trim().length > 0`
- UI: OCR banner (`role="status"`), fiscal `?` badges, unreadable status card
- Lower default `confidence` for OCR-sourced fiscal decisions
- Real-fixture verification: wipe + re-run `pnpm pipeline run --body ellettsville-town-council` and confirm `processed=25 errors=0`

## Key decisions

- **Deps injection over `vi.mock`:** composite exposes an optional `PdfExtractorDeps` argument. Production callers pass only bytes (contract unchanged); tests substitute fake `extractTextLayer` / `ocrPdf` without spinning up the real tesseract worker. Matches the existing "swap-the-impl via function reference" pattern on `RunPipelineInput.extractPdfText`.
- **Guard promoted to composite level:** error message changes from "no text — likely scanned, needs OCR" to "both text-layer extraction and OCR returned no text — PDF may be unreadable." `ALLOW_EMPTY_PDF_TEXT=1` still opts out.
- **Defensive buffer copy in `extractTextLayer`:** pdfjs transfers ownership of the underlying ArrayBuffer; without a copy, the OCR fallback would fault on its `bytes.slice(0)` with a detached-buffer error — caught during the RED-GREEN cycle.

## Test plan

- [x] `pnpm test` — 105/105 passing (includes real OCR run on the existing fixture + empty-fixture integration test exercising both paths)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check` on changed files — clean
- [ ] Follow-up: real-fixture OCR quality check once schema/orchestrator/UI slices land — `pnpm pipeline run --body ellettsville-town-council` against a wiped DB