### PR TITLE
Meeting detail UI: OCR banner + unreadable status card + fiscal badges (#31)

### DIFF
--- a/src/components/MeetingCard.test.tsx
+++ b/src/components/MeetingCard.test.tsx
@@ -11,6 +11,7 @@ const baseMeeting = {
 	meetingType: "regular" as const,
 	bodyName: "Ellettsville Town Council",
 	bodySlug: "ellettsville-town-council",
+	extractionMethod: "text-layer" as const,
 	highlights: ["Approved road repairs", "Discussed park budget"],
 	prose: "The council met to discuss infrastructure spending.",
 	fiscalDecisionCount: 2,
@@ -56,5 +57,39 @@ describe("MeetingCard", () => {
 		);
 
 		expect(screen.queryByText(/decisions/i)).toBeNull();
+	});
+
+	it("renders an unreadable variant without highlights or fiscal rollup", () => {
+		render(
+			<MeetingCard
+				meeting={{
+					...baseMeeting,
+					extractionMethod: "unreadable",
+					highlights: [],
+					prose: "",
+					fiscalDecisionCount: 0,
+					totalSpending: 0,
+				}}
+			/>,
+		);
+
+		// Body + date still shown; link still navigates to detail
+		screen.getByText("Ellettsville Town Council");
+		screen.getByText("March 23, 2026");
+		const link = screen.getByRole("link");
+		expect(link.getAttribute("href")).toBe(
+			"/meetings/ellettsville-town-council/2026-03-23",
+		);
+
+		// Muted explanatory note directing to source PDF
+		expect(
+			screen.getByText(
+				/Source document couldn't be extracted — open to view the original PDF\./,
+			),
+		).toBeDefined();
+
+		// No fiscal rollup, no highlight bullets
+		expect(screen.queryByText(/decisions/i)).toBeNull();
+		expect(screen.queryByRole("list")).toBeNull();
 	});
 });

--- a/src/components/MeetingCard.tsx
+++ b/src/components/MeetingCard.tsx
@@ -20,6 +20,8 @@ function formatCurrency(amount: number): string {
 }
 
 export function MeetingCard({ meeting }: { meeting: MeetingCardData }) {
+	const isUnreadable = meeting.extractionMethod === "unreadable";
+
 	return (
 		<article className="island-shell feature-card rounded-2xl p-5">
 			<a
@@ -30,21 +32,30 @@ export function MeetingCard({ meeting }: { meeting: MeetingCardData }) {
 				<h3 className="mb-2 text-lg font-semibold text-[var(--sea-ink)]">
 					{formatDate(meeting.date)}
 				</h3>
-				<ul className="m-0 mb-3 list-disc space-y-1 pl-5 text-sm text-[var(--sea-ink-soft)]">
-					{meeting.highlights.slice(0, 3).map((h) => (
-						<li key={h}>{h}</li>
-					))}
-				</ul>
-				{meeting.fiscalDecisionCount > 0 && (
-					<div className="flex items-center gap-3 text-sm text-[var(--sea-ink-soft)]">
-						<span className="font-semibold text-[var(--sea-ink)]">
-							{formatCurrency(meeting.totalSpending)}
-						</span>
-						<span>
-							{meeting.fiscalDecisionCount} decision
-							{meeting.fiscalDecisionCount !== 1 ? "s" : ""}
-						</span>
-					</div>
+				{isUnreadable ? (
+					<p className="text-sm italic text-[var(--sea-ink-soft)]">
+						Source document couldn't be extracted — open to view the original
+						PDF.
+					</p>
+				) : (
+					<>
+						<ul className="m-0 mb-3 list-disc space-y-1 pl-5 text-sm text-[var(--sea-ink-soft)]">
+							{meeting.highlights.slice(0, 3).map((h) => (
+								<li key={h}>{h}</li>
+							))}
+						</ul>
+						{meeting.fiscalDecisionCount > 0 && (
+							<div className="flex items-center gap-3 text-sm text-[var(--sea-ink-soft)]">
+								<span className="font-semibold text-[var(--sea-ink)]">
+									{formatCurrency(meeting.totalSpending)}
+								</span>
+								<span>
+									{meeting.fiscalDecisionCount} decision
+									{meeting.fiscalDecisionCount !== 1 ? "s" : ""}
+								</span>
+							</div>
+						)}
+					</>
 				)}
 			</a>
 		</article>

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -58,6 +58,20 @@ async function seedMeetingWithSummary(
 		.returning()
 		.get();
 
+	// A real pipeline always stores at least one document per meeting;
+	// including a text-layer default here keeps derived extractionMethod
+	// consistent with production state.
+	await db
+		.insert(schema.documents)
+		.values({
+			meetingId: meeting.id,
+			sourceUrl: `https://example.gov/${date}.pdf`,
+			rawText: "Document text.",
+			documentType: "minutes",
+			extractionMethod: "text-layer",
+		})
+		.run();
+
 	await db
 		.insert(schema.summaries)
 		.values({
@@ -131,20 +145,36 @@ describe("listRecentMeetingsQuery", () => {
 		expect(result).toHaveLength(0);
 	});
 
-	it("skips meetings without summaries", async () => {
+	it("includes unreadable meetings without a summary, tagged by extractionMethod", async () => {
 		const db = await createTestDb();
 		const body = await seedBody(db);
 		await seedMeetingWithSummary(db, body.id, "2026-03-23");
-		// Insert a meeting with no summary
-		await db
+		// Insert an unreadable meeting: one document, no summary
+		const unreadable = await db
 			.insert(schema.meetings)
 			.values({ bodyId: body.id, date: "2026-04-01", meetingType: "regular" })
+			.returning()
+			.get();
+		await db
+			.insert(schema.documents)
+			.values({
+				meetingId: unreadable.id,
+				sourceUrl: "https://example.gov/scan.pdf",
+				rawText: "",
+				documentType: "minutes",
+				extractionMethod: "unreadable",
+			})
 			.run();
 
 		const result = await listRecentMeetingsQuery(db);
 
-		expect(result).toHaveLength(1);
-		expect(result[0].date).toBe("2026-03-23");
+		expect(result).toHaveLength(2);
+		const unreadableRow = result.find((r) => r.date === "2026-04-01");
+		expect(unreadableRow?.extractionMethod).toBe("unreadable");
+		expect(unreadableRow?.highlights).toEqual([]);
+		expect(unreadableRow?.fiscalDecisionCount).toBe(0);
+		const readableRow = result.find((r) => r.date === "2026-03-23");
+		expect(readableRow?.extractionMethod).toBe("text-layer");
 	});
 
 	it("includes fiscal decision count and total spending", async () => {

--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -7,6 +7,7 @@ import {
 	aggregateFiscalByBodyQuery,
 	aggregateFiscalByCategoryQuery,
 	aggregateFiscalByTimePeriodQuery,
+	getMeetingByBodyAndDateQuery,
 	listGoverningBodiesQuery,
 	listNotableFiscalDecisionsQuery,
 	listRecentMeetingsQuery,
@@ -351,6 +352,155 @@ describe("listNotableFiscalDecisionsQuery", () => {
 		const result = await listNotableFiscalDecisionsQuery(db, 2);
 
 		expect(result).toHaveLength(2);
+	});
+});
+
+describe("getMeetingByBodyAndDateQuery — extractionMethod", () => {
+	async function seedMeetingWithDocs(
+		db: Awaited<ReturnType<typeof createTestDb>>,
+		bodyId: number,
+		date: string,
+		docs: Array<{
+			sourceUrl: string;
+			rawText: string;
+			documentType: "agenda" | "minutes" | "ordinance";
+			extractionMethod: "text-layer" | "ocr" | "unreadable";
+		}>,
+		summary?: { highlights: string[]; prose: string },
+	) {
+		const meeting = await db
+			.insert(schema.meetings)
+			.values({ bodyId, date, meetingType: "regular" })
+			.returning()
+			.get();
+
+		for (const d of docs) {
+			await db
+				.insert(schema.documents)
+				.values({
+					meetingId: meeting.id,
+					sourceUrl: d.sourceUrl,
+					rawText: d.rawText,
+					documentType: d.documentType,
+					extractionMethod: d.extractionMethod,
+				})
+				.run();
+		}
+
+		if (summary) {
+			await db
+				.insert(schema.summaries)
+				.values({
+					meetingId: meeting.id,
+					highlights: summary.highlights,
+					prose: summary.prose,
+					model: "gemini-2.5-flash",
+				})
+				.run();
+		}
+
+		return meeting;
+	}
+
+	it("returns extractionMethod='text-layer' when all docs use text layer", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithDocs(
+			db,
+			body.id,
+			"2026-03-23",
+			[
+				{
+					sourceUrl: "https://example.gov/a.pdf",
+					rawText: "Agenda text.",
+					documentType: "agenda",
+					extractionMethod: "text-layer",
+				},
+			],
+			{ highlights: ["h1"], prose: "prose" },
+		);
+
+		const result = await getMeetingByBodyAndDateQuery(
+			db,
+			"ellettsville-town-council",
+			"2026-03-23",
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.extractionMethod).toBe("text-layer");
+		expect(result?.summary).not.toBeNull();
+	});
+
+	it("returns extractionMethod='ocr' when any doc was extracted via OCR", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithDocs(
+			db,
+			body.id,
+			"2026-03-23",
+			[
+				{
+					sourceUrl: "https://example.gov/a.pdf",
+					rawText: "Agenda text.",
+					documentType: "agenda",
+					extractionMethod: "text-layer",
+				},
+				{
+					sourceUrl: "https://example.gov/m.pdf",
+					rawText: "Scanned minutes text.",
+					documentType: "minutes",
+					extractionMethod: "ocr",
+				},
+			],
+			{ highlights: ["h1"], prose: "prose" },
+		);
+
+		const result = await getMeetingByBodyAndDateQuery(
+			db,
+			"ellettsville-town-council",
+			"2026-03-23",
+		);
+
+		expect(result?.extractionMethod).toBe("ocr");
+	});
+
+	it("returns extractionMethod='unreadable' with no summary when all docs are unreadable", async () => {
+		const db = await createTestDb();
+		const body = await seedBody(db);
+		await seedMeetingWithDocs(db, body.id, "2026-03-23", [
+			{
+				sourceUrl: "https://example.gov/scan.pdf",
+				rawText: "",
+				documentType: "minutes",
+				extractionMethod: "unreadable",
+			},
+		]);
+
+		const result = await getMeetingByBodyAndDateQuery(
+			db,
+			"ellettsville-town-council",
+			"2026-03-23",
+		);
+
+		expect(result).not.toBeNull();
+		expect(result?.extractionMethod).toBe("unreadable");
+		expect(result?.summary).toBeNull();
+		expect(result?.fiscalDecisions).toHaveLength(0);
+		expect(result?.budgetDiscussions).toHaveLength(0);
+		expect(result?.documents).toHaveLength(1);
+	});
+
+	it("returns null when the meeting does not exist", async () => {
+		const db = await createTestDb();
+		await seedBody(db);
+
+		const result = await getMeetingByBodyAndDateQuery(
+			db,
+			"ellettsville-town-council",
+			"1999-01-01",
+		);
+
+		expect(result).toBeNull();
 	});
 });
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -5,6 +5,28 @@ import * as schema from "#/db/schema.ts";
 export type MeetingType = "regular" | "special" | "workshop";
 export type FiscalStatus = "approved" | "denied" | "tabled";
 export type BodyType = "town" | "county" | "school";
+export type ExtractionMethod = "text-layer" | "ocr" | "unreadable";
+
+const EXTRACTION_METHODS = new Set<string>(["text-layer", "ocr", "unreadable"]);
+
+function parseExtractionMethod(raw: string): ExtractionMethod {
+	if (EXTRACTION_METHODS.has(raw)) return raw as ExtractionMethod;
+	throw new Error(`Invalid extraction method: ${raw}`);
+}
+
+/**
+ * Derive meeting-level extraction method from per-document methods.
+ * "unreadable" only if every document is unreadable (or there are none);
+ * "ocr" if any readable doc came through OCR; "text-layer" otherwise.
+ */
+function deriveMeetingExtractionMethod(
+	methods: ExtractionMethod[],
+): ExtractionMethod {
+	if (methods.length === 0) return "unreadable";
+	if (methods.every((m) => m === "unreadable")) return "unreadable";
+	if (methods.some((m) => m === "ocr")) return "ocr";
+	return "text-layer";
+}
 
 const MEETING_TYPES = new Set<string>(["regular", "special", "workshop"]);
 const FISCAL_STATUSES = new Set<string>(["approved", "denied", "tabled"]);
@@ -370,12 +392,14 @@ export type MeetingDetail = {
 	meetingType: MeetingType;
 	bodyName: string;
 	bodySlug: string;
+	extractionMethod: ExtractionMethod;
 	documents: Array<{
 		sourceUrl: string;
 		rawText: string;
 		documentType: "agenda" | "minutes" | "ordinance";
+		extractionMethod: ExtractionMethod;
 	}>;
-	summary: { highlights: string[]; prose: string; model: string };
+	summary: { highlights: string[]; prose: string; model: string } | null;
 	fiscalDecisions: Array<FiscalDecisionDetail>;
 	budgetDiscussions: Array<{
 		topic: string;
@@ -421,13 +445,16 @@ export async function getMeetingByBodyAndDateQuery(
 		.where(eq(schema.documents.meetingId, meeting.id))
 		.all();
 
+	const docMethods = docs.map((d) => parseExtractionMethod(d.extractionMethod));
+	const extractionMethod = deriveMeetingExtractionMethod(docMethods);
+
 	const summary = await db
 		.select()
 		.from(schema.summaries)
 		.where(eq(schema.summaries.meetingId, meeting.id))
 		.get();
 
-	if (!summary) return null;
+	if (!summary && extractionMethod !== "unreadable") return null;
 
 	const fiscals = await db
 		.select()
@@ -447,17 +474,21 @@ export async function getMeetingByBodyAndDateQuery(
 		meetingType: parseMeetingType(meeting.meetingType),
 		bodyName: body.name,
 		bodySlug: body.slug,
-		documents: docs.map((d) => ({
+		extractionMethod,
+		documents: docs.map((d, i) => ({
 			sourceUrl: d.sourceUrl,
 			rawText: d.rawText,
 			documentType:
 				d.documentType as MeetingDetail["documents"][number]["documentType"],
+			extractionMethod: docMethods[i],
 		})),
-		summary: {
-			highlights: summary.highlights as string[],
-			prose: summary.prose,
-			model: summary.model,
-		},
+		summary: summary
+			? {
+					highlights: summary.highlights as string[],
+					prose: summary.prose,
+					model: summary.model,
+				}
+			: null,
 		fiscalDecisions: fiscals.map((f) => ({
 			title: f.title,
 			description: f.description,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -47,6 +47,7 @@ export type MeetingCardData = {
 	meetingType: MeetingType;
 	bodyName: string;
 	bodySlug: string;
+	extractionMethod: ExtractionMethod;
 	highlights: string[];
 	prose: string;
 	fiscalDecisionCount: number;
@@ -134,12 +135,26 @@ export async function listRecentMeetingsQuery(
 			.get();
 		if (!body) continue;
 
+		const docs = await db
+			.select()
+			.from(schema.documents)
+			.where(eq(schema.documents.meetingId, m.id))
+			.all();
+
+		const extractionMethod = deriveMeetingExtractionMethod(
+			docs.map((d) => parseExtractionMethod(d.extractionMethod)),
+		);
+
 		const summary = await db
 			.select()
 			.from(schema.summaries)
 			.where(eq(schema.summaries.meetingId, m.id))
 			.get();
-		if (!summary) continue;
+
+		// Readable meetings without a summary are a broken mid-pipeline state —
+		// skip them. Unreadable meetings legitimately have no summary and must
+		// surface so citizens can reach the detail page + source PDF link.
+		if (!summary && extractionMethod !== "unreadable") continue;
 
 		const fiscals = await db
 			.select()
@@ -153,8 +168,9 @@ export async function listRecentMeetingsQuery(
 			meetingType: parseMeetingType(m.meetingType),
 			bodyName: body.name,
 			bodySlug: body.slug,
-			highlights: summary.highlights as string[],
-			prose: summary.prose,
+			extractionMethod,
+			highlights: (summary?.highlights as string[] | undefined) ?? [],
+			prose: summary?.prose ?? "",
 			fiscalDecisionCount: fiscals.length,
 			totalSpending: fiscals.reduce(
 				(total: number, f: { amount: number }) => total + f.amount,

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -289,8 +289,8 @@ describe("StorageService", () => {
 			expect(result?.date).toBe("2026-03-23");
 			expect(result?.bodyName).toBe("Ellettsville Town Council");
 			expect(result?.documents).toHaveLength(1);
-			expect(result?.summary.prose).toContain("Sale Street");
-			expect(result?.summary.highlights).toHaveLength(2);
+			expect(result?.summary?.prose).toContain("Sale Street");
+			expect(result?.summary?.highlights).toHaveLength(2);
 			expect(result?.fiscalDecisions).toHaveLength(1);
 			expect(result?.fiscalDecisions[0].amount).toBe(50000);
 			expect(result?.budgetDiscussions).toHaveLength(1);

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,10 +9,16 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as SpendingRouteImport } from './routes/spending'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MeetingsBodySlugDateRouteImport } from './routes/meetings/$bodySlug/$date'
 
+const SpendingRoute = SpendingRouteImport.update({
+  id: '/spending',
+  path: '/spending',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -32,35 +38,46 @@ const MeetingsBodySlugDateRoute = MeetingsBodySlugDateRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/spending': typeof SpendingRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/spending': typeof SpendingRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/spending': typeof SpendingRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/meetings/$bodySlug/$date'
+  fullPaths: '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/meetings/$bodySlug/$date'
-  id: '__root__' | '/' | '/about' | '/meetings/$bodySlug/$date'
+  to: '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
+  id: '__root__' | '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  SpendingRoute: typeof SpendingRoute
   MeetingsBodySlugDateRoute: typeof MeetingsBodySlugDateRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/spending': {
+      id: '/spending'
+      path: '/spending'
+      fullPath: '/spending'
+      preLoaderRoute: typeof SpendingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -88,6 +105,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  SpendingRoute: SpendingRoute,
   MeetingsBodySlugDateRoute: MeetingsBodySlugDateRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -22,6 +22,7 @@ const populatedData = {
 			meetingType: "regular" as const,
 			bodyName: "Ellettsville Town Council",
 			bodySlug: "ellettsville-town-council",
+			extractionMethod: "text-layer" as const,
 			highlights: ["Approved road repairs"],
 			prose: "Council met to discuss infrastructure.",
 			fiscalDecisionCount: 1,

--- a/src/routes/meetings/$bodySlug/$date.test.tsx
+++ b/src/routes/meetings/$bodySlug/$date.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MeetingDetail } from "#/db/queries.ts";
+import { MeetingDetailView } from "./$date.tsx";
+
+afterEach(cleanup);
+
+function makeMeeting(overrides: Partial<MeetingDetail> = {}): MeetingDetail {
+	return {
+		id: 1,
+		date: "2026-03-23",
+		meetingType: "regular",
+		bodyName: "Ellettsville Town Council",
+		bodySlug: "ellettsville-town-council",
+		extractionMethod: "text-layer",
+		documents: [
+			{
+				sourceUrl: "https://example.gov/minutes.pdf",
+				rawText: "Text content.",
+				documentType: "minutes",
+				extractionMethod: "text-layer",
+			},
+		],
+		summary: {
+			highlights: ["Approved road repairs"],
+			prose: "Council discussed infrastructure.",
+			model: "gemini-2.5-flash",
+		},
+		fiscalDecisions: [
+			{
+				title: "Sale Street Road Repairs",
+				description: "Funding for road repairs",
+				amount: 50000,
+				originalAmount: "$50,000",
+				budgetCategory: "infrastructure",
+				status: "approved",
+				voteRecord: null,
+				vendor: null,
+				fundingSource: null,
+				ordinanceNumber: null,
+				confidence: 0.95,
+				isRecurring: false,
+			},
+		],
+		budgetDiscussions: [],
+		...overrides,
+	};
+}
+
+describe("MeetingDetailView — text-layer branch", () => {
+	it("renders highlights, summary, and fiscal decisions without OCR banner", () => {
+		render(<MeetingDetailView meeting={makeMeeting()} />);
+
+		expect(screen.getByText("Key Highlights")).toBeDefined();
+		expect(screen.getByText("Summary")).toBeDefined();
+		expect(screen.getByText("Sale Street Road Repairs")).toBeDefined();
+		expect(screen.queryByText(/Extracted via OCR/i)).toBeNull();
+		expect(
+			screen.queryByLabelText("OCR-extracted figure, verify against source"),
+		).toBeNull();
+	});
+});
+
+describe("MeetingDetailView — ocr branch", () => {
+	it("renders the OCR banner with role=status above the summary", () => {
+		render(
+			<MeetingDetailView
+				meeting={makeMeeting({
+					extractionMethod: "ocr",
+					documents: [
+						{
+							sourceUrl: "https://example.gov/minutes.pdf",
+							rawText: "OCR text.",
+							documentType: "minutes",
+							extractionMethod: "ocr",
+						},
+					],
+				})}
+			/>,
+		);
+
+		const banner = screen.getByText(
+			/Extracted via OCR from a scanned PDF\. Verify figures against the original document\./,
+		);
+		expect(banner).toBeDefined();
+		// Banner must be role=status (polite), not role=alert
+		const statusRegion = screen.getByRole("status");
+		expect(statusRegion.textContent).toMatch(/Extracted via OCR/);
+	});
+
+	it("marks every fiscal figure with a ? superscript and correct aria-label", () => {
+		render(
+			<MeetingDetailView
+				meeting={makeMeeting({
+					extractionMethod: "ocr",
+					documents: [
+						{
+							sourceUrl: "https://example.gov/minutes.pdf",
+							rawText: "OCR text.",
+							documentType: "minutes",
+							extractionMethod: "ocr",
+						},
+					],
+					fiscalDecisions: [
+						{
+							title: "A",
+							description: "d",
+							amount: 1000,
+							originalAmount: "$1,000",
+							budgetCategory: null,
+							status: "approved",
+							voteRecord: null,
+							vendor: null,
+							fundingSource: null,
+							ordinanceNumber: null,
+							confidence: 0.7,
+							isRecurring: false,
+						},
+						{
+							title: "B",
+							description: "d",
+							amount: 2000,
+							originalAmount: "$2,000",
+							budgetCategory: null,
+							status: "approved",
+							voteRecord: null,
+							vendor: null,
+							fundingSource: null,
+							ordinanceNumber: null,
+							confidence: 0.7,
+							isRecurring: false,
+						},
+					],
+				})}
+			/>,
+		);
+
+		const badges = screen.getAllByLabelText(
+			"OCR-extracted figure, verify against source",
+		);
+		expect(badges).toHaveLength(2);
+		for (const badge of badges) {
+			expect(badge.textContent).toBe("?");
+		}
+	});
+});
+
+describe("MeetingDetailView — unreadable branch", () => {
+	it("renders a single status card with copy and hides all content sections", () => {
+		render(
+			<MeetingDetailView
+				meeting={makeMeeting({
+					extractionMethod: "unreadable",
+					documents: [
+						{
+							sourceUrl: "https://example.gov/scan.pdf",
+							rawText: "",
+							documentType: "minutes",
+							extractionMethod: "unreadable",
+						},
+					],
+					summary: null,
+					fiscalDecisions: [],
+					budgetDiscussions: [],
+				})}
+			/>,
+		);
+
+		// Status card copy (DATE and BODY interpolated)
+		const statusRegion = screen.getByRole("status");
+		expect(statusRegion.textContent).toMatch(
+			/We couldn't extract readable text from this .+ Ellettsville Town Council meeting\. The original document is available below\./,
+		);
+
+		// Content sections hidden entirely
+		expect(screen.queryByText("Key Highlights")).toBeNull();
+		expect(screen.queryByText("Summary")).toBeNull();
+		expect(screen.queryByText("Fiscal Decisions")).toBeNull();
+		expect(screen.queryByText(/Budget Discussions/)).toBeNull();
+
+		// Source PDF link still present
+		expect(screen.getByText(/View minutes PDF/)).toBeDefined();
+	});
+});

--- a/src/routes/meetings/$bodySlug/$date.tsx
+++ b/src/routes/meetings/$bodySlug/$date.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import type { FiscalDecisionDetail } from "#/db/queries.ts";
+import type { FiscalDecisionDetail, MeetingDetail } from "#/db/queries.ts";
 import { getMeetingByBodyAndDate } from "#/server/meetings.ts";
 
 /**
@@ -7,10 +7,10 @@ import { getMeetingByBodyAndDate } from "#/server/meetings.ts";
  *
  * Route: `/meetings/:bodySlug/:date` (e.g. `/meetings/ellettsville-town-council/2026-03-23`)
  *
- * The `loader` calls the server function before the component renders, so the
- * page has data available immediately (no loading spinners). TanStack Router
- * extracts `bodySlug` and `date` from the URL params automatically via
- * file-based routing (`$bodySlug/$date.tsx` → params `{ bodySlug, date }`).
+ * Three render branches keyed on `meeting.extractionMethod`:
+ *   - `text-layer`: full layout (highlights, summary, fiscal, discussions)
+ *   - `ocr`:        full layout plus OCR trust-disclosure banner and per-figure `?` badge
+ *   - `unreadable`: status card + source PDF links only (no generated content)
  */
 export const Route = createFileRoute("/meetings/$bodySlug/$date")({
 	loader: ({ params }) =>
@@ -36,14 +36,6 @@ export const Route = createFileRoute("/meetings/$bodySlug/$date")({
 	),
 });
 
-/**
- * Renders the full meeting detail: header with source links, highlights,
- * prose summary, fiscal decision cards, and budget discussion items.
- *
- * Uses `Route.useLoaderData()` to access the data fetched by the loader —
- * this is type-safe, so TypeScript knows the shape of `meeting` without
- * any manual type annotations.
- */
 function MeetingDetailPage() {
 	const meeting = Route.useLoaderData();
 
@@ -57,110 +49,186 @@ function MeetingDetailPage() {
 		);
 	}
 
+	return <MeetingDetailView meeting={meeting} />;
+}
+
+/**
+ * Pure render component, exported for testing. Branches on
+ * `meeting.extractionMethod` to surface honest signals about content provenance.
+ */
+export function MeetingDetailView({ meeting }: { meeting: MeetingDetail }) {
+	const isOcr = meeting.extractionMethod === "ocr";
+	const isUnreadable = meeting.extractionMethod === "unreadable";
+
 	return (
 		<main className="page-wrap px-4 pb-8 pt-14">
-			{/* Header */}
-			<header className="island-shell rise-in mb-6 rounded-2xl px-6 py-8">
-				<p className="island-kicker mb-2">{meeting.bodyName}</p>
-				<h1 className="display-title mb-3 text-3xl font-bold tracking-tight text-[var(--sea-ink)]">
-					{formatDate(meeting.date)} Meeting
-				</h1>
-				<div className="flex flex-wrap gap-3">
-					{meeting.documents.map((doc) => (
-						<a
-							key={doc.sourceUrl}
-							href={doc.sourceUrl}
-							target="_blank"
-							rel="noopener noreferrer"
-							className="rounded-full border border-[rgba(50,143,151,0.3)] bg-[rgba(79,184,178,0.14)] px-4 py-1.5 text-sm font-medium text-[var(--lagoon-deep)] no-underline transition hover:bg-[rgba(79,184,178,0.24)]"
-						>
-							View {doc.documentType} PDF
-						</a>
-					))}
-				</div>
-			</header>
+			<MeetingHeader meeting={meeting} />
 
-			{/* Highlights */}
-			{meeting.summary && (
-				<section className="island-shell rise-in mb-6 rounded-2xl p-6">
-					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-						Key Highlights
-					</h2>
-					<ul className="m-0 list-disc space-y-2 pl-5 text-sm text-[var(--sea-ink-soft)]">
-						{meeting.summary.highlights.map((h) => (
-							<li key={h}>{h}</li>
-						))}
-					</ul>
-				</section>
-			)}
+			{isUnreadable ? (
+				<UnreadableStatusCard bodyName={meeting.bodyName} date={meeting.date} />
+			) : (
+				<>
+					{isOcr && <OcrBanner />}
+					{meeting.summary && (
+						<>
+							<section className="island-shell rise-in mb-6 rounded-2xl p-6">
+								<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+									Key Highlights
+								</h2>
+								<ul className="m-0 list-disc space-y-2 pl-5 text-sm text-[var(--sea-ink-soft)]">
+									{meeting.summary.highlights.map((h) => (
+										<li key={h}>{h}</li>
+									))}
+								</ul>
+							</section>
 
-			{/* Prose Summary */}
-			{meeting.summary && (
-				<section className="island-shell rise-in mb-6 rounded-2xl p-6">
-					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-						Summary
-					</h2>
-					<p className="text-sm leading-relaxed text-[var(--sea-ink-soft)]">
-						{meeting.summary.prose}
-					</p>
-				</section>
-			)}
-
-			{/* Fiscal Decisions */}
-			{meeting.fiscalDecisions.length > 0 && (
-				<section className="island-shell rise-in mb-6 rounded-2xl p-6">
-					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-						Fiscal Decisions
-					</h2>
-					<div className="space-y-4">
-						{meeting.fiscalDecisions.map((fd) => (
-							<FiscalCard key={fd.title} decision={fd} />
-						))}
-					</div>
-				</section>
-			)}
-
-			{/* Budget Discussions */}
-			{meeting.budgetDiscussions.length > 0 && (
-				<section className="island-shell rise-in rounded-2xl p-6">
-					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-						Budget Discussions (No Vote Taken)
-					</h2>
-					<div className="space-y-3">
-						{meeting.budgetDiscussions.map((bd) => (
-							<div
-								key={bd.topic}
-								className="rounded-xl border border-[rgba(23,58,64,0.1)] p-4"
-							>
-								<p className="mb-1 text-sm font-medium text-[var(--sea-ink)]">
-									{bd.topic}
+							<section className="island-shell rise-in mb-6 rounded-2xl p-6">
+								<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+									Summary
+								</h2>
+								<p className="text-sm leading-relaxed text-[var(--sea-ink-soft)]">
+									{meeting.summary.prose}
 								</p>
-								{bd.estimatedAmount != null && (
-									<p className="text-sm text-[var(--sea-ink-soft)]">
-										Estimated: {formatCurrency(bd.estimatedAmount)}
-									</p>
-								)}
-								{bd.notes && (
-									<p className="mt-1 text-xs text-[var(--sea-ink-soft)]">
-										{bd.notes}
-									</p>
-								)}
+							</section>
+						</>
+					)}
+
+					{meeting.fiscalDecisions.length > 0 && (
+						<section className="island-shell rise-in mb-6 rounded-2xl p-6">
+							<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+								Fiscal Decisions
+							</h2>
+							<div className="space-y-4">
+								{meeting.fiscalDecisions.map((fd) => (
+									<FiscalCard key={fd.title} decision={fd} ocrFlagged={isOcr} />
+								))}
 							</div>
-						))}
-					</div>
-				</section>
+						</section>
+					)}
+
+					{meeting.budgetDiscussions.length > 0 && (
+						<section className="island-shell rise-in rounded-2xl p-6">
+							<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+								Budget Discussions (No Vote Taken)
+							</h2>
+							<div className="space-y-3">
+								{meeting.budgetDiscussions.map((bd) => (
+									<div
+										key={bd.topic}
+										className="rounded-xl border border-[rgba(23,58,64,0.1)] p-4"
+									>
+										<p className="mb-1 text-sm font-medium text-[var(--sea-ink)]">
+											{bd.topic}
+										</p>
+										{bd.estimatedAmount != null && (
+											<p className="text-sm text-[var(--sea-ink-soft)]">
+												Estimated:{" "}
+												<FiscalFigure
+													amount={bd.estimatedAmount}
+													ocrFlagged={isOcr}
+												/>
+											</p>
+										)}
+										{bd.notes && (
+											<p className="mt-1 text-xs text-[var(--sea-ink-soft)]">
+												{bd.notes}
+											</p>
+										)}
+									</div>
+								))}
+							</div>
+						</section>
+					)}
+				</>
 			)}
 		</main>
 	);
 }
 
+function MeetingHeader({ meeting }: { meeting: MeetingDetail }) {
+	return (
+		<header className="island-shell rise-in mb-6 rounded-2xl px-6 py-8">
+			<p className="island-kicker mb-2">{meeting.bodyName}</p>
+			<h1 className="display-title mb-3 text-3xl font-bold tracking-tight text-[var(--sea-ink)]">
+				{formatDate(meeting.date)} Meeting
+			</h1>
+			<div className="flex flex-wrap gap-3">
+				{meeting.documents.map((doc) => (
+					<a
+						key={doc.sourceUrl}
+						href={doc.sourceUrl}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="rounded-full border border-[rgba(50,143,151,0.3)] bg-[rgba(79,184,178,0.14)] px-4 py-1.5 text-sm font-medium text-[var(--lagoon-deep)] no-underline transition hover:bg-[rgba(79,184,178,0.24)]"
+					>
+						View {doc.documentType} PDF
+					</a>
+				))}
+			</div>
+		</header>
+	);
+}
+
+function OcrBanner() {
+	// <output> has implicit role="status" — announces politely without interrupting
+	return (
+		<output className="island-shell rise-in mb-6 block rounded-2xl border border-[rgba(217,119,6,0.3)] bg-[rgba(253,230,138,0.35)] px-6 py-4 text-sm text-[var(--sea-ink)]">
+			Extracted via OCR from a scanned PDF. Verify figures against the original
+			document.
+		</output>
+	);
+}
+
+function UnreadableStatusCard({
+	bodyName,
+	date,
+}: {
+	bodyName: string;
+	date: string;
+}) {
+	return (
+		<output className="island-shell rise-in block rounded-2xl px-6 py-6 text-sm text-[var(--sea-ink-soft)]">
+			We couldn't extract readable text from this {formatDate(date)} {bodyName}{" "}
+			meeting. The original document is available below.
+		</output>
+	);
+}
+
 /**
- * Card component for a single fiscal decision.
- * Color-codes the status badge: green (approved), red (denied), amber (tabled).
- * Displays the dollar amount prominently, with metadata (vote record, category,
- * vendor, funding source, ordinance number) in a compact flex row beneath.
+ * Wraps a formatted dollar amount. On OCR-sourced meetings, appends a `?`
+ * superscript with an aria-label so the figure is flagged as provenance-uncertain.
  */
-function FiscalCard({ decision }: { decision: FiscalDecisionDetail }) {
+function FiscalFigure({
+	amount,
+	ocrFlagged,
+}: {
+	amount: number;
+	ocrFlagged: boolean;
+}) {
+	return (
+		<span>
+			{formatCurrency(amount)}
+			{ocrFlagged && (
+				<sup className="ml-0.5 text-xs text-[var(--lagoon-deep)]">
+					<span
+						role="img"
+						aria-label="OCR-extracted figure, verify against source"
+					>
+						?
+					</span>
+				</sup>
+			)}
+		</span>
+	);
+}
+
+function FiscalCard({
+	decision,
+	ocrFlagged,
+}: {
+	decision: FiscalDecisionDetail;
+	ocrFlagged: boolean;
+}) {
 	let statusColor: string;
 	switch (decision.status) {
 		case "approved":
@@ -191,7 +259,7 @@ function FiscalCard({ decision }: { decision: FiscalDecisionDetail }) {
 				</span>
 			</div>
 			<p className="mb-2 text-2xl font-bold text-[var(--sea-ink)]">
-				{formatCurrency(decision.amount)}
+				<FiscalFigure amount={decision.amount} ocrFlagged={ocrFlagged} />
 			</p>
 			<p className="mb-2 text-sm text-[var(--sea-ink-soft)]">
 				{decision.description}

--- a/src/routes/meetings/$bodySlug/$date.tsx
+++ b/src/routes/meetings/$bodySlug/$date.tsx
@@ -81,26 +81,30 @@ function MeetingDetailPage() {
 			</header>
 
 			{/* Highlights */}
-			<section className="island-shell rise-in mb-6 rounded-2xl p-6">
-				<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-					Key Highlights
-				</h2>
-				<ul className="m-0 list-disc space-y-2 pl-5 text-sm text-[var(--sea-ink-soft)]">
-					{meeting.summary.highlights.map((h) => (
-						<li key={h}>{h}</li>
-					))}
-				</ul>
-			</section>
+			{meeting.summary && (
+				<section className="island-shell rise-in mb-6 rounded-2xl p-6">
+					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+						Key Highlights
+					</h2>
+					<ul className="m-0 list-disc space-y-2 pl-5 text-sm text-[var(--sea-ink-soft)]">
+						{meeting.summary.highlights.map((h) => (
+							<li key={h}>{h}</li>
+						))}
+					</ul>
+				</section>
+			)}
 
 			{/* Prose Summary */}
-			<section className="island-shell rise-in mb-6 rounded-2xl p-6">
-				<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
-					Summary
-				</h2>
-				<p className="text-sm leading-relaxed text-[var(--sea-ink-soft)]">
-					{meeting.summary.prose}
-				</p>
-			</section>
+			{meeting.summary && (
+				<section className="island-shell rise-in mb-6 rounded-2xl p-6">
+					<h2 className="mb-4 text-lg font-semibold text-[var(--sea-ink)]">
+						Summary
+					</h2>
+					<p className="text-sm leading-relaxed text-[var(--sea-ink-soft)]">
+						{meeting.summary.prose}
+					</p>
+				</section>
+			)}
 
 			{/* Fiscal Decisions */}
 			{meeting.fiscalDecisions.length > 0 && (


### PR DESCRIPTION
## Summary

Surfaces the tri-state `extractionMethod` produced by #30 on the meeting detail page — and on the landing feed — so citizens see honest signals about how each meeting's content was extracted. OCR-extracted meetings show a trust-disclosure banner and per-figure `?` badges; unreadable meetings show a status card instead of empty summary sections and remain reachable from the landing feed.

## PRD

Closes #26

## Slices

- [x] #30 — Tri-state extraction contract + orchestrator unreadable path
- [x] #31 — Meeting detail UI: OCR banner + unreadable status card + fiscal badge
- [ ] #32 — QA: end-to-end verification on Ellettsville Town Council historical corpus

## Key Decisions

- **Meeting-level `extractionMethod` derived from per-document methods.** Rule: all-unreadable → `unreadable`, any-OCR → `ocr`, else `text-layer`. Each document's method is also exposed for future fine-grained rendering. Matches StorageService's existing OCR confidence multiplier logic.
- **`MeetingDetail.summary` widened to nullable.** `getMeetingByBodyAndDateQuery` no longer returns `null` when an unreadable meeting has no summary — it returns the meeting with `summary: null` so the UI can render the status card.
- **`<output>` instead of `role="status"` on a div.** The PRD mandates `role="status"` for both the banner and the unreadable status card. Using `<output>` (implicit `role="status"`) keeps the polite-announcement semantics without a lint suppression.
- **`?` badge wraps a `<span role="img" aria-label="...">` inside `<sup>`.** Biome rejects `aria-label` on `<sup>` directly. The inner `<span role="img">` carries the accessible name while the `<sup>` keeps the visual superscript.
- **`MeetingDetailView` extracted as an exported pure component.** Lets each render branch be unit-tested with synthetic fixtures instead of going through TanStack Router's loader integration layer.
- **Landing feed surfaces unreadable meetings (scope expansion beyond #31's boundary map).** Pre-merge review caught that user story 3 ("unreadable meeting records visible with PDF link") had no entry point — `listRecentMeetingsQuery` was hard-filtering meetings without a summary. Fixed here rather than filed as a follow-up since the unreadable detail-page branch is otherwise unreachable.

## Test plan
- [x] `pnpm test` — 119/119 passing (4 route-component tests, 4 query tests for detail, 1 query test for feed, 1 component test for unreadable card)
- [x] `npx tsc --noEmit` clean
- [x] Dev server boots, home and meeting detail return 200
- [ ] Manual: verify all three branches render against real data (see #32)