### PR TITLE
feat(mobile): tab bar, Drama Watch, Bodies routes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { Link } from "@tanstack/react-router";
+import { Link, useRouterState } from "@tanstack/react-router";
 
 const NAV = [
 	{ to: "/", label: "Front Page", search: { body: undefined } as const },
@@ -11,7 +11,17 @@ const NAV = [
 			period: undefined,
 		} as const,
 	},
+	{ to: "/drama", label: "Drama Watch" },
+	{ to: "/bodies", label: "Bodies" },
 	{ to: "/about", label: "About" },
+] as const;
+
+const TAB_BAR = [
+	{ to: "/", label: "Front", icon: "◉", match: /^\/$/ },
+	{ to: "/spending", label: "Ledger", icon: "$", match: /^\/spending/ },
+	{ to: "/drama", label: "Drama", icon: "★", match: /^\/drama/ },
+	{ to: "/bodies", label: "Bodies", icon: "⌂", match: /^\/bodies/ },
+	{ to: "/about", label: "About", icon: "?", match: /^\/about/ },
 ] as const;
 
 function dateline(): string {
@@ -25,56 +35,96 @@ function dateline(): string {
 		.toUpperCase();
 }
 
+function MobileTabBar() {
+	const pathname = useRouterState({
+		select: (s) => s.location.pathname,
+	});
+
+	return (
+		<nav className="fixed bottom-0 left-0 right-0 z-50 border-t-[3px] border-double border-[var(--rule)] bg-[var(--paper)] pb-safe sm:hidden">
+			<div className="flex justify-around pb-2 pt-2">
+				{TAB_BAR.map((tab) => {
+					const active = tab.match.test(pathname);
+					return (
+						<Link
+							key={tab.to}
+							to={tab.to}
+							className="flex flex-col items-center gap-0.5 no-underline"
+							style={{ color: active ? "var(--accent)" : "var(--ink-soft)" }}
+						>
+							<span
+								className="font-display text-[18px] leading-none"
+								style={{ color: active ? "var(--accent)" : "var(--ink)" }}
+							>
+								{tab.icon}
+							</span>
+							<span
+								className="mono text-[9px] font-bold uppercase tracking-[0.14em]"
+								style={{ color: active ? "var(--accent)" : "var(--ink-soft)" }}
+							>
+								{tab.label}
+							</span>
+						</Link>
+					);
+				})}
+			</div>
+		</nav>
+	);
+}
+
 export default function Header() {
 	return (
-		<header className="border-b border-[var(--rule)] bg-[var(--paper)]">
-			<div className="page-wrap flex flex-wrap items-end justify-between gap-6 px-2 py-5 sm:py-6">
-				<Link
-					to="/"
-					search={{ body: undefined }}
-					className="flex items-baseline gap-4 no-underline"
-				>
-					<h1 className="display m-0 text-4xl leading-none sm:text-5xl">
-						Civic Mirror
-					</h1>
-					<span className="mono hidden text-[11px] uppercase tracking-[0.18em] text-[var(--ink-soft)] sm:inline">
-						Ellettsville · Monroe County, IN
-					</span>
-				</Link>
-				<div className="mono hidden text-right text-[11px] uppercase leading-[1.55] tracking-[0.14em] text-[var(--ink-soft)] sm:block">
-					Vol. II — No. 16
-					<br />
-					{dateline()}
-				</div>
-			</div>
-
-			<div className="border-t border-[var(--rule)]" />
-
-			<nav className="border-t border-[var(--rule)] bg-[var(--paper)]">
-				<div className="page-wrap flex flex-wrap items-center justify-between gap-x-6 gap-y-3 px-2 py-3">
-					<ul className="flex flex-wrap items-center gap-x-6 gap-y-2">
-						{NAV.map((item) => (
-							<li key={item.to}>
-								<Link
-									to={item.to}
-									search={"search" in item ? item.search : undefined}
-									className="subnav-link"
-									activeProps={{ className: "subnav-link is-active" }}
-									activeOptions={{ exact: item.to === "/" }}
-								>
-									{item.label}
-								</Link>
-							</li>
-						))}
-					</ul>
-					<div className="mono hidden items-center gap-4 text-[11px] text-[var(--ink-soft)] md:flex">
-						<span>Independent · Non-partisan · AI-summarized</span>
-						<span className="border border-[var(--ink)] bg-[var(--paper)] px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--ink)]">
-							Subscribe — Weekly digest →
+		<>
+			<header className="border-b border-[var(--rule)] bg-[var(--paper)]">
+				<div className="page-wrap flex flex-wrap items-end justify-between gap-6 px-2 py-5 sm:py-6">
+					<Link
+						to="/"
+						search={{ body: undefined }}
+						className="flex items-baseline gap-4 no-underline"
+					>
+						<h1 className="display m-0 text-4xl leading-none sm:text-5xl">
+							Civic Mirror
+						</h1>
+						<span className="mono hidden text-[11px] uppercase tracking-[0.18em] text-[var(--ink-soft)] sm:inline">
+							Ellettsville · Monroe County, IN
 						</span>
+					</Link>
+					<div className="mono hidden text-right text-[11px] uppercase leading-[1.55] tracking-[0.14em] text-[var(--ink-soft)] sm:block">
+						Vol. II — No. 16
+						<br />
+						{dateline()}
 					</div>
 				</div>
-			</nav>
-		</header>
+
+				<div className="border-t border-[var(--rule)]" />
+
+				<nav className="border-t border-[var(--rule)] bg-[var(--paper)]">
+					<div className="page-wrap flex flex-wrap items-center justify-between gap-x-6 gap-y-3 px-2 py-3">
+						<ul className="flex flex-wrap items-center gap-x-6 gap-y-2">
+							{NAV.map((item) => (
+								<li key={item.to}>
+									<Link
+										to={item.to}
+										search={"search" in item ? item.search : undefined}
+										className="subnav-link"
+										activeProps={{ className: "subnav-link is-active" }}
+										activeOptions={{ exact: item.to === "/" }}
+									>
+										{item.label}
+									</Link>
+								</li>
+							))}
+						</ul>
+						<div className="mono hidden items-center gap-4 text-[11px] text-[var(--ink-soft)] md:flex">
+							<span>Independent · Non-partisan · AI-summarized</span>
+							<span className="border border-[var(--ink)] bg-[var(--paper)] px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--ink)]">
+								Subscribe — Weekly digest →
+							</span>
+						</div>
+					</div>
+				</nav>
+			</header>
+			<MobileTabBar />
+		</>
 	);
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -394,6 +394,11 @@ export async function listGoverningBodiesQuery(
 
 /**
  * Lists all governing bodies with aggregated meeting and spending stats.
+ *
+ * Uses three GROUP BY queries (bodies, meeting counts, fiscal aggregates) and
+ * stitches them together in memory rather than a per-body loop. Avoids the
+ * row-explosion that would happen if we LEFT JOINed both meetings and
+ * fiscal_decisions into a single query.
  */
 export async function listBodiesWithStatsQuery(
 	db: LibSQLDatabase<typeof schema>,
@@ -404,38 +409,91 @@ export async function listBodiesWithStatsQuery(
 		.orderBy(schema.governingBodies.name)
 		.all();
 
-	const result: BodyWithStats[] = [];
-	for (const body of bodies) {
-		const meetingCount = await db
-			.select({ count: sql<number>`count(*)` })
-			.from(schema.meetings)
-			.where(eq(schema.meetings.bodyId, body.id))
-			.get();
+	const meetingCounts = await db
+		.select({
+			bodyId: schema.meetings.bodyId,
+			count: sql<number>`count(*)`,
+		})
+		.from(schema.meetings)
+		.groupBy(schema.meetings.bodyId)
+		.all();
 
-		const fiscalAgg = await db
-			.select({
-				total: sum(schema.fiscalDecisions.amount),
-				count: sql<number>`count(${schema.fiscalDecisions.id})`,
-			})
-			.from(schema.fiscalDecisions)
-			.innerJoin(
-				schema.meetings,
-				eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
-			)
-			.where(eq(schema.meetings.bodyId, body.id))
-			.get();
+	const fiscalAggs = await db
+		.select({
+			bodyId: schema.meetings.bodyId,
+			total: sum(schema.fiscalDecisions.amount),
+			count: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.groupBy(schema.meetings.bodyId)
+		.all();
 
-		result.push({
-			name: body.name,
-			slug: body.slug,
-			type: body.type as BodyType,
-			meetingCount: meetingCount?.count ?? 0,
-			totalSpending: Number(fiscalAgg?.total) || 0,
-			decisionCount: fiscalAgg?.count ?? 0,
-		});
-	}
+	const meetingsByBody = new Map(meetingCounts.map((r) => [r.bodyId, r.count]));
+	const fiscalsByBody = new Map(
+		fiscalAggs.map((r) => [
+			r.bodyId,
+			{ total: Number(r.total) || 0, count: r.count },
+		]),
+	);
 
-	return result;
+	return bodies.map((body) => ({
+		name: body.name,
+		slug: body.slug,
+		type: body.type as BodyType,
+		meetingCount: meetingsByBody.get(body.id) ?? 0,
+		totalSpending: fiscalsByBody.get(body.id)?.total ?? 0,
+		decisionCount: fiscalsByBody.get(body.id)?.count ?? 0,
+	}));
+}
+
+/**
+ * Single-body variant of listBodiesWithStatsQuery — scoped to one body slug
+ * so the body profile page doesn't load the full bodies table to validate
+ * one slug. Returns null if the slug doesn't match an existing body.
+ */
+export async function getBodyWithStatsBySlugQuery(
+	db: LibSQLDatabase<typeof schema>,
+	bodySlug: string,
+): Promise<BodyWithStats | null> {
+	const body = await db
+		.select()
+		.from(schema.governingBodies)
+		.where(eq(schema.governingBodies.slug, bodySlug))
+		.get();
+
+	if (!body) return null;
+
+	const meetingCount = await db
+		.select({ count: sql<number>`count(*)` })
+		.from(schema.meetings)
+		.where(eq(schema.meetings.bodyId, body.id))
+		.get();
+
+	const fiscalAgg = await db
+		.select({
+			total: sum(schema.fiscalDecisions.amount),
+			count: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.where(eq(schema.meetings.bodyId, body.id))
+		.get();
+
+	return {
+		name: body.name,
+		slug: body.slug,
+		type: body.type as BodyType,
+		meetingCount: meetingCount?.count ?? 0,
+		totalSpending: Number(fiscalAgg?.total) || 0,
+		decisionCount: fiscalAgg?.count ?? 0,
+	};
 }
 
 /**

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -98,6 +98,15 @@ export type GoverningBodySummary = {
 	type: BodyType;
 };
 
+export type BodyWithStats = {
+	name: string;
+	slug: string;
+	type: BodyType;
+	meetingCount: number;
+	totalSpending: number;
+	decisionCount: number;
+};
+
 /**
  * Lists recent meetings with summary data for the landing page feed.
  * Optionally filtered by body slug. Returns newest first.
@@ -381,6 +390,90 @@ export async function listGoverningBodiesQuery(
 		.all();
 
 	return rows.map((r) => ({ ...r, type: r.type as BodyType }));
+}
+
+/**
+ * Lists all governing bodies with aggregated meeting and spending stats.
+ */
+export async function listBodiesWithStatsQuery(
+	db: LibSQLDatabase<typeof schema>,
+): Promise<BodyWithStats[]> {
+	const bodies = await db
+		.select()
+		.from(schema.governingBodies)
+		.orderBy(schema.governingBodies.name)
+		.all();
+
+	const result: BodyWithStats[] = [];
+	for (const body of bodies) {
+		const meetingCount = await db
+			.select({ count: sql<number>`count(*)` })
+			.from(schema.meetings)
+			.where(eq(schema.meetings.bodyId, body.id))
+			.get();
+
+		const fiscalAgg = await db
+			.select({
+				total: sum(schema.fiscalDecisions.amount),
+				count: sql<number>`count(${schema.fiscalDecisions.id})`,
+			})
+			.from(schema.fiscalDecisions)
+			.innerJoin(
+				schema.meetings,
+				eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+			)
+			.where(eq(schema.meetings.bodyId, body.id))
+			.get();
+
+		result.push({
+			name: body.name,
+			slug: body.slug,
+			type: body.type as BodyType,
+			meetingCount: meetingCount?.count ?? 0,
+			totalSpending: Number(fiscalAgg?.total) || 0,
+			decisionCount: fiscalAgg?.count ?? 0,
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Aggregates fiscal decisions by budget category for a single governing body.
+ */
+export async function aggregateFiscalByCategoryForBodyQuery(
+	db: LibSQLDatabase<typeof schema>,
+	bodySlug: string,
+): Promise<FiscalByCategory[]> {
+	const body = await db
+		.select()
+		.from(schema.governingBodies)
+		.where(eq(schema.governingBodies.slug, bodySlug))
+		.get();
+
+	if (!body) return [];
+
+	const rows = await db
+		.select({
+			budgetCategory: schema.fiscalDecisions.budgetCategory,
+			totalAmount: sum(schema.fiscalDecisions.amount),
+			decisionCount: sql<number>`count(${schema.fiscalDecisions.id})`,
+		})
+		.from(schema.fiscalDecisions)
+		.innerJoin(
+			schema.meetings,
+			eq(schema.fiscalDecisions.meetingId, schema.meetings.id),
+		)
+		.where(eq(schema.meetings.bodyId, body.id))
+		.groupBy(schema.fiscalDecisions.budgetCategory)
+		.orderBy(desc(sum(schema.fiscalDecisions.amount)))
+		.all();
+
+	return rows.map((r) => ({
+		budgetCategory: r.budgetCategory ?? "Uncategorized",
+		totalAmount: Number(r.totalAmount) || 0,
+		decisionCount: r.decisionCount,
+	}));
 }
 
 export type FiscalDecisionDetail = {

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,13 +10,21 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as SpendingRouteImport } from './routes/spending'
+import { Route as DramaRouteImport } from './routes/drama'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as BodiesIndexRouteImport } from './routes/bodies/index'
+import { Route as BodiesBodySlugRouteImport } from './routes/bodies/$bodySlug'
 import { Route as MeetingsBodySlugDateRouteImport } from './routes/meetings/$bodySlug/$date'
 
 const SpendingRoute = SpendingRouteImport.update({
   id: '/spending',
   path: '/spending',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DramaRoute = DramaRouteImport.update({
+  id: '/drama',
+  path: '/drama',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AboutRoute = AboutRouteImport.update({
@@ -29,6 +37,16 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BodiesIndexRoute = BodiesIndexRouteImport.update({
+  id: '/bodies/',
+  path: '/bodies/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BodiesBodySlugRoute = BodiesBodySlugRouteImport.update({
+  id: '/bodies/$bodySlug',
+  path: '/bodies/$bodySlug',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MeetingsBodySlugDateRoute = MeetingsBodySlugDateRouteImport.update({
   id: '/meetings/$bodySlug/$date',
   path: '/meetings/$bodySlug/$date',
@@ -38,34 +56,68 @@ const MeetingsBodySlugDateRoute = MeetingsBodySlugDateRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/drama': typeof DramaRoute
   '/spending': typeof SpendingRoute
+  '/bodies/$bodySlug': typeof BodiesBodySlugRoute
+  '/bodies/': typeof BodiesIndexRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/drama': typeof DramaRoute
   '/spending': typeof SpendingRoute
+  '/bodies/$bodySlug': typeof BodiesBodySlugRoute
+  '/bodies': typeof BodiesIndexRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/drama': typeof DramaRoute
   '/spending': typeof SpendingRoute
+  '/bodies/$bodySlug': typeof BodiesBodySlugRoute
+  '/bodies/': typeof BodiesIndexRoute
   '/meetings/$bodySlug/$date': typeof MeetingsBodySlugDateRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
+  fullPaths:
+    | '/'
+    | '/about'
+    | '/drama'
+    | '/spending'
+    | '/bodies/$bodySlug'
+    | '/bodies/'
+    | '/meetings/$bodySlug/$date'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
-  id: '__root__' | '/' | '/about' | '/spending' | '/meetings/$bodySlug/$date'
+  to:
+    | '/'
+    | '/about'
+    | '/drama'
+    | '/spending'
+    | '/bodies/$bodySlug'
+    | '/bodies'
+    | '/meetings/$bodySlug/$date'
+  id:
+    | '__root__'
+    | '/'
+    | '/about'
+    | '/drama'
+    | '/spending'
+    | '/bodies/$bodySlug'
+    | '/bodies/'
+    | '/meetings/$bodySlug/$date'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  DramaRoute: typeof DramaRoute
   SpendingRoute: typeof SpendingRoute
+  BodiesBodySlugRoute: typeof BodiesBodySlugRoute
+  BodiesIndexRoute: typeof BodiesIndexRoute
   MeetingsBodySlugDateRoute: typeof MeetingsBodySlugDateRoute
 }
 
@@ -76,6 +128,13 @@ declare module '@tanstack/react-router' {
       path: '/spending'
       fullPath: '/spending'
       preLoaderRoute: typeof SpendingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/drama': {
+      id: '/drama'
+      path: '/drama'
+      fullPath: '/drama'
+      preLoaderRoute: typeof DramaRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/about': {
@@ -92,6 +151,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/bodies/': {
+      id: '/bodies/'
+      path: '/bodies'
+      fullPath: '/bodies/'
+      preLoaderRoute: typeof BodiesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/bodies/$bodySlug': {
+      id: '/bodies/$bodySlug'
+      path: '/bodies/$bodySlug'
+      fullPath: '/bodies/$bodySlug'
+      preLoaderRoute: typeof BodiesBodySlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/meetings/$bodySlug/$date': {
       id: '/meetings/$bodySlug/$date'
       path: '/meetings/$bodySlug/$date'
@@ -105,7 +178,10 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  DramaRoute: DramaRoute,
   SpendingRoute: SpendingRoute,
+  BodiesBodySlugRoute: BodiesBodySlugRoute,
+  BodiesIndexRoute: BodiesIndexRoute,
   MeetingsBodySlugDateRoute: MeetingsBodySlugDateRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/bodies/$bodySlug.tsx
+++ b/src/routes/bodies/$bodySlug.tsx
@@ -6,7 +6,7 @@ import type {
 } from "#/db/queries.ts";
 import {
 	aggregateFiscalByCategoryForBody,
-	listBodiesWithStats,
+	getBodyWithStatsBySlug,
 	listRecentMeetings,
 } from "#/server/meetings.ts";
 
@@ -18,12 +18,11 @@ type BodyProfileData = {
 
 export const Route = createFileRoute("/bodies/$bodySlug")({
 	loader: async ({ params }): Promise<BodyProfileData | null> => {
-		const [bodies, meetings, byCategory] = await Promise.all([
-			listBodiesWithStats({ data: undefined }),
+		const [body, meetings, byCategory] = await Promise.all([
+			getBodyWithStatsBySlug({ data: { bodySlug: params.bodySlug } }),
 			listRecentMeetings({ data: { bodySlug: params.bodySlug } }),
 			aggregateFiscalByCategoryForBody({ data: { bodySlug: params.bodySlug } }),
 		]);
-		const body = bodies.find((b) => b.slug === params.bodySlug);
 		if (!body) return null;
 		return { body, meetings, byCategory };
 	},

--- a/src/routes/bodies/$bodySlug.tsx
+++ b/src/routes/bodies/$bodySlug.tsx
@@ -1,0 +1,249 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type {
+	BodyWithStats,
+	FiscalByCategory,
+	MeetingCardData,
+} from "#/db/queries.ts";
+import {
+	aggregateFiscalByCategoryForBody,
+	listBodiesWithStats,
+	listRecentMeetings,
+} from "#/server/meetings.ts";
+
+type BodyProfileData = {
+	body: BodyWithStats;
+	meetings: MeetingCardData[];
+	byCategory: FiscalByCategory[];
+};
+
+export const Route = createFileRoute("/bodies/$bodySlug")({
+	loader: async ({ params }): Promise<BodyProfileData | null> => {
+		const [bodies, meetings, byCategory] = await Promise.all([
+			listBodiesWithStats({ data: undefined }),
+			listRecentMeetings({ data: { bodySlug: params.bodySlug } }),
+			aggregateFiscalByCategoryForBody({ data: { bodySlug: params.bodySlug } }),
+		]);
+		const body = bodies.find((b) => b.slug === params.bodySlug);
+		if (!body) return null;
+		return { body, meetings, byCategory };
+	},
+	head: ({ loaderData }) => ({
+		meta: [
+			{
+				title: loaderData?.body
+					? `${loaderData.body.name} — Civic Mirror`
+					: "Body Not Found — Civic Mirror",
+			},
+		],
+	}),
+	component: BodyProfilePage,
+	notFoundComponent: () => (
+		<main className="page-wrap px-4 pb-8 pt-14">
+			<p className="text-center text-lg text-[var(--ink-soft)]">
+				Governing body not found.
+			</p>
+		</main>
+	),
+});
+
+function formatCurrency(amount: number): string {
+	if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
+	if (amount >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+	return `$${amount.toLocaleString()}`;
+}
+
+function formatDate(iso: string): string {
+	const [year, month, day] = iso.split("-");
+	const date = new Date(Number(year), Number(month) - 1, Number(day));
+	return date.toLocaleDateString("en-US", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+	});
+}
+
+function BodyProfilePage() {
+	const data = Route.useLoaderData();
+
+	if (!data) {
+		return (
+			<main className="page-wrap px-4 pb-8 pt-14">
+				<p className="text-center text-lg text-[var(--ink-soft)]">
+					Governing body not found.
+				</p>
+			</main>
+		);
+	}
+
+	const { body, meetings, byCategory } = data;
+	const maxCat = Math.max(...byCategory.map((c) => c.totalAmount), 1);
+
+	return (
+		<main className="page-wrap px-4 pb-8 pt-6">
+			{/* Dateline */}
+			<div className="mono flex flex-wrap justify-between gap-2 border-y border-[var(--rule)] bg-[var(--paper-alt)] px-2 py-2 text-[11px] uppercase tracking-[0.16em] text-[var(--ink-soft)]">
+				<span>
+					<Link
+						to="/bodies"
+						className="font-bold text-[var(--accent)] no-underline hover:underline"
+					>
+						← BODIES
+					</Link>
+				</span>
+				<span className="hidden sm:inline">Monroe Co., IN</span>
+			</div>
+
+			{/* Hero */}
+			<section className="rise-in pt-10">
+				<p className="kicker text-[var(--accent)]">
+					Governing body ·{" "}
+					{body.type === "town"
+						? "Municipal"
+						: body.type === "county"
+							? "County"
+							: "School District"}
+				</p>
+				<h1 className="display mt-3 text-[40px] leading-[1.0] tracking-[-0.025em] sm:text-[54px]">
+					{body.name}
+				</h1>
+
+				{/* Quick stats */}
+				<div className="rule-double mt-8 grid grid-cols-2 border-b-[3px] border-double border-[var(--rule)] sm:grid-cols-3">
+					{[
+						{ n: body.meetingCount, l: "Meetings YTD" },
+						{ n: formatCurrency(body.totalSpending), l: "Approved YTD" },
+						{ n: body.decisionCount, l: "Fiscal decisions" },
+					].map((s, i, arr) => (
+						<div
+							key={s.l}
+							className={`py-4 pr-4 ${i > 0 ? "pl-4" : ""} ${
+								i < arr.length - 1
+									? "sm:border-r sm:border-[var(--rule-soft)]"
+									: ""
+							}`}
+						>
+							<div className="display text-[28px] leading-none sm:text-[34px]">
+								{s.n}
+							</div>
+							<div className="kicker mt-2">{s.l}</div>
+						</div>
+					))}
+				</div>
+			</section>
+
+			{/* Roster placeholder */}
+			<section className="mt-12">
+				<div className="rule-double border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+					<p className="kicker">The Roster</p>
+					<h2 className="display mt-1 text-[26px]">Who's on the dais</h2>
+				</div>
+				<div className="paper-card-alt mt-4 p-6">
+					<p className="mono text-[11px] uppercase tracking-[0.14em] text-[var(--ink-soft)]">
+						Roster data coming soon — member attendance and tenure will appear
+						here once the pipeline includes structured roster ingestion.
+					</p>
+				</div>
+			</section>
+
+			{/* Recent meetings */}
+			{meetings.length > 0 && (
+				<section className="mt-12">
+					<div className="rule-double flex items-end justify-between border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+						<div>
+							<p className="kicker">Recent meetings</p>
+							<h2 className="display mt-1 text-[26px]">
+								Last {meetings.length} on file
+							</h2>
+						</div>
+						<span className="mono hidden text-[11px] uppercase tracking-[0.12em] text-[var(--ink-soft)] sm:block">
+							Newest first
+						</span>
+					</div>
+					<div className="mt-2 border-t border-[var(--rule)]">
+						{meetings.map((m, i) => (
+							<Link
+								key={m.id}
+								to="/meetings/$bodySlug/$date"
+								params={{ bodySlug: m.bodySlug, date: m.date }}
+								className={`block py-4 no-underline hover:bg-[var(--paper-alt)] ${
+									i < meetings.length - 1
+										? "border-b border-dotted border-[var(--rule-dot)]"
+										: ""
+								}`}
+							>
+								<div className="mono mb-1 flex justify-between text-[10px] uppercase tracking-[0.14em] text-[var(--ink-soft)]">
+									<span>{formatDate(m.date)}</span>
+									<span>{m.meetingType}</span>
+								</div>
+								<p className="display m-0 text-[18px] leading-[1.2] text-[var(--ink)]">
+									{m.highlights[0] ?? `${m.bodyName} — ${m.date}`}
+								</p>
+								<div className="mono mt-2 flex flex-wrap gap-3 text-[10px] uppercase tracking-[0.1em] text-[var(--ink-soft)]">
+									{m.totalSpending > 0 && (
+										<span className="money-pill">
+											{formatCurrency(m.totalSpending)}
+										</span>
+									)}
+									<span>{m.fiscalDecisionCount} decisions</span>
+								</div>
+							</Link>
+						))}
+					</div>
+				</section>
+			)}
+
+			{/* Spending by category */}
+			{byCategory.length > 0 && (
+				<section className="mt-12">
+					<div className="rule-double border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+						<p className="kicker">Where this body spent</p>
+						<h2 className="display mt-1 text-[26px]">
+							YTD: {formatCurrency(body.totalSpending)}
+						</h2>
+					</div>
+					<div className="mt-2 border-t border-[var(--rule)]">
+						{byCategory.map((c, i) => (
+							<div
+								key={c.budgetCategory}
+								className={`py-3 ${
+									i < byCategory.length - 1
+										? "border-b border-dotted border-[var(--rule-dot)]"
+										: ""
+								}`}
+							>
+								<div className="flex items-baseline justify-between gap-2">
+									<span className="text-[14px] font-semibold capitalize text-[var(--ink)]">
+										{c.budgetCategory}
+									</span>
+									<span className="mono text-[12px] font-bold text-[var(--ink)]">
+										{formatCurrency(c.totalAmount)}
+									</span>
+								</div>
+								<div className="mt-1.5 h-[8px] border border-[var(--rule-soft)] bg-[var(--paper-alt)]">
+									<div
+										style={{
+											width: `${(c.totalAmount / maxCat) * 100}%`,
+											height: "100%",
+											background: i === 0 ? "var(--accent)" : "var(--ink)",
+										}}
+									/>
+								</div>
+								<div className="mono mt-1 text-[10px] uppercase tracking-[0.1em] text-[var(--ink-faint)]">
+									{c.decisionCount} decision{c.decisionCount !== 1 ? "s" : ""}
+								</div>
+							</div>
+						))}
+					</div>
+				</section>
+			)}
+
+			{meetings.length === 0 && byCategory.length === 0 && (
+				<div className="paper-card mt-10 p-8 text-center">
+					<p className="text-[14px] text-[var(--ink-soft)]">
+						No meeting data yet for this body.
+					</p>
+				</div>
+			)}
+		</main>
+	);
+}

--- a/src/routes/bodies/index.tsx
+++ b/src/routes/bodies/index.tsx
@@ -1,0 +1,109 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { BodyWithStats } from "#/db/queries.ts";
+import { listBodiesWithStats } from "#/server/meetings.ts";
+
+export const Route = createFileRoute("/bodies/")({
+	loader: async (): Promise<BodyWithStats[]> => {
+		return await listBodiesWithStats({ data: undefined });
+	},
+	head: () => ({
+		meta: [{ title: "Governing Bodies — Civic Mirror" }],
+	}),
+	component: BodiesIndexPage,
+});
+
+function formatCurrency(amount: number): string {
+	if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
+	if (amount >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+	return `$${amount.toLocaleString()}`;
+}
+
+function BodiesIndexPage() {
+	const bodies = Route.useLoaderData();
+
+	return (
+		<main className="page-wrap px-4 pb-8 pt-6">
+			<div className="mono flex flex-wrap justify-between gap-2 border-y border-[var(--rule)] bg-[var(--paper-alt)] px-2 py-2 text-[11px] uppercase tracking-[0.16em] text-[var(--ink-soft)]">
+				<span>
+					<span className="font-bold text-[var(--accent)]">
+						GOVERNING BODIES
+					</span>{" "}
+					— Monroe Co., IN
+				</span>
+				<span className="hidden sm:inline">{bodies.length} bodies indexed</span>
+			</div>
+
+			<section className="rise-in pt-10">
+				<p className="kicker text-[var(--accent)]">Bodies · Indexed</p>
+				<h1 className="display mt-3 text-[40px] leading-[1.0] tracking-[-0.025em] sm:text-[56px]">
+					Who governs Ellettsville
+				</h1>
+				<p className="lede mt-5 max-w-[72ch] text-[18px] leading-[1.5]">
+					Eight local governing bodies — every meeting summarized, every dollar
+					tracked.
+				</p>
+			</section>
+
+			{bodies.length === 0 ? (
+				<div className="paper-card mt-10 p-8 text-center">
+					<p className="text-[14px] text-[var(--ink-soft)]">
+						No governing bodies on file yet. Check back after the pipeline
+						processes its first batch.
+					</p>
+				</div>
+			) : (
+				<section className="mt-12">
+					<div className="rule-double border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+						<p className="kicker">All bodies · {bodies.length} on file</p>
+						<h2 className="display mt-1 text-[26px]">
+							Every gavel, every body
+						</h2>
+					</div>
+
+					<div className="mt-2 border-t border-[var(--rule)]">
+						{bodies.map((body, i) => (
+							<Link
+								key={body.slug}
+								to="/bodies/$bodySlug"
+								params={{ bodySlug: body.slug }}
+								className={`grid grid-cols-[1fr_auto] items-center gap-4 py-5 no-underline hover:bg-[var(--paper-alt)] ${
+									i < bodies.length - 1
+										? "border-b border-dotted border-[var(--rule-dot)]"
+										: ""
+								}`}
+							>
+								<div>
+									<div className="mono mb-1 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--ink-soft)]">
+										{body.type === "town"
+											? "Municipal"
+											: body.type === "county"
+												? "County"
+												: "School District"}{" "}
+										· Monroe Co., IN
+									</div>
+									<h3 className="display m-0 text-[22px] leading-tight text-[var(--ink)]">
+										{body.name}
+									</h3>
+									<div className="mono mt-2 flex flex-wrap gap-4 text-[10px] uppercase tracking-[0.1em] text-[var(--ink-soft)]">
+										<span>{body.meetingCount} meetings</span>
+										<span>{body.decisionCount} decisions</span>
+									</div>
+								</div>
+								<div className="text-right">
+									{body.totalSpending > 0 && (
+										<div className="money-pill">
+											{formatCurrency(body.totalSpending)}
+										</div>
+									)}
+									<div className="mono mt-2 text-[10px] uppercase tracking-[0.12em] text-[var(--ink-soft)]">
+										YTD approved
+									</div>
+								</div>
+							</Link>
+						))}
+					</div>
+				</section>
+			)}
+		</main>
+	);
+}

--- a/src/routes/drama.tsx
+++ b/src/routes/drama.tsx
@@ -1,0 +1,135 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { MeetingCardData } from "#/db/queries.ts";
+import { listRecentMeetings } from "#/server/meetings.ts";
+
+export const Route = createFileRoute("/drama")({
+	loader: async (): Promise<MeetingCardData[]> => {
+		return await listRecentMeetings({ data: {} });
+	},
+	head: () => ({
+		meta: [{ title: "Drama Watch — Civic Mirror" }],
+	}),
+	component: DramaPage,
+});
+
+function formatDate(iso: string): string {
+	const [year, month, day] = iso.split("-");
+	const date = new Date(Number(year), Number(month) - 1, Number(day));
+	return date.toLocaleDateString("en-US", { month: "long", day: "numeric" });
+}
+
+function DramaPage() {
+	const meetings = Route.useLoaderData();
+
+	return (
+		<main className="page-wrap px-4 pb-8 pt-6">
+			<div className="mono flex flex-wrap justify-between gap-2 border-y border-[var(--rule)] bg-[var(--paper-alt)] px-2 py-2 text-[11px] uppercase tracking-[0.16em] text-[var(--ink-soft)]">
+				<span>
+					<span className="font-bold text-[var(--accent)]">DRAMA WATCH</span> —
+					Archive
+				</span>
+				<span className="hidden sm:inline">
+					Flagging circular debate · fixations · personal grievances
+				</span>
+			</div>
+
+			<section className="rise-in pt-10">
+				<p className="kicker text-[var(--accent)]">Drama Watch · Archive</p>
+				<h1 className="display mt-3 text-[40px] leading-[1.0] tracking-[-0.025em] sm:text-[56px]">
+					Every meeting that wasted your time, logged
+				</h1>
+				<p className="lede mt-5 max-w-[72ch] text-[18px] leading-[1.5]">
+					We flag circular debate, fixations, and personal grievances that cost
+					more than ten minutes. No gossip — just minutes spent on nothing.
+				</p>
+			</section>
+
+			<section className="mt-12">
+				<div className="rule-double border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+					<p className="kicker">Detection status</p>
+					<h2 className="display mt-1 text-[26px]">Drama detection pipeline</h2>
+				</div>
+
+				<div className="paper-card-alt mt-6 p-8">
+					<div className="mono mb-3 inline-block border border-[var(--ink)] bg-[var(--ink)] px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-[var(--highlight)]">
+						In progress
+					</div>
+					<p className="display text-[22px] leading-tight">
+						Drama classification is being added to the pipeline
+					</p>
+					<p className="mt-3 max-w-[60ch] text-[14px] leading-[1.6] text-[var(--ink-mid)]">
+						The AI will flag petty arguments, fixations, and circular debates
+						with a drama level, headline, and minute count. Once the pipeline
+						runs, incidents will appear here in chronological order with filters
+						for Pettiness, Heated, and Unresolved.
+					</p>
+					<p className="mono mt-5 text-[11px] uppercase tracking-[0.14em] text-[var(--ink-soft)]">
+						What we'll surface: fixation · circular debate · personal anecdote ·
+						conflict of interest
+					</p>
+				</div>
+			</section>
+
+			{meetings.length > 0 && (
+				<section className="mt-14">
+					<div className="rule-double flex items-end justify-between border-b-[3px] border-double border-[var(--rule)] pb-3 pt-4">
+						<div>
+							<p className="kicker">Recent meetings · Indexed</p>
+							<h2 className="display mt-1 text-[26px]">
+								Meetings on file — drama TBD
+							</h2>
+						</div>
+						<span className="mono hidden text-[11px] uppercase tracking-[0.12em] text-[var(--ink-soft)] sm:block">
+							{meetings.length} meetings
+						</span>
+					</div>
+
+					<div className="mt-4 border-t border-[var(--rule)]">
+						{meetings.map((m) => (
+							<Link
+								key={m.id}
+								to="/meetings/$bodySlug/$date"
+								params={{ bodySlug: m.bodySlug, date: m.date }}
+								className="grid grid-cols-[64px_1fr] gap-4 border-b border-dotted border-[var(--rule-dot)] py-4 no-underline hover:bg-[var(--paper-alt)]"
+							>
+								<div className="mono border-r border-[var(--rule-soft)] pr-3 text-right">
+									<div className="text-[10px] uppercase tracking-[0.14em] text-[var(--ink-soft)]">
+										{formatDate(m.date).split(" ")[0].slice(0, 3).toUpperCase()}
+									</div>
+									<div className="display text-[22px] leading-none text-[var(--ink)]">
+										{formatDate(m.date).split(" ")[1]}
+									</div>
+								</div>
+								<div>
+									<div className="mono mb-1 text-[10px] font-bold uppercase tracking-[0.14em] text-[var(--accent)]">
+										{m.bodyName}
+									</div>
+									<p className="display m-0 text-[17px] leading-[1.2] text-[var(--ink)]">
+										{m.highlights[0] ?? `${m.bodyName} — ${m.date}`}
+									</p>
+									<div className="mono mt-2 flex flex-wrap gap-3 text-[10px] uppercase tracking-[0.1em] text-[var(--ink-soft)]">
+										{m.totalSpending > 0 && (
+											<span className="money-pill">
+												{formatCurrency(m.totalSpending)}
+											</span>
+										)}
+										<span>{m.fiscalDecisionCount} decisions</span>
+										<span className="text-[var(--ink-faint)]">
+											Drama: pending
+										</span>
+									</div>
+								</div>
+							</Link>
+						))}
+					</div>
+				</section>
+			)}
+		</main>
+	);
+}
+
+function formatCurrency(amount: number): string {
+	if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(2)}M`;
+	if (amount >= 1_000) return `$${Math.round(amount / 1_000)}K`;
+	return `$${amount.toLocaleString()}`;
+}

--- a/src/server/meetings.ts
+++ b/src/server/meetings.ts
@@ -2,9 +2,11 @@ import { createServerFn } from "@tanstack/react-start";
 import { db } from "#/db/index.ts";
 import {
 	aggregateFiscalByBodyQuery,
+	aggregateFiscalByCategoryForBodyQuery,
 	aggregateFiscalByCategoryQuery,
 	aggregateFiscalByTimePeriodQuery,
 	getMeetingByBodyAndDateQuery,
+	listBodiesWithStatsQuery,
 	listFiscalDecisionsQuery,
 	listGoverningBodiesQuery,
 	listNotableFiscalDecisionsQuery,
@@ -68,3 +70,17 @@ export const listGoverningBodies = createServerFn({
 }).handler(async () => {
 	return await listGoverningBodiesQuery(db);
 });
+
+export const listBodiesWithStats = createServerFn({
+	method: "GET",
+}).handler(async () => {
+	return await listBodiesWithStatsQuery(db);
+});
+
+export const aggregateFiscalByCategoryForBody = createServerFn({
+	method: "GET",
+})
+	.inputValidator((input: { bodySlug: string }) => input)
+	.handler(async ({ data }) => {
+		return await aggregateFiscalByCategoryForBodyQuery(db, data.bodySlug);
+	});

--- a/src/server/meetings.ts
+++ b/src/server/meetings.ts
@@ -5,6 +5,7 @@ import {
 	aggregateFiscalByCategoryForBodyQuery,
 	aggregateFiscalByCategoryQuery,
 	aggregateFiscalByTimePeriodQuery,
+	getBodyWithStatsBySlugQuery,
 	getMeetingByBodyAndDateQuery,
 	listBodiesWithStatsQuery,
 	listFiscalDecisionsQuery,
@@ -76,6 +77,14 @@ export const listBodiesWithStats = createServerFn({
 }).handler(async () => {
 	return await listBodiesWithStatsQuery(db);
 });
+
+export const getBodyWithStatsBySlug = createServerFn({
+	method: "GET",
+})
+	.inputValidator((input: { bodySlug: string }) => input)
+	.handler(async ({ data }) => {
+		return await getBodyWithStatsBySlugQuery(db, data.bodySlug);
+	});
 
 export const aggregateFiscalByCategoryForBody = createServerFn({
 	method: "GET",

--- a/src/styles.css
+++ b/src/styles.css
@@ -97,6 +97,13 @@ body,
   min-height: 100%;
 }
 
+/* Reserve space for mobile tab bar */
+@media (max-width: 639px) {
+  body {
+    padding-bottom: 72px;
+  }
+}
+
 body {
   margin: 0;
   background: var(--paper);


### PR DESCRIPTION
## Summary

Civic Mirror is a local-government transparency app that summarizes meetings and fiscal decisions from eight Ellettsville/Monroe County governing bodies. The app had a complete desktop Ledger redesign but no mobile navigation and was missing two planned content sections.

This PR adds three things the design handoff specified: a fixed bottom tab bar for mobile screens (Front / Ledger / Drama / Bodies / About), a Drama Watch archive page at `/drama`, and governing body profile pages at `/bodies` and `/bodies/$bodySlug`. The tab bar uses `useRouterState` to derive active state without any client-side logic outside the router. The two new content sections are wired to real DB data — body stats aggregate from `governing_bodies` + `fiscal_decisions`, and the body profile pulls recent meetings and per-category spending. Drama classification doesn't exist in the schema yet, so `/drama` renders a pipeline-pending state alongside the indexed meeting feed; it will fill in automatically once the pipeline adds drama fields.

The new DB queries (`listBodiesWithStatsQuery`, `aggregateFiscalByCategoryForBodyQuery`) follow the same serial-join pattern already established in the file rather than introducing new patterns.

## Key Decisions

- Removed Meetings tab from mobile tab bar (no `/meetings` index route exists — the meeting surface is `/meetings/$bodySlug/$date`)
- Drama page shows graceful empty state rather than failing hard on missing drama data, matching the precedent set by the spending page
- Body profile roster section shows a "coming soon" placeholder rather than omitting the section, preserving the page's visual shape from the design mockups