### PR TITLE
Tri-state PDF extraction: unreadable as first-class outcome

### DIFF
--- a/drizzle/0001_natural_tarot.sql
+++ b/drizzle/0001_natural_tarot.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `documents` ADD `extraction_method` text DEFAULT 'text-layer' NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,570 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "48b8454c-b010-48dc-9f16-572613f37f01",
+  "prevId": "82bd638e-6320-416e-9f12-037c6cfedf36",
+  "tables": {
+    "budget_discussions": {
+      "name": "budget_discussions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "estimated_amount": {
+          "name": "estimated_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_discussions_meeting_id_meetings_id_fk": {
+          "name": "budget_discussions_meeting_id_meetings_id_fk",
+          "tableFrom": "budget_discussions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "documents": {
+      "name": "documents",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extraction_method": {
+          "name": "extraction_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text-layer'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_meeting_id_meetings_id_fk": {
+          "name": "documents_meeting_id_meetings_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "fiscal_decisions": {
+      "name": "fiscal_decisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_amount": {
+          "name": "original_amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "budget_category": {
+          "name": "budget_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'approved'"
+        },
+        "vote_record": {
+          "name": "vote_record",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "vendor": {
+          "name": "vendor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "funding_source": {
+          "name": "funding_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ordinance_number": {
+          "name": "ordinance_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_recurring": {
+          "name": "is_recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fiscal_decisions_meeting_id_meetings_id_fk": {
+          "name": "fiscal_decisions_meeting_id_meetings_id_fk",
+          "tableFrom": "fiscal_decisions",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "governing_bodies": {
+      "name": "governing_bodies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "egov_search_type": {
+          "name": "egov_search_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "youtube_playlist_id": {
+          "name": "youtube_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finalsite_url": {
+          "name": "finalsite_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "governing_bodies_slug_unique": {
+          "name": "governing_bodies_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "meetings": {
+      "name": "meetings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meeting_type": {
+          "name": "meeting_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'regular'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "meetings_body_id_governing_bodies_id_fk": {
+          "name": "meetings_body_id_governing_bodies_id_fk",
+          "tableFrom": "meetings",
+          "tableTo": "governing_bodies",
+          "columnsFrom": [
+            "body_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "summaries": {
+      "name": "summaries",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "highlights": {
+          "name": "highlights",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prose": {
+          "name": "prose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "summaries_meeting_id_meetings_id_fk": {
+          "name": "summaries_meeting_id_meetings_id_fk",
+          "tableFrom": "summaries",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "transcripts": {
+      "name": "transcripts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "meeting_id": {
+          "name": "meeting_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "segments": {
+          "name": "segments",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transcripts_meeting_id_meetings_id_fk": {
+          "name": "transcripts_meeting_id_meetings_id_fk",
+          "tableFrom": "transcripts",
+          "tableTo": "meetings",
+          "columnsFrom": [
+            "meeting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1775669041303,
       "tag": "0000_jazzy_marvel_boy",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776100879514,
+      "tag": "0001_natural_tarot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -54,6 +54,16 @@ export const meetings = sqliteTable("meetings", {
  * Source documents (agendas, minutes, ordinances) scraped from the eGov portal.
  * `rawText` holds the extracted text content from the PDF, which becomes the
  * input for the LLM summarization step. `sourceUrl` links back to the original.
+ *
+ * `extractionMethod` records which path produced `rawText`:
+ *   - `text-layer`: PDF had a native text layer (fast path, high fidelity)
+ *   - `ocr`:        rasterize + tesseract fallback for scanned/image-only PDFs
+ *   - `unreadable`: neither path yielded text; `rawText` is empty and no
+ *                   summary or fiscal decisions are stored for the meeting,
+ *                   but the document row still exists so the meeting appears
+ *                   in listings with a link to the source PDF.
+ *
+ * Default `'text-layer'` keeps pre-OCR rows valid without a backfill.
  */
 export const documents = sqliteTable("documents", {
 	id: integer({ mode: "number" }).primaryKey({ autoIncrement: true }),
@@ -63,6 +73,7 @@ export const documents = sqliteTable("documents", {
 	sourceUrl: text("source_url").notNull(),
 	rawText: text("raw_text").notNull(),
 	documentType: text("document_type").notNull(), // "agenda" | "minutes" | "ordinance"
+	extractionMethod: text("extraction_method").notNull().default("text-layer"), // "text-layer" | "ocr" | "unreadable"
 	createdAt: integer("created_at", { mode: "timestamp" }).default(
 		sql`(unixepoch())`,
 	),

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -8,7 +8,10 @@ import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScrap
 import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
 import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
 import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
-import type { Meeting } from "#/pipeline/services/StorageService.ts";
+import type {
+	Meeting,
+	MeetingInput,
+} from "#/pipeline/services/StorageService.ts";
 import { StorageService } from "#/pipeline/services/StorageService.ts";
 import type { SummarizationResult } from "#/pipeline/services/SummarizationService.ts";
 import { SummarizationService } from "#/pipeline/services/SummarizationService.ts";
@@ -30,6 +33,7 @@ type CallLog = {
 	transcribe: Array<string>;
 	summarize: Array<{ sourceText: string; meetingContext: string }>;
 	store: Array<{ bodySlug: string; date: string }>;
+	storeInputs: Array<MeetingInput>;
 	alert: Array<{ subject: string; body: string }>;
 };
 
@@ -43,6 +47,7 @@ function emptyCallLog(): CallLog {
 		transcribe: [],
 		summarize: [],
 		store: [],
+		storeInputs: [],
 		alert: [],
 	};
 }
@@ -137,6 +142,7 @@ function buildStubLayers(config: StubConfig) {
 		storeMeeting: (input) =>
 			Effect.sync(() => {
 				config.log.store.push({ bodySlug: input.bodySlug, date: input.date });
+				config.log.storeInputs.push(input);
 				return config.storedMeeting ?? defaultMeeting;
 			}),
 		getMeetingByBodyAndDate: () =>
@@ -197,8 +203,10 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () =>
-				"Meeting minutes body text with $50,000 decision",
+			extractPdfText: async () => ({
+				text: "Meeting minutes body text with $50,000 decision",
+				method: "text-layer",
+			}),
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
 
@@ -235,7 +243,7 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "text",
+			extractPdfText: async () => ({ text: "text", method: "text-layer" }),
 			dryRun: true,
 		}).pipe(Effect.provide(layers));
 
@@ -274,7 +282,7 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "text",
+			extractPdfText: async () => ({ text: "text", method: "text-layer" }),
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
 
@@ -326,7 +334,10 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "school board text",
+			extractPdfText: async () => ({
+				text: "school board text",
+				method: "text-layer",
+			}),
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
 
@@ -358,7 +369,7 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "text",
+			extractPdfText: async () => ({ text: "text", method: "text-layer" }),
 			dryRun: true,
 			now: new Date("2026-04-10T00:00:00Z"),
 		}).pipe(Effect.provide(layers));
@@ -394,7 +405,7 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "text",
+			extractPdfText: async () => ({ text: "text", method: "text-layer" }),
 			dryRun: true,
 			now: new Date("2026-04-10T00:00:00Z"),
 		}).pipe(Effect.provide(layers));
@@ -430,7 +441,7 @@ describe("runPipeline", () => {
 			youtubeDelayMs: 0,
 			networkRetry: { attempts: 0, baseDelayMs: 0 },
 			llmRetry: { attempts: 0, baseDelayMs: 0 },
-			extractPdfText: async () => "unused",
+			extractPdfText: async () => ({ text: "unused", method: "text-layer" }),
 			dryRun: false,
 		}).pipe(Effect.provide(layers));
 
@@ -442,5 +453,95 @@ describe("runPipeline", () => {
 		expect(log.summarize[0].sourceText).toContain("transcript for abc123");
 		expect(log.store).toHaveLength(1);
 		expect(result.processed).toBe(1);
+	});
+
+	it("persists an unreadable eGov PDF as a document row without summarizing", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 42,
+					title: "Scanned 2024 Minutes",
+					date: "05/13/2024",
+					downloadUrl: "https://example.com/doc/scanned-42",
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "town-council",
+					name: "Town Council",
+					egovSearchType: "12",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			// Tri-state outcome: both the text-layer and OCR paths returned nothing.
+			extractPdfText: async () => ({ text: "", method: "unreadable" }),
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		// Summarizer was skipped — no LLM call for an unreadable document.
+		expect(log.summarize).toHaveLength(0);
+		// Meeting was still persisted so the scanned minutes show up in listings.
+		expect(log.store).toHaveLength(1);
+		const stored = log.storeInputs[0];
+		expect(stored.documents).toHaveLength(1);
+		expect(stored.documents[0].extractionMethod).toBe("unreadable");
+		expect(stored.documents[0].rawText).toBe("");
+		expect(stored.summary).toBeUndefined();
+		expect(stored.fiscalDecisions).toBeUndefined();
+		// An unreadable extraction is not a pipeline error — it's a first-class
+		// outcome now, so `processed` increments and `errors` stays at zero.
+		expect(result.processed).toBe(1);
+		expect(result.errors).toBe(0);
+		expect(log.alert).toHaveLength(0);
+	});
+
+	it("threads the OCR extraction method through to the stored document row", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 99,
+					title: "Scanned minutes that OCR could read",
+					date: "06/11/2024",
+					downloadUrl: "https://example.com/doc/ocr-99",
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "town-council",
+					name: "Town Council",
+					egovSearchType: "12",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({
+				text: "OCR-extracted meeting minutes discussing $42,000",
+				method: "ocr",
+			}),
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		await Effect.runPromise(program);
+
+		expect(log.summarize).toHaveLength(1);
+		expect(log.store).toHaveLength(1);
+		expect(log.storeInputs[0].documents[0].extractionMethod).toBe("ocr");
 	});
 });

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -623,8 +623,8 @@ describe("runPipeline", () => {
 		const byMethod = Object.fromEntries(
 			stored.documents.map((d) => [d.extractionMethod, d]),
 		);
-		expect(byMethod["unreadable"]?.rawText).toBe("");
-		expect(byMethod["unreadable"]?.sourceUrl).toContain("uuid-agenda-scanned");
+		expect(byMethod.unreadable?.rawText).toBe("");
+		expect(byMethod.unreadable?.sourceUrl).toContain("uuid-agenda-scanned");
 		expect(byMethod["text-layer"]?.rawText).toContain("$10,000");
 		expect(byMethod["text-layer"]?.sourceUrl).toContain(
 			"uuid-minutes-readable",

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -637,4 +637,69 @@ describe("runPipeline", () => {
 		expect(result.errors).toBe(0);
 		expect(log.alert).toHaveLength(0);
 	});
+
+	it("persists an all-unreadable Finalsite meeting without summarizing", async () => {
+		// Symmetric to the eGov all-unreadable test, but exercises the
+		// distinct allUnreadable branch in processFinalsiteListing — multi-doc
+		// meetings (e.g., agenda + minutes) where every document came back as
+		// `unreadable` should still appear in listings via their PDF links,
+		// without the summarizer being called or any error surfacing.
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			finalsiteListings: [
+				{
+					date: "March 17, 2024",
+					meetingType: "Regular Meeting",
+					year: 2024,
+					documents: [
+						{
+							uuid: "uuid-old-agenda",
+							documentType: "agenda",
+							downloadUrl: "/fs/resource-manager/view/uuid-old-agenda",
+							fileName: "old-agenda.pdf",
+						},
+						{
+							uuid: "uuid-old-minutes",
+							documentType: "minutes",
+							downloadUrl: "/fs/resource-manager/view/uuid-old-minutes",
+							fileName: "old-minutes.pdf",
+						},
+					],
+				},
+			],
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "school-board",
+					name: "School Board",
+					finalsiteUrl: "https://example.com/school-board",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({ text: "", method: "unreadable" }),
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		expect(log.summarize).toHaveLength(0);
+		expect(log.store).toHaveLength(1);
+		const stored = log.storeInputs[0];
+		expect(stored.documents).toHaveLength(2);
+		expect(
+			stored.documents.every((d) => d.extractionMethod === "unreadable"),
+		).toBe(true);
+		expect(stored.documents.every((d) => d.rawText === "")).toBe(true);
+		expect(stored.summary).toBeUndefined();
+		expect(stored.fiscalDecisions).toBeUndefined();
+		expect(result.processed).toBe(1);
+		expect(result.errors).toBe(0);
+		expect(log.alert).toHaveLength(0);
+	});
 });

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -544,4 +544,97 @@ describe("runPipeline", () => {
 		expect(log.store).toHaveLength(1);
 		expect(log.storeInputs[0].documents[0].extractionMethod).toBe("ocr");
 	});
+
+	it("summarizes readable Finalsite docs while persisting unreadable siblings on the same meeting", async () => {
+		// Mixed-outcome path: a Finalsite meeting posts one image-only PDF
+		// (e.g. a scanned agenda) and one machine-readable PDF (e.g. minutes).
+		// The orchestrator must summarize from the readable text only, but
+		// still persist both documents on the meeting so the unreadable one
+		// is reachable via its source-of-record link in the UI.
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			finalsiteListings: [
+				{
+					date: "January 20, 2026",
+					meetingType: "Regular Meeting",
+					year: 2026,
+					documents: [
+						{
+							uuid: "uuid-agenda-scanned",
+							documentType: "agenda",
+							downloadUrl: "/fs/resource-manager/view/uuid-agenda-scanned",
+							fileName: "agenda-scanned.pdf",
+						},
+						{
+							uuid: "uuid-minutes-readable",
+							documentType: "minutes",
+							downloadUrl: "/fs/resource-manager/view/uuid-minutes-readable",
+							fileName: "minutes-readable.pdf",
+						},
+					],
+				},
+			],
+		});
+
+		// Sequential per-call mocking via a closure counter — this is the
+		// repo's idiom (see other orchestrator tests). First doc is a scanned
+		// agenda that neither the text-layer nor OCR could read; second is
+		// minutes with a real text layer.
+		let callIndex = 0;
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "school-board",
+					name: "School Board",
+					finalsiteUrl: "https://example.com/school-board",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => {
+				const result =
+					callIndex === 0
+						? ({ text: "", method: "unreadable" } as const)
+						: ({
+								text: "Minutes body text mentioning $10,000 facilities decision",
+								method: "text-layer",
+							} as const);
+				callIndex += 1;
+				return result;
+			},
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		// Summarizer ran exactly once — over the readable text only, not over
+		// the unreadable doc's empty string.
+		expect(log.summarize).toHaveLength(1);
+		expect(log.summarize[0].sourceText).toContain("$10,000");
+
+		// Single meeting persisted with both docs.
+		expect(log.store).toHaveLength(1);
+		const stored = log.storeInputs[0];
+		expect(stored.documents).toHaveLength(2);
+
+		const byMethod = Object.fromEntries(
+			stored.documents.map((d) => [d.extractionMethod, d]),
+		);
+		expect(byMethod["unreadable"]?.rawText).toBe("");
+		expect(byMethod["unreadable"]?.sourceUrl).toContain("uuid-agenda-scanned");
+		expect(byMethod["text-layer"]?.rawText).toContain("$10,000");
+		expect(byMethod["text-layer"]?.sourceUrl).toContain(
+			"uuid-minutes-readable",
+		);
+
+		// Mixed meetings get the summary (only the all-unreadable case skips it).
+		expect(stored.summary).toBeDefined();
+
+		expect(result.processed).toBe(1);
+		expect(result.errors).toBe(0);
+		expect(log.alert).toHaveLength(0);
+	});
 });

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -6,6 +6,7 @@ import {
 } from "#/pipeline/services/AlertService.ts";
 import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
 import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
+import type { ExtractResult } from "#/pipeline/services/PdfExtractor.ts";
 import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
 import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
 import type { MeetingInput } from "#/pipeline/services/StorageService.ts";
@@ -103,8 +104,16 @@ type RunPipelineInput = {
 	crawlDelayMs: number;
 	/** Milliseconds to sleep between YouTube transcription calls. Production: 2000-5000. */
 	youtubeDelayMs?: number;
-	/** Converts a downloaded PDF (ArrayBuffer) into plain text. */
-	extractPdfText: (bytes: ArrayBuffer) => Promise<string>;
+	/**
+	 * Converts a downloaded PDF (ArrayBuffer) into a tri-state extraction
+	 * result. The `method` field tells the orchestrator whether the text came
+	 * from the PDF's native text layer, an OCR fallback, or — when both paths
+	 * yield nothing — that the PDF is `unreadable`. The orchestrator persists
+	 * the `unreadable` case as a document row with empty text and skips
+	 * summarization + fiscal extraction for that meeting instead of treating
+	 * it as a pipeline failure.
+	 */
+	extractPdfText: (bytes: ArrayBuffer) => Promise<ExtractResult>;
 	/** When true, run all stages except storage and alerts — for smoke-testing. */
 	dryRun: boolean;
 	/** Retry policy for network operations (scrape, download). Defaults to {3, 500ms}. */
@@ -367,7 +376,7 @@ function processEgovListing(
 			.downloadDocument(listing.downloadUrl)
 			.pipe(Effect.retry(config.networkSchedule));
 
-		const text = yield* Effect.tryPromise({
+		const extraction = yield* Effect.tryPromise({
 			try: () => config.extractPdfText(bytes),
 			catch: (error) =>
 				new PipelineExtractError({
@@ -375,9 +384,34 @@ function processEgovListing(
 				}),
 		});
 
+		// Unreadable branch: persist the document row so the meeting appears in
+		// listings with a link to the PDF, but skip summarization + fiscal
+		// extraction entirely. This is the "silent hole" the PRD is eliminating
+		// — previously, a scanned PDF would fail extraction and the whole row
+		// would be dropped, making the meeting invisible on the public site.
+		if (extraction.method === "unreadable") {
+			if (config.dryRun) return { processed: 1, errors: 0 };
+
+			yield* storage.storeMeeting({
+				bodySlug: body.slug,
+				date: normalizeEgovDate(listing.date),
+				meetingType: "regular",
+				documents: [
+					{
+						sourceUrl: listing.downloadUrl,
+						rawText: "",
+						documentType: "minutes",
+						extractionMethod: "unreadable",
+					},
+				],
+			});
+
+			return { processed: 1, errors: 0 };
+		}
+
 		const summary = yield* summarizer
 			.summarize({
-				sourceText: text,
+				sourceText: extraction.text,
 				meetingContext: `${body.name}, ${listing.date}`,
 			})
 			.pipe(Effect.retry(config.llmSchedule));
@@ -391,8 +425,9 @@ function processEgovListing(
 			documents: [
 				{
 					sourceUrl: listing.downloadUrl,
-					rawText: text,
+					rawText: extraction.text,
 					documentType: "minutes",
+					extractionMethod: extraction.method,
 				},
 			],
 			summary: {
@@ -462,7 +497,7 @@ function processFinalsiteListing(
 				.downloadDocument(doc.uuid)
 				.pipe(Effect.retry(config.networkSchedule));
 
-			const text = yield* Effect.tryPromise({
+			const extraction = yield* Effect.tryPromise({
 				try: () => config.extractPdfText(bytes),
 				catch: (error) =>
 					new PipelineExtractError({
@@ -471,11 +506,35 @@ function processFinalsiteListing(
 			});
 			documents.push({
 				sourceUrl: doc.downloadUrl,
-				rawText: text,
+				rawText: extraction.text,
 				documentType:
 					doc.documentType === "notice" ? "agenda" : doc.documentType,
+				extractionMethod: extraction.method,
 			});
-			combinedText += `\n${text}`;
+			if (extraction.method !== "unreadable") {
+				combinedText += `\n${extraction.text}`;
+			}
+		}
+
+		// If every document for the meeting came back unreadable, skip
+		// summarization and persist the meeting + document rows so the meeting
+		// still appears in listings with a PDF link. Otherwise summarize the
+		// concatenated text of the readable documents and persist normally.
+		const allUnreadable = documents.every(
+			(d) => d.extractionMethod === "unreadable",
+		);
+
+		if (allUnreadable) {
+			if (config.dryRun) return { processed: 1, errors: 0 };
+
+			yield* storage.storeMeeting({
+				bodySlug: body.slug,
+				date: normalizeFinalsiteDate(listing.date, listing.year),
+				meetingType: meetingTypeFromFinalsiteLabel(listing.meetingType),
+				documents,
+			});
+
+			return { processed: 1, errors: 0 };
 		}
 
 		const summary = yield* summarizer

--- a/src/pipeline/services/PdfExtractor.test.ts
+++ b/src/pipeline/services/PdfExtractor.test.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { extractPdfText, type PdfExtractorDeps } from "./PdfExtractor.ts";
 
 const FIXTURE_URL = new URL(
@@ -22,77 +22,82 @@ async function loadFixtureBytes(url: URL = FIXTURE_URL): Promise<ArrayBuffer> {
 }
 
 describe("extractPdfText", () => {
-	it("extracts plain text from a real multi-page eGov minutes PDF", async () => {
-		const bytes = await loadFixtureBytes();
+	describe("text-layer path", () => {
+		it("returns text with method='text-layer' for a real multi-page PDF", async () => {
+			const bytes = await loadFixtureBytes();
 
-		const text = await extractPdfText(bytes);
+			const result = await extractPdfText(bytes);
 
-		// Header + body content from page 1
-		expect(text).toContain("Ellettsville Town Council");
-		expect(text).toContain("January 14, 2026");
-		expect(text).toContain("Mayor Smith");
+			expect(result.method).toBe("text-layer");
+			expect(result.text).toContain("Ellettsville Town Council");
+			expect(result.text).toContain("January 14, 2026");
+			expect(result.text).toContain("Mayor Smith");
+		});
+
+		it("preserves dollar amounts in the extracted text", async () => {
+			const bytes = await loadFixtureBytes();
+
+			const result = await extractPdfText(bytes);
+
+			// Dollar amounts spread across both pages. We check digit groups rather
+			// than strict "$12,500.00" formatting because PDF text extractors often
+			// tokenize punctuation separately from whitespace.
+			expect(result.text).toMatch(/12[,\s]?500/);
+			expect(result.text).toMatch(/47[,\s]?850/);
+			expect(result.text).toMatch(/112[,\s]?500/);
+		});
+
+		it("preserves multi-page text order (page 1 content before page 2 content)", async () => {
+			const bytes = await loadFixtureBytes();
+
+			const result = await extractPdfText(bytes);
+
+			const page1Marker = result.text.indexOf("called to order");
+			const page2Marker = result.text.indexOf("adjourned at 9:15");
+
+			expect(page1Marker).toBeGreaterThanOrEqual(0);
+			expect(page2Marker).toBeGreaterThanOrEqual(0);
+			expect(page1Marker).toBeLessThan(page2Marker);
+		});
 	});
 
-	it("preserves dollar amounts in the extracted text", async () => {
-		const bytes = await loadFixtureBytes();
+	describe("parse errors", () => {
+		// Real parser errors (bad bytes, truncated files) still throw. Only
+		// "the PDF had no extractable text" maps to method='unreadable'.
+		it("throws for non-PDF input bytes", async () => {
+			const garbage = new TextEncoder().encode("this is not a pdf file at all");
+			const bytes = garbage.buffer.slice(
+				garbage.byteOffset,
+				garbage.byteOffset + garbage.byteLength,
+			);
 
-		const text = await extractPdfText(bytes);
+			await expect(extractPdfText(bytes)).rejects.toThrow();
+		});
 
-		// Dollar amounts spread across both pages. We check digit groups rather
-		// than strict "$12,500.00" formatting because PDF text extractors often
-		// tokenize punctuation separately from whitespace.
-		expect(text).toMatch(/12[,\s]?500/);
-		expect(text).toMatch(/47[,\s]?850/);
-		expect(text).toMatch(/112[,\s]?500/);
+		it("throws for truncated PDF bytes", async () => {
+			const fixture = await loadFixtureBytes();
+			const truncated = fixture.slice(0, 8);
+
+			await expect(extractPdfText(truncated)).rejects.toThrow();
+		});
 	});
 
-	it("preserves multi-page text order (page 1 content before page 2 content)", async () => {
-		const bytes = await loadFixtureBytes();
-
-		const text = await extractPdfText(bytes);
-
-		const page1Marker = text.indexOf("called to order");
-		const page2Marker = text.indexOf("adjourned at 9:15");
-
-		expect(page1Marker).toBeGreaterThanOrEqual(0);
-		expect(page2Marker).toBeGreaterThanOrEqual(0);
-		expect(page1Marker).toBeLessThan(page2Marker);
-	});
-
-	it("throws a clear error for non-PDF input bytes", async () => {
-		const garbage = new TextEncoder().encode("this is not a pdf file at all");
-		const bytes = garbage.buffer.slice(
-			garbage.byteOffset,
-			garbage.byteOffset + garbage.byteLength,
-		);
-
-		await expect(extractPdfText(bytes)).rejects.toThrow();
-	});
-
-	it("throws a clear error for truncated PDF bytes", async () => {
-		const fixture = await loadFixtureBytes();
-		// First 8 bytes = "%PDF-1.3" header but nothing else. Should trip parser.
-		const truncated = fixture.slice(0, 8);
-
-		await expect(extractPdfText(truncated)).rejects.toThrow();
-	});
-
-	describe("OCR fallback", () => {
+	describe("OCR fallback (with injected deps)", () => {
 		// These tests exercise the composite wiring in isolation by injecting
 		// fake deps. The real OCR path is covered end-to-end in
 		// OcrExtractor.test.ts; here we care only that the composite routes to
 		// OCR when (and only when) the text-layer path produces no text.
 		const BYTES = new Uint8Array([0]).buffer;
 
-		it("falls back to OCR when the text layer returns an empty string", async () => {
+		it("returns method='ocr' when the text layer is empty and OCR produces text", async () => {
 			const deps: PdfExtractorDeps = {
 				extractTextLayer: vi.fn().mockResolvedValue(""),
 				ocrPdf: vi.fn().mockResolvedValue("hello from OCR"),
 			};
 
-			const text = await extractPdfText(BYTES, deps);
+			const result = await extractPdfText(BYTES, deps);
 
-			expect(text).toBe("hello from OCR");
+			expect(result).toEqual({ text: "hello from OCR", method: "ocr" });
 			expect(deps.ocrPdf).toHaveBeenCalledOnce();
 		});
 
@@ -104,9 +109,9 @@ describe("extractPdfText", () => {
 				ocrPdf: vi.fn().mockResolvedValue("real text"),
 			};
 
-			const text = await extractPdfText(BYTES, deps);
+			const result = await extractPdfText(BYTES, deps);
 
-			expect(text).toBe("real text");
+			expect(result).toEqual({ text: "real text", method: "ocr" });
 			expect(deps.ocrPdf).toHaveBeenCalledOnce();
 		});
 
@@ -119,89 +124,44 @@ describe("extractPdfText", () => {
 				ocrPdf,
 			};
 
-			const text = await extractPdfText(BYTES, deps);
+			const result = await extractPdfText(BYTES, deps);
 
-			expect(text).toBe("text layer content");
+			expect(result).toEqual({
+				text: "text layer content",
+				method: "text-layer",
+			});
 			expect(ocrPdf).not.toHaveBeenCalled();
-		});
-
-		describe("when both paths return no text", () => {
-			const originalAllowEmpty = process.env.ALLOW_EMPTY_PDF_TEXT;
-
-			beforeEach(() => {
-				delete process.env.ALLOW_EMPTY_PDF_TEXT;
-			});
-
-			afterEach(() => {
-				if (originalAllowEmpty === undefined) {
-					delete process.env.ALLOW_EMPTY_PDF_TEXT;
-				} else {
-					process.env.ALLOW_EMPTY_PDF_TEXT = originalAllowEmpty;
-				}
-			});
-
-			it("throws a clear error mentioning both paths failed", async () => {
-				const deps: PdfExtractorDeps = {
-					extractTextLayer: vi.fn().mockResolvedValue(""),
-					ocrPdf: vi.fn().mockResolvedValue(""),
-				};
-
-				await expect(extractPdfText(BYTES, deps)).rejects.toThrow(
-					/text-layer.*OCR|OCR.*text-layer/i,
-				);
-			});
-
-			it("returns empty text when ALLOW_EMPTY_PDF_TEXT=1 is set", async () => {
-				process.env.ALLOW_EMPTY_PDF_TEXT = "1";
-				const deps: PdfExtractorDeps = {
-					extractTextLayer: vi.fn().mockResolvedValue(""),
-					ocrPdf: vi.fn().mockResolvedValue(""),
-				};
-
-				const text = await extractPdfText(BYTES, deps);
-
-				expect(text).toBe("");
-			});
 		});
 	});
 
-	describe("empty-text guard", () => {
-		const originalAllowEmpty = process.env.ALLOW_EMPTY_PDF_TEXT;
+	describe("unreadable outcome", () => {
+		const BYTES = new Uint8Array([0]).buffer;
 
-		beforeEach(() => {
-			delete process.env.ALLOW_EMPTY_PDF_TEXT;
+		it("returns method='unreadable' with empty text when both paths produce no text", async () => {
+			// The silent-degradation guard moved from a thrown error to a tri-state
+			// return: the orchestrator now records an unreadable document row
+			// rather than treating the meeting as a pipeline failure. The
+			// StorageService invariant assertion catches any drift that would try
+			// to persist a non-unreadable document with empty text.
+			const deps: PdfExtractorDeps = {
+				extractTextLayer: vi.fn().mockResolvedValue(""),
+				ocrPdf: vi.fn().mockResolvedValue(""),
+			};
+
+			const result = await extractPdfText(BYTES, deps);
+
+			expect(result).toEqual({ text: "", method: "unreadable" });
 		});
 
-		afterEach(() => {
-			if (originalAllowEmpty === undefined) {
-				delete process.env.ALLOW_EMPTY_PDF_TEXT;
-			} else {
-				process.env.ALLOW_EMPTY_PDF_TEXT = originalAllowEmpty;
-			}
-		});
-
-		// End-to-end: the composite now attempts OCR before failing, so a
-		// truly blank PDF flows through both paths before the guard throws.
-		// Tesseract worker startup + blank-page recognition adds a few seconds.
-		it("throws a clear error when a valid PDF has no extractable text (likely scanned/image-only)", {
+		it("returns method='unreadable' end-to-end for a valid PDF with no extractable text", {
 			timeout: 60_000,
 		}, async () => {
 			const bytes = await loadFixtureBytes(EMPTY_FIXTURE_URL);
 
-			await expect(extractPdfText(bytes)).rejects.toThrow(
-				/no text|scanned|OCR/i,
-			);
-		});
+			const result = await extractPdfText(bytes);
 
-		it("returns empty text when ALLOW_EMPTY_PDF_TEXT=1 is set (smoke-test opt-in)", {
-			timeout: 60_000,
-		}, async () => {
-			process.env.ALLOW_EMPTY_PDF_TEXT = "1";
-			const bytes = await loadFixtureBytes(EMPTY_FIXTURE_URL);
-
-			const text = await extractPdfText(bytes);
-
-			expect(text.trim().length).toBe(0);
+			expect(result.method).toBe("unreadable");
+			expect(result.text.trim()).toBe("");
 		});
 	});
 });

--- a/src/pipeline/services/PdfExtractor.ts
+++ b/src/pipeline/services/PdfExtractor.ts
@@ -4,21 +4,27 @@ import { ocrPdf as defaultOcrPdf } from "./OcrExtractor.ts";
 
 /**
  * Composite PDF text extractor: tries the text-layer path first, falls back
- * to OCR for scanned/image-only PDFs, then enforces the empty-text guard
- * across both paths.
+ * to OCR for scanned/image-only PDFs, then signals the outcome via a tri-state
+ * return rather than throwing on empty.
  *
- * Used via `RunPipelineInput.extractPdfText` in the orchestrator, which wraps
- * this call in `Effect.tryPromise` so any thrown error surfaces as a tagged
- * `PipelineExtractError`. Keeping this as a plain async function (not an
- * Effect.Tag service) matches the orchestrator's function-reference seam:
- * tests and the dry-run path substitute a different implementation by passing
- * a different reference, not by reshaping the dependency graph.
+ * Used via `RunPipelineInput.extractPdfText` in the orchestrator. The
+ * orchestrator still wraps this call in `Effect.tryPromise` — real parser
+ * errors (bad bytes, truncated files) continue to throw — but a PDF with no
+ * extractable text now returns `{ text: '', method: 'unreadable' }` so the
+ * orchestrator can persist a document row for the meeting instead of dropping
+ * it. The previous `ALLOW_EMPTY_PDF_TEXT` env-var escape hatch is retired by
+ * the tri-state return.
  *
- * The internal two-path structure is exposed through the optional `deps`
- * argument so unit tests can drive the wiring without spinning up the real
- * OCR worker. Production callers pass only `bytes` and get the default
- * implementations.
+ * Keeping this as a plain async function (not an Effect.Tag service) matches
+ * the orchestrator's function-reference seam: tests and the dry-run path
+ * substitute a different implementation by passing a different reference, not
+ * by reshaping the dependency graph.
  */
+export type ExtractResult = {
+	text: string;
+	method: "text-layer" | "ocr" | "unreadable";
+};
+
 export type PdfExtractorDeps = {
 	extractTextLayer: (bytes: ArrayBuffer) => Promise<string>;
 	ocrPdf: (bytes: ArrayBuffer) => Promise<string>;
@@ -46,29 +52,24 @@ const defaultDeps: PdfExtractorDeps = {
 export async function extractPdfText(
 	bytes: ArrayBuffer,
 	deps: PdfExtractorDeps = defaultDeps,
-): Promise<string> {
+): Promise<ExtractResult> {
 	const textLayer = await deps.extractTextLayer(bytes);
 	if (textLayer.trim().length > 0) {
-		return textLayer;
+		return { text: textLayer, method: "text-layer" };
 	}
 
 	const ocrText = await deps.ocrPdf(bytes);
-
-	// Silent-degradation guard, promoted to the composite level. An image-only
-	// PDF that tesseract also can't read (too dark, skewed, handwritten) would
-	// otherwise flow through the pipeline as an empty summary and zero fiscal
-	// decisions — the failure class documented in
-	// docs/solutions/patterns/empty-output-silent-degradation-2026-04-11.md.
-	// Fail loudly so the orchestrator alerts and the row is not stored. Opt out
-	// via ALLOW_EMPTY_PDF_TEXT=1 for smoke-test scenarios with a deliberately
-	// blank PDF.
-	if (ocrText.trim().length === 0 && !process.env.ALLOW_EMPTY_PDF_TEXT) {
-		throw new Error(
-			"Both text-layer extraction and OCR returned no text — the PDF may be " +
-				"unreadable (too dark, rotated, handwritten). " +
-				"Set ALLOW_EMPTY_PDF_TEXT=1 to accept empty extractions.",
-		);
+	if (ocrText.trim().length > 0) {
+		return { text: ocrText, method: "ocr" };
 	}
 
-	return ocrText;
+	// Both paths yielded no text. Return the unreadable outcome; the
+	// orchestrator is responsible for persisting the meeting with this
+	// document flagged as unreadable and skipping summarization + fiscal
+	// extraction. The failure class is documented in
+	// docs/solutions/patterns/empty-output-silent-degradation-2026-04-11.md —
+	// we keep the silent-degradation guard honest by forcing the orchestrator
+	// to handle this path explicitly and by asserting in StorageService that
+	// non-unreadable documents always carry non-empty text.
+	return { text: "", method: "unreadable" };
 }

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -7,7 +7,11 @@ import { migrate } from "drizzle-orm/libsql/migrator";
 import { Effect } from "effect";
 import { afterAll, describe, expect, it } from "vitest";
 import * as schema from "#/db/schema.ts";
-import { StorageService, StorageServiceLive } from "./StorageService.ts";
+import {
+	OCR_CONFIDENCE_MULTIPLIER,
+	StorageService,
+	StorageServiceLive,
+} from "./StorageService.ts";
 
 const tmpFiles: string[] = [];
 
@@ -54,6 +58,7 @@ const testMeetingInput = {
 			rawText:
 				"Meeting called to order. Motion to approve $50,000 for road repairs.",
 			documentType: "minutes" as const,
+			extractionMethod: "text-layer" as const,
 		},
 	],
 	summary: {
@@ -148,6 +153,111 @@ describe("StorageService", () => {
 				.all();
 			expect(discussions).toHaveLength(1);
 			expect(discussions[0].topic).toBe("Park pavilion renovation");
+
+			// Default extraction method is preserved on the document row
+			expect(docs[0].extractionMethod).toBe("text-layer");
+		});
+
+		it("persists an unreadable meeting with the document row but no summary or fiscal data", async () => {
+			const db = await createTestDb();
+			const unreadableInput = {
+				bodySlug: "ellettsville-town-council",
+				date: "2024-05-13",
+				meetingType: "regular" as const,
+				documents: [
+					{
+						sourceUrl:
+							"https://ellettsville.in.us/egov/docs/scanned-2024-05-13.pdf",
+						rawText: "",
+						documentType: "minutes" as const,
+						extractionMethod: "unreadable" as const,
+					},
+				],
+				// No summary, fiscalDecisions, or budgetDiscussions — the meeting
+				// is reachable via its PDF link but the upstream pipeline did not
+				// produce any LLM output.
+			};
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeMeeting(unreadableInput);
+				}).pipe(Effect.provide(StorageServiceLive(db))),
+			);
+
+			const meetings = await db.select().from(schema.meetings).all();
+			expect(meetings).toHaveLength(1);
+
+			const docs = await db.select().from(schema.documents).all();
+			expect(docs).toHaveLength(1);
+			expect(docs[0].extractionMethod).toBe("unreadable");
+			expect(docs[0].rawText).toBe("");
+
+			const summaries = await db.select().from(schema.summaries).all();
+			expect(summaries).toHaveLength(0);
+			const fiscals = await db.select().from(schema.fiscalDecisions).all();
+			expect(fiscals).toHaveLength(0);
+			const discussions = await db
+				.select()
+				.from(schema.budgetDiscussions)
+				.all();
+			expect(discussions).toHaveLength(0);
+		});
+
+		it("rejects a document that claims 'text-layer' or 'ocr' but has empty rawText", async () => {
+			const db = await createTestDb();
+			const brokenInput = {
+				...testMeetingInput,
+				documents: [
+					{
+						...testMeetingInput.documents[0],
+						rawText: "",
+						extractionMethod: "text-layer" as const,
+					},
+				],
+			};
+
+			const program = Effect.gen(function* () {
+				const storage = yield* StorageService;
+				return yield* storage.storeMeeting(brokenInput);
+			}).pipe(Effect.provide(StorageServiceLive(db)));
+
+			await expect(Effect.runPromise(program)).rejects.toThrow(
+				/invariant|unreadable/i,
+			);
+
+			// And nothing was written — the assertion fires before the transaction.
+			const meetings = await db.select().from(schema.meetings).all();
+			expect(meetings).toHaveLength(0);
+		});
+
+		it("applies the OCR confidence multiplier to fiscal decisions when any source doc is OCR", async () => {
+			const db = await createTestDb();
+			const ocrInput = {
+				...testMeetingInput,
+				date: "2025-09-09",
+				documents: [
+					{
+						...testMeetingInput.documents[0],
+						extractionMethod: "ocr" as const,
+					},
+				],
+			};
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeMeeting(ocrInput);
+				}).pipe(Effect.provide(StorageServiceLive(db))),
+			);
+
+			const fiscals = await db.select().from(schema.fiscalDecisions).all();
+			expect(fiscals).toHaveLength(1);
+			// testMeetingInput.fiscalDecisions[0].confidence === 0.95
+			expect(fiscals[0].confidence).toBeCloseTo(
+				0.95 * OCR_CONFIDENCE_MULTIPLIER,
+				5,
+			);
 		});
 	});
 

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -19,6 +19,8 @@ import { DatabaseError } from "#/pipeline/errors.ts";
  * This is the "write shape" — what the pipeline produces after scraping
  * and summarizing, ready to be stored atomically in a single transaction.
  */
+type ExtractionMethod = "text-layer" | "ocr" | "unreadable";
+
 type MeetingInput = {
 	bodySlug: string;
 	date: string;
@@ -27,13 +29,20 @@ type MeetingInput = {
 		sourceUrl: string;
 		rawText: string;
 		documentType: "agenda" | "minutes" | "ordinance";
+		extractionMethod: ExtractionMethod;
 	}>;
-	summary: {
+	/**
+	 * Optional — omitted when every document for this meeting is `unreadable`.
+	 * In that case the meeting row + document rows are still persisted so the
+	 * meeting appears in listings with a link to the source PDF, but nothing
+	 * is written to `summaries`, `fiscal_decisions`, or `budget_discussions`.
+	 */
+	summary?: {
 		highlights: string[];
 		prose: string;
 		model: string;
 	};
-	fiscalDecisions: Array<{
+	fiscalDecisions?: Array<{
 		title: string;
 		description: string;
 		amount: number;
@@ -53,6 +62,16 @@ type MeetingInput = {
 		notes?: string;
 	}>;
 };
+
+/**
+ * Multiplier applied to `confidence` on fiscal decisions whose source meeting
+ * has at least one OCR-extracted document. OCR typically sits at 3–8% WER on
+ * clean printed scans and 10–20% on degraded ones, which can subtly corrupt
+ * dollar figures in ways the LLM can't detect. Lowering the default confidence
+ * lets the existing confidence-aware UI surface that uncertainty without
+ * adding OCR-specific rendering paths downstream of the fiscal-decision row.
+ */
+const OCR_CONFIDENCE_MULTIPLIER = 0.75;
 
 type TranscriptInput = {
 	meetingId: number;
@@ -197,6 +216,26 @@ async function storeMeetingTransaction(
 	db: LibSQLDatabase<typeof schema>,
 	input: MeetingInput,
 ): Promise<Meeting> {
+	// Silent-degradation guard, enforced at the storage boundary. The composite
+	// extractor returns `method: 'unreadable'` for empty outcomes; anything
+	// claiming `text-layer` or `ocr` must carry non-empty text. This assertion
+	// catches upstream drift (a new path that forgets to map its empty case to
+	// 'unreadable') before the row hits the database and turns into invisible
+	// bad data. See docs/solutions/patterns/empty-output-silent-degradation-2026-04-11.md.
+	for (const doc of input.documents) {
+		if (doc.extractionMethod !== "unreadable" && doc.rawText.trim() === "") {
+			throw new Error(
+				`StorageService invariant violated: document sourceUrl=${doc.sourceUrl} ` +
+					`has extractionMethod='${doc.extractionMethod}' but empty rawText. ` +
+					`Empty text must be tagged as 'unreadable'.`,
+			);
+		}
+	}
+
+	const hasOcrSource = input.documents.some(
+		(d) => d.extractionMethod === "ocr",
+	);
+
 	return await db.transaction(async (tx) => {
 		// Resolve governing body by slug
 		const body = await tx
@@ -229,41 +268,51 @@ async function storeMeetingTransaction(
 					sourceUrl: doc.sourceUrl,
 					rawText: doc.rawText,
 					documentType: doc.documentType,
+					extractionMethod: doc.extractionMethod,
 				})
 				.run();
 		}
 
-		// Insert summary
-		await tx
-			.insert(schema.summaries)
-			.values({
-				meetingId: meeting.id,
-				highlights: input.summary.highlights,
-				prose: input.summary.prose,
-				model: input.summary.model,
-			})
-			.run();
-
-		// Insert fiscal decisions
-		for (const fd of input.fiscalDecisions) {
+		// Insert summary — skipped when all documents were unreadable.
+		if (input.summary) {
 			await tx
-				.insert(schema.fiscalDecisions)
+				.insert(schema.summaries)
 				.values({
 					meetingId: meeting.id,
-					title: fd.title,
-					description: fd.description,
-					amount: fd.amount,
-					originalAmount: fd.originalAmount,
-					budgetCategory: fd.budgetCategory,
-					status: fd.status,
-					voteRecord: fd.voteRecord,
-					vendor: fd.vendor,
-					fundingSource: fd.fundingSource,
-					ordinanceNumber: fd.ordinanceNumber,
-					confidence: fd.confidence,
-					isRecurring: fd.isRecurring,
+					highlights: input.summary.highlights,
+					prose: input.summary.prose,
+					model: input.summary.model,
 				})
 				.run();
+		}
+
+		// Insert fiscal decisions. When any source document was OCR, we lower
+		// the default confidence so the existing confidence-aware UI conveys
+		// the extra uncertainty without needing an OCR-aware branch of its own.
+		if (input.fiscalDecisions) {
+			for (const fd of input.fiscalDecisions) {
+				const confidence = hasOcrSource
+					? fd.confidence * OCR_CONFIDENCE_MULTIPLIER
+					: fd.confidence;
+				await tx
+					.insert(schema.fiscalDecisions)
+					.values({
+						meetingId: meeting.id,
+						title: fd.title,
+						description: fd.description,
+						amount: fd.amount,
+						originalAmount: fd.originalAmount,
+						budgetCategory: fd.budgetCategory,
+						status: fd.status,
+						voteRecord: fd.voteRecord,
+						vendor: fd.vendor,
+						fundingSource: fd.fundingSource,
+						ordinanceNumber: fd.ordinanceNumber,
+						confidence,
+						isRecurring: fd.isRecurring,
+					})
+					.run();
+			}
 		}
 
 		// Insert budget discussions
@@ -285,5 +334,5 @@ async function storeMeetingTransaction(
 	});
 }
 
-export { StorageService, StorageServiceLive };
-export type { MeetingInput, Meeting };
+export { StorageService, StorageServiceLive, OCR_CONFIDENCE_MULTIPLIER };
+export type { MeetingInput, Meeting, ExtractionMethod };


### PR DESCRIPTION
## Summary

Scanned / image-only eGov PDFs — ~84% of Ellettsville Town Council's historical listings — were being silently dropped when extraction failed. This slice turns "no text" from a thrown error into a first-class `unreadable` extraction outcome that the orchestrator persists as a document row with a link to the source PDF, so the meeting still appears in listings instead of vanishing.

## PRD

Refs #26

## Slices

- [x] #30 — Tri-state extraction contract + orchestrator unreadable path (this PR)
- [ ] #31 — Meeting detail UI: OCR banner + unreadable status card + fiscal badge
- [ ] #32 — QA: end-to-end verification on Ellettsville Town Council historical corpus

## Key Decisions

- **Flat `ExtractResult = { text, method }` over a discriminated union.** Chose the shape the PRD checkpoint specified; keeps the orchestrator branch a simple `if method === 'unreadable'` check and avoids a generic helper just to narrow a union at the single call site that needs it.
- **`ALLOW_EMPTY_PDF_TEXT` env escape hatch dropped.** The tri-state return makes the knob redundant — tests inject deps, smoke tests get the `unreadable` outcome directly.
- **`OCR_CONFIDENCE_MULTIPLIER = 0.75` lives in StorageService**, not in the composite or the orchestrator. Applied at insert time when any source document is OCR. Keeps the existing confidence-aware UI working without OCR-specific rendering.
- **Invariant assertion in StorageService** (`method !== 'unreadable' → rawText.trim().length > 0`) catches upstream drift before it hits the DB — the silent-corruption failure class from `docs/solutions/patterns/empty-output-silent-degradation-2026-04-11.md`.
- **Finalsite multi-doc semantic:** persist as unreadable only when **every** doc on a meeting came back unreadable; otherwise summarize the readable docs and mark per-doc methods. Not explicit in the PRD — flagging here because it's a product call.
- **Schema change shipped as a standalone additive commit** ahead of the type-ripple commit so the column default preserves pre-OCR rows without a backfill.