### PR TITLE
[drama-watch] Slice 2: DramaDetectionService + Gemini boundary + storeDramaAssessment + orchestrator

### DIFF
--- a/docs/solutions/integration-issues/gemini-response-schema-numeric-enum-rejection-2026-05-01.md
+++ b/docs/solutions/integration-issues/gemini-response-schema-numeric-enum-rejection-2026-05-01.md
@@ -1,0 +1,117 @@
+---
+date: 2026-05-01
+category: integration-issues
+problem_type: provider rejects valid JSON Schema feature
+components: [pipeline, ai-boundary, drama-detection, summarization]
+technologies: [gemini, ai-sdk, zod, vercel-ai-sdk]
+severity: high
+volatility: volatile
+---
+
+# Gemini `response_schema` rejects numeric enums
+
+## Problem
+
+Gemini's structured-output API (the schema you pass via `output: Output.object({ schema })` in AI SDK v6, which becomes `generation_config.response_schema` on the wire) accepts a strictly narrower subset of JSON Schema than full JSON Schema spec. Numeric enums — `enum: [0, 1, 2, 3]` — are rejected even though they validate cleanly under Zod and Output.object accepts them locally. This means a Zod schema that uses `z.union([z.literal(0), ...])` for a small integer field will compile, typecheck, run unit tests with stubbed `generateFn`, and only fail when the real Gemini call is made — with an opaque error pointing at deep schema paths.
+
+## Symptoms
+
+- `LlmError` from the AI SDK's google provider with messages of the form:
+  ```
+  Invalid value at 'generation_config.response_schema.properties[0].value.properties[0].value.properties[0].value.any_of[0].enum[0]' (TYPE_STRING), 0
+  ```
+- The path traverses `properties[i].value.properties[j].value.…any_of[k].enum[0]` — Gemini is saying "the value at this position should be a string, but you sent the number 0."
+- `(TYPE_STRING), 0` / `(TYPE_STRING), 1` / `(TYPE_STRING), 2` / `(TYPE_STRING), 3` — one error per literal in the rejected union.
+- Failure happens at the network boundary; unit tests with stubbed `generateFn` pass because they bypass the schema-to-Gemini translation entirely.
+
+## Root Cause
+
+Gemini's `response_schema` is based on the OpenAPI 3.0 schema subset, not full JSON Schema. The OpenAPI 3.0 `enum` field is type-constrained to its declared `type:` — a `type: "string"` field's enum entries must be strings. A field declared with `any_of: [{ const: 0 }, { const: 1 }, …]` resolves to a numeric enum after Zod 4 → JSON Schema translation, which Gemini's validator interprets as "string-typed enum slot, got a number" and rejects per literal.
+
+Zod's `z.union` of `z.literal` values is the idiomatic way to express "one of these specific values," and the Vercel AI SDK's `Output.object` faithfully translates that into JSON Schema. Neither layer warns that Gemini will reject the result.
+
+## Learning Level
+
+- **Level:** Pattern. Will recur on any field where the natural Zod expression is a small enumerated set of non-string primitives — bool literals, numeric IDs, etc.
+- **Feedback loop or delay:** Delayed effect. Local validation, AI SDK type-checks, and stubbed unit tests all pass; only the real-API call fails. The first signal arrives when an operator runs the live pipeline, not when the developer writes the schema.
+
+## Rule Scope
+
+- **Applies when:** Building a Zod schema that will be sent to Gemini via `Output.object({ schema })` (AI SDK v6) or any path that becomes `generation_config.response_schema` on the wire.
+- **Inverts or does not apply when:** The schema field is sent through a JSON-mode-only path (`providerOptions.google.structuredOutputs: false`) — Gemini then validates more loosely after generation, and the literal union survives. Also does not apply to OpenAI / Anthropic structured-output paths, which accept full JSON Schema.
+- **Sibling docs:** None yet. Adjacent pattern: `docs/solutions/patterns/llm-scoring-tier-drift-mechanical-guardrails-2026-05-01.md` (the load-bearing field this pattern protects is also the one most likely to drift across re-runs).
+
+## Solution
+
+Replace literal-union score schemas with constrained number types. The runtime validation behavior is identical for valid values; the JSON Schema translation drops the `enum`/`anyOf` and emits `{ type: "integer", minimum: 0, maximum: 3 }` which Gemini accepts. The tradeoff is the inferred TypeScript type widens from `0|1|2|3` to `number`.
+
+**Before:**
+
+```typescript
+const categoryScoreSchema = z.object({
+  // Gemini rejects: enum[0..3] under any_of becomes a string-typed enum slot
+  score: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+  evidence_quotes: z.array(z.string()).max(2),
+});
+```
+
+**After:**
+
+```typescript
+const categoryScoreSchema = z.object({
+  // Gemini accepts integer with min/max; runtime validation identical for 0–3,
+  // and the system prompt instructs the model on the 0–3 anchor scale.
+  score: z.number().int().min(0).max(3),
+  evidence_quotes: z.array(z.string()).max(2),
+});
+```
+
+If the literal union is load-bearing for downstream type narrowing, narrow at the boundary (`as 0 | 1 | 2 | 3` after schema validation) rather than expressing it in the schema itself.
+
+## Prevention
+
+**Code-level:**
+
+- For any new field sent to Gemini via `response_schema`, prefer `z.number().int().min().max()` or `z.string()` over `z.union(z.literal(...))` of non-string primitives.
+- For string enums (`z.enum(["routine", "bumpy", "heated", "off-the-rails"])`), this issue does not apply — Gemini accepts string enums.
+- When the contract genuinely needs a literal-typed TS surface, narrow downstream of `safeParse`, not in the schema definition itself.
+
+**Process-level:**
+
+- Add to `/research`'s Phase 1 verification ladder: when a feature uses a new structured-output schema with Gemini, run the live API call once during the research spike — not at slice-2 verification time. The failure path is opaque and burns a debug round-trip; surfacing it in `/research` lets the PRD pin the schema shape upfront.
+- Add to `/write-a-prd`'s "Don't Hand-Roll" scan: "If the structured-output schema uses small integer enums, prefer `int().min/max`."
+
+## Planning / Calibration Notes
+
+- **What widened the work:** Discovered at slice-2 first-run-verification time. Fix was 2 minutes; the round trip (write logging, re-run, parse error path, find the right Zod construct) was ~30 minutes of slice-2 wall-clock plus one wasted Gemini call.
+- **What tightened the work:** The PRD's research artifact noted "thinkingConfig + Output.object interaction unverified — verify on first run." That's adjacent to the actual failure mode but didn't predict it; future research scans should explicitly probe schema-to-Gemini translation for any non-string enum field.
+- **Future planning adjustment:** When `/research` Phase 1 covers structured-output schemas, the verification step should be "send one real call with the proposed schema," not "confirm Output.object exists in the SDK."
+
+## Defect Classification
+
+- **Origin phase:** Specification error. The PRD locked the schema shape (literal union 0|1|2|3) without verifying it against Gemini's stricter subset. The error did not exist when the PRD was written; it exists because no live-API verification stage was scheduled before slice 2.
+- **Fix type:** Correction. The schema now uses a Gemini-compatible representation that preserves the runtime invariant.
+
+## Key Decision
+
+**Decision:** Use `z.number().int().min(0).max(3)` for category scores instead of `z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)])`.
+
+**Rationale:** Identical runtime validation for valid values; Gemini-compatible JSON Schema translation; the system prompt already enforces the 0–3 anchor semantics so the LLM contract is unchanged.
+
+**Alternatives considered:**
+
+- Cast to `0 | 1 | 2 | 3` post-parse to preserve narrow downstream typing — rejected as scope creep; `number` propagates fine through the existing storage and orchestrator code.
+- Switch to `providerOptions.google.structuredOutputs: false` (JSON mode) — rejected; we want strict validation, and JSON mode loses the schema-enforcement entirely.
+
+**Revisable:** Yes, if Gemini's `response_schema` validator is updated to accept full JSON Schema (specifically OpenAPI 3.1+'s relaxed enum typing), or if we move to a different provider whose structured-output mode accepts numeric enums.
+
+## Related
+
+- PR: https://github.com/chrislacey89/civic-mirror/pull/65
+- AI SDK v6: `node_modules/ai/dist/index.d.ts:1468` (canonical `output:` parameter); `node_modules/@ai-sdk/google/dist/*.d.ts:17–19` (`thinkingConfig` shape)
+- Gemini API docs: https://ai.google.dev/gemini-api/docs/structured-output
+- Adjacent: `docs/solutions/patterns/llm-scoring-tier-drift-mechanical-guardrails-2026-05-01.md`
+
+## Shelf Life
+
+When Gemini's `response_schema` validator accepts numeric enums (i.e., adopts OpenAPI 3.1+ enum semantics or relaxes the OpenAPI 3.0 type-coupling), this entire constraint disappears and the literal-union form becomes valid. Until then, stable.

--- a/docs/solutions/patterns/llm-scoring-tier-drift-mechanical-guardrails-2026-05-01.md
+++ b/docs/solutions/patterns/llm-scoring-tier-drift-mechanical-guardrails-2026-05-01.md
@@ -1,0 +1,148 @@
+---
+date: 2026-05-01
+category: patterns
+problem_type: probabilistic LLM emissions on load-bearing fields
+components: [pipeline, drama-detection, ai-boundary, storage]
+technologies: [gemini, ai-sdk, effect, llm-judging]
+severity: high
+volatility: stable
+---
+
+# LLM scoring drifts across re-runs; mechanical guardrails own the load-bearing field
+
+## Problem
+
+When an LLM is asked to produce both a *score* and a *tier label* derived from that score, two re-runs of the same input can produce materially different tiers — even with low temperature, native thinking budgets, and a locked prompt. If the tier label is the load-bearing field for downstream behavior (auto-publishing, gating, tier-based routing), trusting the LLM's emitted label means downstream behavior also drifts. The fix is to make the mechanical derivation the source of truth and treat the LLM's label as a hint that gets overridden when it disagrees.
+
+## Context
+
+Drama Watch v1 asks Gemini 2.5 Flash to score seven categories of meeting friction (0–3 each, sum range 0–21) and emit a tier (`routine`/`bumpy`/`heated`/`off-the-rails`) where the tier is mechanically derived from the sum (`mapSumToLevel(sum)`). The tier gates the auto-publish rule: `routine`/`bumpy`/`heated` go live at insert time, `off-the-rails` queues for manual review.
+
+Two real-API runs against the same RBB hiring transcript with `prompt_version="v1"`, `model="gemini-2.5-flash"`, and `thinkingBudget: 4096`:
+
+| Run | Sum | LLM-emitted level | mapSumToLevel(sum) |
+|-----|-----|-------------------|--------------------|
+| A | 18 | `off-the-rails` | `off-the-rails` |
+| B | 11 | `heated` | `bumpy` |
+
+That's a 7-point swing on identical input. Run A would have queued for manual review; Run B auto-published. Without a mechanical override, the same meeting could have either outcome depending on which side of an LLM coin flip we're on.
+
+## Symptoms
+
+- Same input, same model, same prompt version → different scores and tier classifications across runs.
+- The LLM's emitted tier label disagrees with the mechanical sum-to-tier mapping (LLM says "heated" when sum is 11, which `mapSumToLevel` correctly maps to "bumpy").
+- Storage-boundary log: `[drama] level override: LLM emitted "X", mapSumToLevel(N) = "Y"`.
+- Sibling effect: hand-graded eval set drift across runs of the same transcript — a category may score 2 on Monday and 0 on Tuesday for reasons no prompt change can pin down.
+
+## Root Cause
+
+LLM token sampling is non-deterministic by design (even at temperature 0, scheduling and quantization create observable variance). The model is also asked to do two arithmetic-like operations that probabilistic generation handles poorly: sum seven small integers, then map the sum into one of four buckets. The score field is *easier* to get right (it's anchored on category-specific 0–3 rubric language); the tier label is *harder* because it requires an internal computation the model is being trained to *generate* rather than *execute*.
+
+Trusting the LLM's emitted tier as the source of truth conflates two different kinds of output:
+
+- **Judgment fields** (score, headline, narrative, evidence quotes): the LLM is the right tool — these require pattern recognition over a long transcript.
+- **Mechanical fields** (sum, tier, derived flags): the LLM is the wrong tool — these are pure functions of the judgment fields and should be computed deterministically.
+
+## Learning Level
+
+- **Level:** Pattern. Recurs whenever an LLM is asked to emit both a score-like field and a derived/computed field over the same response.
+- **Feedback loop or delay:** Delayed effect with low signal density. A single wrong tier looks like a normal LLM output; the drift only becomes visible after multiple runs of the same input or after operators notice "the same meeting got published differently last week."
+
+## Rule Scope
+
+- **Applies when:** The LLM's structured output contains a *load-bearing* field that is mechanically derivable from other fields in the same response. "Load-bearing" means downstream code reads it to make a decision (gate publication, route to a queue, classify severity, count toward a metric).
+- **Inverts or does not apply when:** The derived field is *advisory only* — e.g., a UI hint, a confidence summary, a human-readable label rendered next to the underlying numbers. In that case the LLM's emission can stand because nothing branches on it.
+- **Sibling docs:**
+  - `docs/solutions/patterns/tri-state-return-for-pipeline-outcomes-2026-04-13.md` — same shape (in-band discriminant + variant payload). The drama assessment is a tri-state-style return where `level` is the discriminant and `category_scores` is the payload; this doc adds the "the discriminant must be mechanically derived, not LLM-emitted" rule on top of tri-state.
+  - `docs/solutions/integration-issues/gemini-response-schema-numeric-enum-rejection-2026-05-01.md` — adjacent issue on the same boundary. The score field this pattern protects is also where Gemini's enum constraint bit.
+
+## Solution
+
+Apply the mechanical override at every layer that touches the load-bearing field. Defense-in-depth, because the cheapest guardrail to skip is the one that's never been wrong yet.
+
+**Two-layer override:**
+
+1. **Service layer** (`DramaDetectionService.ts`): after the LLM call returns and before the result leaves the boundary, recompute the derived field from the source-of-truth fields. Log mismatches as prompt-iteration signal.
+
+   ```typescript
+   function recomputeLevelFromScores(
+     assessment: DramaAssessmentOutput,
+   ): DramaAssessmentOutput {
+     const sum = sumCategoryScores(assessment.category_scores);
+     const computed = mapSumToLevel(sum);
+     if (computed === assessment.level) return assessment;
+     console.warn(
+       `[drama] level override: LLM emitted "${assessment.level}", ` +
+         `mapSumToLevel(${sum}) = "${computed}"`,
+     );
+     return { ...assessment, level: computed };
+   }
+   ```
+
+2. **Storage boundary** (`StorageService.ts`): repeat the invariant check on insert. The service-layer override protects the "passed through `detect()`" path; the storage-boundary override protects every path, including future direct callers and any test that constructs an assessment by hand.
+
+   ```typescript
+   const computedLevel = mapSumToLevel(total);
+   let level = input.level;
+   if (computedLevel !== level) {
+     console.warn(`[drama-storage] level override on insert: …`);
+     level = computedLevel;
+   }
+   ```
+
+The duplication is intentional and worth a comment at the storage site so future readers don't dedup it away.
+
+## Prevention
+
+**Code-level:**
+
+- For any LLM-emitted derived field, write the mechanical computation as a pure function (e.g., `mapSumToLevel(sum)`) and apply it as the source of truth at the storage or boundary layer. Do not trust the LLM's emission.
+- Log overrides at warn level so prompt iteration has a visible signal when drift accumulates.
+- Test: a unit test where the LLM-emitted tier disagrees with the score sum and the result is the computed tier, not the emitted one. (See `DramaDetectionService.test.ts:120–135` and `StorageService.test.ts:756–786` for the canonical shapes.)
+
+**Process-level:**
+
+- Add to `/research`'s Phase 1 LLM-feature scan: identify which response fields are load-bearing for downstream behavior and which are derivable from other fields. Flag derivable load-bearing fields as candidates for mechanical override before shaping.
+- Add to `/write-a-prd`'s "Don't Hand-Roll" scan: "If the LLM emits both a score and a derived label, the storage boundary must enforce `label === f(score)` and override-on-mismatch."
+- Add to `/qa` heuristics: when an LLM-judgment feature is the subject of a bug report, re-run the same input 3–5 times before accepting the bug as a defect. Drift across runs is its own defect class, separate from "the model gave the wrong answer once."
+
+## Planning / Calibration Notes
+
+- **What widened the work:** None directly — the override pattern was already in the PRD's boundary map. What this *will* widen: slice #5 (methodology + prompt iteration) needs to budget for hand-graded eval across multiple runs of the same transcript, not just single-shot scoring.
+- **What tightened the work:** The PRD baked in the `mapSumToLevel` invariant and the override-with-log pattern explicitly, so first-run drift surfaced clean override logs rather than silently corrupted data. This is the win — without the pattern, the calibration data wouldn't exist.
+- **Future planning adjustment:** When `/research` covers an LLM-judgment feature, surface "expected re-run drift" as an explicit unknown alongside "expected response latency." Run-to-run variance is a first-class characteristic of the feature, not an edge case.
+
+## Actuals Worth Reusing
+
+- **Comparable future work:** Any LLM-as-judge feature where a tier, severity, classification, or gating flag is part of the response. Civic Mirror examples on the horizon: severity scoring of fiscal-decision opacity, ranking of which meetings are "newsworthy," confidence calibration on summaries.
+- **Reusable baseline:** Expect ≥10% absolute tier disagreement between re-runs on borderline inputs (sum-near-tier-boundary cases). Budget hand-graded eval in pairs (same input, two runs) to surface drift, not single-shot.
+
+## Defect Classification
+
+- **Origin phase:** Design success, not a defect. The pattern was anticipated in the PRD and shipped correctly.
+- **Fix type:** N/A. This compound captures the pattern that *prevented* the defect class — future work should adopt it, not avoid it.
+
+## Key Decision
+
+**Decision:** Mechanical sum-to-tier mapping is the source of truth for the `level` field; LLM emissions are advisory and overridden on mismatch.
+
+**Rationale:** LLM token-sampling drift makes the emitted tier non-deterministic across runs of the same input; tier is load-bearing for the auto-publish rule; arithmetic over small integers is a domain where deterministic functions strictly dominate generative inference.
+
+**Alternatives considered:**
+
+- **Trust the LLM, retry on mismatch.** Rejected: doesn't converge — the next run can disagree differently. Burns API calls. Doesn't address the fundamental drift.
+- **Lower the temperature further / pin random seed.** Rejected: scheduling and quantization variance are not seed-controlled. Drift remains.
+- **Make the LLM output only the scores, compute tier client-side.** Considered. Roughly equivalent in correctness; the chosen design lets the LLM emit a tier so its reasoning shows the framing decision (procedural-theater pattern, etc.) for prompt iteration. The override gives us the safety without losing the diagnostic.
+
+**Revisable:** No, in the sense that "trust the LLM emission" is never safe for load-bearing derived fields. Yes in the sense that *which* layer applies the override is a design choice — single-layer is acceptable if the override layer is the only consumer.
+
+## Related
+
+- PR: https://github.com/chrislacey89/civic-mirror/pull/65
+- Sibling: `docs/solutions/patterns/tri-state-return-for-pipeline-outcomes-2026-04-13.md`
+- Adjacent: `docs/solutions/integration-issues/gemini-response-schema-numeric-enum-rejection-2026-05-01.md`
+- Calibration evidence: PR #65 commit `4241426`'s body — two runs, sum=18 and sum=11 on the same RBB hiring transcript
+
+## Shelf Life
+
+Evergreen for the duration that LLM token sampling is non-deterministic — i.e., for the foreseeable future of generative AI. Even when models become substantially more reliable on arithmetic-like derivations, "trust the LLM for load-bearing computed fields" remains the wrong posture; the cost of the deterministic override is one pure function and one log line. If a future provider ships true determinism guarantees on a specific class of derived fields, revisit selectively.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "tesseract.js": "^7.0.0",
     "tw-animate-css": "^1.3.6",
     "unpdf": "^1.6.0",
-    "youtube-transcript": "^1.3.0",
+    "youtube-transcript": "^1.3.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0(@napi-rs/canvas@0.1.97)
       youtube-transcript:
-        specifier: ^1.3.0
-        version: 1.3.0
+        specifier: ^1.3.1
+        version: 1.3.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -3626,8 +3626,8 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
-  youtube-transcript@1.3.0:
-    resolution: {integrity: sha512-laWv9RcKIWh6rZUH3hVnOngEvtKAhFMV5UepUO6AgevPYqe2zv8KW/uCkZJDSnPwf5/AdVu0Q66/1RDblKsp6Q==}
+  youtube-transcript@1.3.1:
+    resolution: {integrity: sha512-NDCjwad113TGybbYF51y9Z4tcwzBHUZWQdF9veULNca18L+FdDbHHtTHIr69WVa3bB90l67S8kN0HtL2JO9fhg==}
     engines: {node: '>=18.0.0'}
 
   zlibjs@0.3.1:
@@ -6683,7 +6683,7 @@ snapshots:
 
   yaml@2.8.3: {}
 
-  youtube-transcript@1.3.0: {}
+  youtube-transcript@1.3.1: {}
 
   zlibjs@0.3.1: {}
 

--- a/src/pipeline/cli.ts
+++ b/src/pipeline/cli.ts
@@ -10,7 +10,10 @@ import {
 	DEFAULT_BODIES,
 	extractPdfText,
 } from "#/pipeline/composition.ts";
-import { runPipeline } from "#/pipeline/orchestrator.ts";
+import {
+	runDramaDetectForVideo,
+	runPipeline,
+} from "#/pipeline/orchestrator.ts";
 
 /**
  * Effect teaching note: This file owns the CLI surface — `@effect/cli` Command
@@ -93,6 +96,91 @@ const runCommand = Command.make(
 // can see what `run` will process without running anything.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// `drama:detect` subcommand — first-run inspection on a single YouTube video.
+// Bypasses the playlist scraper so the operator can target one meeting,
+// observe the structured output, and confirm Heated-band assignment on the
+// RBB hiring transcript before configuring full playlist ingestion.
+// ---------------------------------------------------------------------------
+
+const detectVideoId = Options.text("video-id").pipe(
+	Options.withDescription("YouTube video ID (the part after `?v=`)."),
+);
+
+const detectBodySlug = Options.text("body").pipe(
+	Options.withDescription(
+		"Body slug to attribute the meeting to (must exist in governing_bodies).",
+	),
+);
+
+const detectTitle = Options.text("title").pipe(
+	Options.optional,
+	Options.withDescription(
+		"Meeting title used as the prompt context (defaults to a stub).",
+	),
+);
+
+const detectDate = Options.text("date").pipe(
+	Options.optional,
+	Options.withDescription(
+		"ISO date (YYYY-MM-DD) recorded as the meeting date (defaults to today).",
+	),
+);
+
+const dramaDetectCommand = Command.make(
+	"drama:detect",
+	{
+		videoId: detectVideoId,
+		bodySlug: detectBodySlug,
+		title: detectTitle,
+		date: detectDate,
+	},
+	({ videoId, bodySlug, title, date }) =>
+		Effect.gen(function* () {
+			const body = DEFAULT_BODIES.find((b) => b.slug === bodySlug);
+			if (!body) {
+				yield* Console.error(
+					`Unknown body slug: ${bodySlug}. Known slugs: ${DEFAULT_BODIES.map((b) => b.slug).join(", ")}`,
+				);
+				return;
+			}
+
+			const resolvedTitle = Option.getOrElse(
+				title,
+				() => `Manual drama:detect ${videoId}`,
+			);
+			const resolvedDate = Option.getOrElse(date, () =>
+				new Date().toISOString().slice(0, 10),
+			);
+
+			yield* Console.log(
+				`[drama:detect] body=${bodySlug} videoId=${videoId} date=${resolvedDate}`,
+			);
+
+			const layers = yield* Effect.try({
+				try: () => buildProductionLayers({ dryRun: false }),
+				catch: (error) =>
+					new Error(
+						`Failed to construct pipeline layers: ${error instanceof Error ? error.message : String(error)}`,
+					),
+			});
+
+			const result = yield* runDramaDetectForVideo({
+				body,
+				video: {
+					videoId,
+					title: resolvedTitle,
+					publishedAt: `${resolvedDate}T00:00:00Z`,
+					hasCaptions: true,
+				},
+			}).pipe(Effect.provide(layers));
+
+			yield* Console.log(
+				`[drama:detect] done: processed=${result.processed} errors=${result.errors}`,
+			);
+		}),
+);
+
 const listBodiesCommand = Command.make("list-bodies", {}, () =>
 	Effect.gen(function* () {
 		for (const body of DEFAULT_BODIES) {
@@ -115,7 +203,9 @@ const rootCommand = Command.make("pipeline", {}, () =>
 	Console.log(
 		"Civic Mirror pipeline — run `pipeline run --help` or `pipeline list-bodies`.",
 	),
-).pipe(Command.withSubcommands([runCommand, listBodiesCommand]));
+).pipe(
+	Command.withSubcommands([runCommand, listBodiesCommand, dramaDetectCommand]),
+);
 
 const cli = Command.run(rootCommand, {
 	name: "Civic Mirror Pipeline",

--- a/src/pipeline/composition.ts
+++ b/src/pipeline/composition.ts
@@ -4,7 +4,12 @@ import { Layer } from "effect";
 import { Resend } from "resend";
 import * as schema from "#/db/schema.ts";
 import { AlertServiceLive } from "#/pipeline/services/AlertService.ts";
+import { DramaDetectionServiceLive } from "#/pipeline/services/DramaDetectionService.ts";
 import { FinalsiteScraperLive } from "#/pipeline/services/FinalsiteScraper.ts";
+import {
+	createGeminiDramaDetector,
+	DRAMA_DETECTION_PROMPT_VERSION,
+} from "#/pipeline/services/GeminiDramaDetector.ts";
 import { createGeminiSummarizer } from "#/pipeline/services/GeminiSummarizer.ts";
 import { extractPdfText } from "#/pipeline/services/PdfExtractor.ts";
 import { EgovScraperLive } from "#/pipeline/services/ScraperService.ts";
@@ -143,6 +148,13 @@ function buildProductionLayers(input: BuildLayersInput) {
 		generateFn: geminiGenerator,
 	});
 
+	const dramaDetector = createGeminiDramaDetector({ modelId: geminiModelId });
+	const dramaDetection = DramaDetectionServiceLive({
+		model: geminiModelId,
+		promptVersion: DRAMA_DETECTION_PROMPT_VERSION,
+		generateFn: dramaDetector,
+	});
+
 	const storage = StorageServiceLive(db);
 
 	const alert = AlertServiceLive({
@@ -168,6 +180,7 @@ function buildProductionLayers(input: BuildLayersInput) {
 		youtube,
 		transcription,
 		summarization,
+		dramaDetection,
 		storage,
 		alert,
 	);

--- a/src/pipeline/composition.ts
+++ b/src/pipeline/composition.ts
@@ -84,7 +84,7 @@ const DEFAULT_BODIES: BodyConfigEntry[] = [
 		egovTitlePattern: /^Monroe County/i,
 	},
 	{
-		slug: "richland-bean-blossom-school-board",
+		slug: "rbb-school-board",
 		name: "Richland-Bean Blossom School Board",
 		finalsiteUrl: "https://www.rbbschools.net/school-board",
 	},

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -2,7 +2,10 @@ import { Effect, Layer } from "effect";
 import { describe, expect, it } from "vitest";
 import type { MeetingDetail } from "#/db/queries.ts";
 import { LlmError } from "#/pipeline/errors.ts";
-import { runPipeline } from "#/pipeline/orchestrator.ts";
+import {
+	runDramaDetectForVideo,
+	runPipeline,
+} from "#/pipeline/orchestrator.ts";
 import { AlertService } from "#/pipeline/services/AlertService.ts";
 import {
 	type DramaAssessmentResult,
@@ -946,5 +949,36 @@ describe("runPipeline", () => {
 		expect(result.processed).toBe(1);
 		expect(result.errors).toBe(0);
 		expect(log.alert).toHaveLength(0);
+	});
+});
+
+describe("runDramaDetectForVideo", () => {
+	it("runs the YouTube path on one video without scraping a playlist", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({ log });
+
+		const program = runDramaDetectForVideo({
+			body: { slug: "town-council", name: "Town Council" },
+			video: {
+				videoId: "rbb-hiring-2026-04-15",
+				title: "RBB School Board, April 15 2026",
+				publishedAt: "2026-04-15T00:00:00Z",
+				hasCaptions: true,
+			},
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		// Did NOT touch the playlist scraper.
+		expect(log.youtubeList).toHaveLength(0);
+		// Did transcribe, summarize, store, and run drama detection.
+		expect(log.transcribe).toEqual(["rbb-hiring-2026-04-15"]);
+		expect(log.summarize).toHaveLength(1);
+		expect(log.store).toHaveLength(1);
+		expect(log.drama).toBe(1);
+		expect(result.processed).toBe(1);
+		expect(result.errors).toBe(0);
 	});
 });

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -150,6 +150,7 @@ function buildStubLayers(config: StubConfig) {
 		storeTranscript: () => Effect.void,
 		getMostRecentMeetingDate: () =>
 			Effect.sync(() => config.mostRecentMeetingDate ?? null),
+		storeDramaAssessment: () => Effect.void,
 	});
 
 	const alert = Layer.succeed(AlertService, {

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -4,6 +4,10 @@ import type { MeetingDetail } from "#/db/queries.ts";
 import { LlmError } from "#/pipeline/errors.ts";
 import { runPipeline } from "#/pipeline/orchestrator.ts";
 import { AlertService } from "#/pipeline/services/AlertService.ts";
+import {
+	type DramaAssessmentResult,
+	DramaDetectionService,
+} from "#/pipeline/services/DramaDetectionService.ts";
 import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
 import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
 import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
@@ -35,6 +39,7 @@ type CallLog = {
 	store: Array<{ bodySlug: string; date: string }>;
 	storeInputs: Array<MeetingInput>;
 	alert: Array<{ subject: string; body: string }>;
+	drama: number;
 };
 
 function emptyCallLog(): CallLog {
@@ -49,6 +54,7 @@ function emptyCallLog(): CallLog {
 		store: [],
 		storeInputs: [],
 		alert: [],
+		drama: 0,
 	};
 }
 
@@ -62,6 +68,8 @@ type StubConfig = {
 	storedMeeting?: Meeting;
 	lastMeetingLookup?: MeetingDetail | null;
 	mostRecentMeetingDate?: string | null;
+	dramaDetectionResult?: DramaAssessmentResult;
+	dramaDetectionError?: Error;
 };
 
 function buildStubLayers(config: StubConfig) {
@@ -160,6 +168,40 @@ function buildStubLayers(config: StubConfig) {
 			}),
 	});
 
+	const defaultDramaResult: DramaAssessmentResult = {
+		category_scores: {
+			procedural_breakdown: { score: 0, evidence_quotes: [] },
+			question_looping: { score: 0, evidence_quotes: [] },
+			defensive_hedging: { score: 0, evidence_quotes: [] },
+			timeline_pressure: { score: 0, evidence_quotes: [] },
+			improvised_workarounds: { score: 0, evidence_quotes: [] },
+			visible_dissent: { score: 0, evidence_quotes: [] },
+			post_hoc_corrections: { score: 0, evidence_quotes: [] },
+		},
+		level: "routine",
+		confidence: 0.8,
+		headline: "Routine meeting",
+		narrative: "Nothing notable.",
+		model: "stub-model",
+		promptVersion: "v1",
+	};
+
+	const drama = Layer.succeed(DramaDetectionService, {
+		detect: () =>
+			Effect.try({
+				try: () => {
+					config.log.drama += 1;
+					if (config.dramaDetectionError) throw config.dramaDetectionError;
+					return config.dramaDetectionResult ?? defaultDramaResult;
+				},
+				catch: (error) =>
+					new LlmError({
+						model: "stub-model",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+
 	return Layer.mergeAll(
 		egov,
 		finalsite,
@@ -168,6 +210,7 @@ function buildStubLayers(config: StubConfig) {
 		summarization,
 		storage,
 		alert,
+		drama,
 	);
 }
 
@@ -606,7 +649,51 @@ describe("runPipeline", () => {
 		expect(log.summarize).toHaveLength(1);
 		expect(log.summarize[0].sourceText).toContain("transcript for abc123");
 		expect(log.store).toHaveLength(1);
+		expect(log.drama).toBe(1);
 		expect(result.processed).toBe(1);
+	});
+
+	it("does not block transcript storage when drama detection fails", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			youtubeVideos: [
+				{
+					videoId: "abc123",
+					title: "Town Council, March 23, 2026",
+					publishedAt: "2026-03-24T00:00:00Z",
+					hasCaptions: true,
+				},
+			],
+			dramaDetectionError: new Error("Gemini API down"),
+		});
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "town-council",
+					name: "Town Council",
+					youtubePlaylistId: "PL_test",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({ text: "unused", method: "text-layer" }),
+			dryRun: false,
+		}).pipe(Effect.provide(layers));
+
+		const result = await Effect.runPromise(program);
+
+		// Transcript and summary still landed despite drama detection failure.
+		expect(log.store).toHaveLength(1);
+		expect(result.processed).toBe(1);
+		expect(result.errors).toBe(0);
+		// Operator was alerted to the drama failure.
+		expect(log.alert.some((a) => a.subject.includes("drama-detection"))).toBe(
+			true,
+		);
 	});
 
 	it("persists an unreadable eGov PDF as a document row without summarizing", async () => {

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -839,5 +839,60 @@ function meetingTypeFromFinalsiteLabel(
 	return "regular";
 }
 
-export { runPipeline };
+/**
+ * One-shot entry point: run the YouTube branch on a single video. Used by
+ * the `drama:detect` CLI subcommand for first-run inspection of a known
+ * meeting before configuring the full playlist on a body. Bypasses
+ * YouTubeScraper.listPlaylistVideos entirely — the operator supplies the
+ * video metadata directly.
+ */
+function runDramaDetectForVideo(input: {
+	body: BodyConfig;
+	video: YouTubeVideo;
+	networkRetry?: RetryPolicy;
+	llmRetry?: RetryPolicy;
+	now?: Date;
+}): Effect.Effect<
+	PipelineResult,
+	never,
+	| TranscriptionService
+	| SummarizationService
+	| StorageService
+	| AlertService
+	| DramaDetectionService
+> {
+	const config: ResolvedConfig = {
+		bodies: [input.body],
+		crawlDelayMs: 0,
+		youtubeDelayMs: 0,
+		extractPdfText: async () => ({ text: "", method: "unreadable" }),
+		dryRun: false,
+		networkSchedule: scheduleFromPolicy(
+			input.networkRetry ?? DEFAULT_NETWORK_RETRY,
+		),
+		llmSchedule: scheduleFromPolicy(input.llmRetry ?? DEFAULT_LLM_RETRY),
+		now: input.now ?? new Date(),
+	};
+
+	return processYouTubeVideo(input.body, input.video, config).pipe(
+		Effect.catchAll((error) =>
+			Effect.gen(function* () {
+				const alert = yield* AlertService;
+				yield* alert
+					.sendAlert(
+						formatPipelineErrorAlert({
+							stage: error._tag,
+							bodyName: input.body.name,
+							errorTag: error._tag,
+							errorMessage: error.message,
+						}),
+					)
+					.pipe(Effect.catchAll(() => Effect.void));
+				return { processed: 0, errors: 1 };
+			}),
+		),
+	);
+}
+
+export { runDramaDetectForVideo, runPipeline };
 export type { BodyConfig, RunPipelineInput, PipelineResult, RetryPolicy };

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,10 +1,12 @@
 import { Duration, Effect, Schedule } from "effect";
+import { DRAMA_CATEGORIES } from "#/lib/drama-levels.ts";
 import { normalizeEgovDate, normalizeFinalsiteDate } from "#/pipeline/dates.ts";
 import {
 	AlertService,
 	formatPipelineErrorAlert,
 	formatZeroResultsAlert,
 } from "#/pipeline/services/AlertService.ts";
+import { DramaDetectionService } from "#/pipeline/services/DramaDetectionService.ts";
 import type { FinalsiteMeetingListing } from "#/pipeline/services/FinalsiteScraper.ts";
 import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
 import type { ExtractResult } from "#/pipeline/services/PdfExtractor.ts";
@@ -13,7 +15,9 @@ import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
 import type { MeetingInput } from "#/pipeline/services/StorageService.ts";
 import { StorageService } from "#/pipeline/services/StorageService.ts";
 import { SummarizationService } from "#/pipeline/services/SummarizationService.ts";
+import type { TranscriptResult } from "#/pipeline/services/TranscriptionService.ts";
 import { TranscriptionService } from "#/pipeline/services/TranscriptionService.ts";
+import { formatTranscriptWithTimestamps } from "#/pipeline/services/transcriptFormatting.ts";
 import type { YouTubeVideo } from "#/pipeline/services/YouTubeScraper.ts";
 import { YouTubeScraper } from "#/pipeline/services/YouTubeScraper.ts";
 
@@ -165,6 +169,7 @@ function runPipeline(
 	| SummarizationService
 	| StorageService
 	| AlertService
+	| DramaDetectionService
 > {
 	const config: ResolvedConfig = {
 		...input,
@@ -203,6 +208,7 @@ function runPipelineForBody(
 	| SummarizationService
 	| StorageService
 	| AlertService
+	| DramaDetectionService
 > {
 	return Effect.gen(function* () {
 		// Zero-results anomaly check: alert if this body hasn't had fresh content
@@ -599,6 +605,7 @@ function runYouTubeForBody(
 	| SummarizationService
 	| StorageService
 	| AlertService
+	| DramaDetectionService
 > {
 	return Effect.gen(function* () {
 		const playlistId = body.youtubePlaylistId;
@@ -629,7 +636,11 @@ function processYouTubeVideo(
 ): Effect.Effect<
 	PipelineResult,
 	TaggedPipelineError,
-	TranscriptionService | SummarizationService | StorageService
+	| TranscriptionService
+	| SummarizationService
+	| StorageService
+	| DramaDetectionService
+	| AlertService
 > {
 	return Effect.gen(function* () {
 		const transcription = yield* TranscriptionService;
@@ -671,7 +682,85 @@ function processYouTubeVideo(
 			sourceUrl: `https://www.youtube.com/watch?v=${video.videoId}`,
 		});
 
+		// Drama detection runs AFTER transcript storage. Failure must not
+		// regress transcript or summary persistence — those are first-class
+		// transparency artifacts. The catchAll below absorbs any error,
+		// alerts the operator, and returns Effect.void so the orchestrator's
+		// tagged-error channel is unaffected.
+		yield* runDramaDetection({
+			body,
+			video,
+			meetingId: meeting.id,
+			transcript,
+		}).pipe(Effect.catchAll((error) => alertDramaFailure(body, error)));
+
 		return { processed: 1, errors: 0 };
+	});
+}
+
+function runDramaDetection(input: {
+	body: BodyConfig;
+	video: YouTubeVideo;
+	meetingId: number;
+	transcript: TranscriptResult;
+}) {
+	return Effect.gen(function* () {
+		const detector = yield* DramaDetectionService;
+		const storage = yield* StorageService;
+
+		const formatted = formatTranscriptWithTimestamps(input.transcript);
+
+		const assessment = yield* detector.detect({
+			sourceText: formatted,
+			meetingContext: `${input.body.name}, ${input.video.title}`,
+		});
+
+		const categoryScores = Object.fromEntries(
+			DRAMA_CATEGORIES.map((cat) => [
+				cat,
+				{
+					score: assessment.category_scores[cat].score,
+					evidenceQuotes: assessment.category_scores[cat].evidence_quotes,
+				},
+			]),
+		) as Parameters<typeof storage.storeDramaAssessment>[0]["categoryScores"];
+
+		yield* storage.storeDramaAssessment({
+			meetingId: input.meetingId,
+			level: assessment.level,
+			confidence: assessment.confidence,
+			promptVersion: assessment.promptVersion,
+			model: assessment.model,
+			headline: assessment.headline,
+			narrative: assessment.narrative,
+			categoryScores,
+		});
+	});
+}
+
+function alertDramaFailure(body: BodyConfig, error: unknown) {
+	return Effect.gen(function* () {
+		const alert = yield* AlertService;
+		const tag =
+			typeof error === "object" && error !== null && "_tag" in error
+				? String((error as { _tag: unknown })._tag)
+				: "DramaDetectionError";
+		const message =
+			error instanceof Error
+				? error.message
+				: typeof error === "object" && error !== null && "message" in error
+					? String((error as { message: unknown }).message)
+					: String(error);
+		yield* alert
+			.sendAlert(
+				formatPipelineErrorAlert({
+					stage: "drama-detection",
+					bodyName: body.name,
+					errorTag: tag,
+					errorMessage: message,
+				}),
+			)
+			.pipe(Effect.catchAll(() => Effect.void));
 	});
 }
 

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -1,6 +1,7 @@
 import { Duration, Effect, Schedule } from "effect";
-import { DRAMA_CATEGORIES } from "#/lib/drama-levels.ts";
+import { DRAMA_CATEGORIES, type DramaCategory } from "#/lib/drama-levels.ts";
 import { normalizeEgovDate, normalizeFinalsiteDate } from "#/pipeline/dates.ts";
+import type { DatabaseError, LlmError } from "#/pipeline/errors.ts";
 import {
 	AlertService,
 	formatPipelineErrorAlert,
@@ -12,7 +13,10 @@ import { FinalsiteScraper } from "#/pipeline/services/FinalsiteScraper.ts";
 import type { ExtractResult } from "#/pipeline/services/PdfExtractor.ts";
 import type { EgovDocumentListing } from "#/pipeline/services/ScraperService.ts";
 import { EgovScraper } from "#/pipeline/services/ScraperService.ts";
-import type { MeetingInput } from "#/pipeline/services/StorageService.ts";
+import type {
+	DramaCategoryScoreInput,
+	MeetingInput,
+} from "#/pipeline/services/StorageService.ts";
 import { StorageService } from "#/pipeline/services/StorageService.ts";
 import { SummarizationService } from "#/pipeline/services/SummarizationService.ts";
 import type { TranscriptResult } from "#/pipeline/services/TranscriptionService.ts";
@@ -715,15 +719,21 @@ function runDramaDetection(input: {
 			meetingContext: `${input.body.name}, ${input.video.title}`,
 		});
 
-		const categoryScores = Object.fromEntries(
-			DRAMA_CATEGORIES.map((cat) => [
-				cat,
-				{
-					score: assessment.category_scores[cat].score,
-					evidenceQuotes: assessment.category_scores[cat].evidence_quotes,
-				},
-			]),
-		) as Parameters<typeof storage.storeDramaAssessment>[0]["categoryScores"];
+		const categoryScores: Record<DramaCategory, DramaCategoryScoreInput> = {
+			procedural_breakdown: { score: 0, evidenceQuotes: [] },
+			question_looping: { score: 0, evidenceQuotes: [] },
+			defensive_hedging: { score: 0, evidenceQuotes: [] },
+			timeline_pressure: { score: 0, evidenceQuotes: [] },
+			improvised_workarounds: { score: 0, evidenceQuotes: [] },
+			visible_dissent: { score: 0, evidenceQuotes: [] },
+			post_hoc_corrections: { score: 0, evidenceQuotes: [] },
+		};
+		for (const cat of DRAMA_CATEGORIES) {
+			categoryScores[cat] = {
+				score: assessment.category_scores[cat].score,
+				evidenceQuotes: assessment.category_scores[cat].evidence_quotes,
+			};
+		}
 
 		yield* storage.storeDramaAssessment({
 			meetingId: input.meetingId,
@@ -738,26 +748,16 @@ function runDramaDetection(input: {
 	});
 }
 
-function alertDramaFailure(body: BodyConfig, error: unknown) {
+function alertDramaFailure(body: BodyConfig, error: LlmError | DatabaseError) {
 	return Effect.gen(function* () {
 		const alert = yield* AlertService;
-		const tag =
-			typeof error === "object" && error !== null && "_tag" in error
-				? String((error as { _tag: unknown })._tag)
-				: "DramaDetectionError";
-		const message =
-			error instanceof Error
-				? error.message
-				: typeof error === "object" && error !== null && "message" in error
-					? String((error as { message: unknown }).message)
-					: String(error);
 		yield* alert
 			.sendAlert(
 				formatPipelineErrorAlert({
 					stage: "drama-detection",
 					bodyName: body.name,
-					errorTag: tag,
-					errorMessage: message,
+					errorTag: error._tag,
+					errorMessage: error.message,
 				}),
 			)
 			.pipe(Effect.catchAll(() => Effect.void));

--- a/src/pipeline/services/DramaDetectionService.test.ts
+++ b/src/pipeline/services/DramaDetectionService.test.ts
@@ -169,12 +169,12 @@ describe("dramaAssessmentSchema", () => {
 		expect(() => dramaAssessmentSchema.parse(bad)).toThrow();
 	});
 
-	it("rejects headlines longer than 100 chars", () => {
+	it("rejects headlines longer than 200 chars", () => {
 		const bad = {
 			category_scores: ZERO_CATEGORY_SCORES,
 			level: "routine",
 			confidence: 0.5,
-			headline: "x".repeat(101),
+			headline: "x".repeat(201),
 			narrative: "n",
 		};
 

--- a/src/pipeline/services/DramaDetectionService.test.ts
+++ b/src/pipeline/services/DramaDetectionService.test.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect";
+import { Cause, Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
 import {
 	DramaDetectionService,
@@ -321,9 +321,17 @@ describe("DramaDetectionServiceLive", () => {
 			),
 		);
 
-		const error = await Effect.runPromise(program.pipe(Effect.flip));
+		// runPromiseExit preserves the typed Exit so we can distinguish a typed
+		// failure (Cause.Fail) from a defect (Cause.Die) — flip + runPromise
+		// would conflate the two.
+		const exit = await Effect.runPromiseExit(program);
 
-		expect(error._tag).toBe("LlmError");
-		expect(error.message).toContain("API quota exceeded");
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (!Exit.isFailure(exit)) return;
+		const failure = Cause.failureOption(exit.cause);
+		expect(failure._tag).toBe("Some");
+		if (failure._tag !== "Some") return;
+		expect(failure.value._tag).toBe("LlmError");
+		expect(failure.value.message).toContain("API quota exceeded");
 	});
 });

--- a/src/pipeline/services/DramaDetectionService.test.ts
+++ b/src/pipeline/services/DramaDetectionService.test.ts
@@ -1,0 +1,329 @@
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	DramaDetectionService,
+	DramaDetectionServiceLive,
+	dramaAssessmentSchema,
+	recomputeLevelFromScores,
+	verifyEvidenceQuotes,
+} from "./DramaDetectionService.ts";
+
+const SOURCE_TEXT = `
+Council member Smith said, "I cannot support this without seeing the
+job descriptions first." The board chair replied that the descriptions
+would be drafted next week. Smith pressed: "We are voting on positions
+that have not been formally approved." The motion passed 4-1.
+`.trim();
+
+const ZERO_CATEGORY_SCORES = {
+	procedural_breakdown: { score: 0 as const, evidence_quotes: [] },
+	question_looping: { score: 0 as const, evidence_quotes: [] },
+	defensive_hedging: { score: 0 as const, evidence_quotes: [] },
+	timeline_pressure: { score: 0 as const, evidence_quotes: [] },
+	improvised_workarounds: { score: 0 as const, evidence_quotes: [] },
+	visible_dissent: { score: 0 as const, evidence_quotes: [] },
+	post_hoc_corrections: { score: 0 as const, evidence_quotes: [] },
+};
+
+describe("verifyEvidenceQuotes", () => {
+	it("keeps quotes that appear verbatim in the source text", () => {
+		const verified = verifyEvidenceQuotes(
+			{
+				score: 2,
+				evidence_quotes: [
+					"I cannot support this without seeing the job descriptions first.",
+				],
+			},
+			SOURCE_TEXT,
+		);
+
+		expect(verified.score).toBe(2);
+		expect(verified.evidence_quotes).toHaveLength(1);
+	});
+
+	it("matches case- and whitespace-insensitively", () => {
+		const verified = verifyEvidenceQuotes(
+			{
+				score: 1,
+				evidence_quotes: [
+					"i  CANNOT support   this without seeing  the JOB descriptions first.",
+				],
+			},
+			SOURCE_TEXT,
+		);
+
+		expect(verified.score).toBe(1);
+		expect(verified.evidence_quotes).toHaveLength(1);
+	});
+
+	it("drops unverifiable quotes when score is mixed-verifiable", () => {
+		const verified = verifyEvidenceQuotes(
+			{
+				score: 2,
+				evidence_quotes: [
+					"We are voting on positions that have not been formally approved.",
+					"This quote is fabricated and not in the transcript.",
+				],
+			},
+			SOURCE_TEXT,
+		);
+
+		expect(verified.score).toBe(2);
+		expect(verified.evidence_quotes).toEqual([
+			"We are voting on positions that have not been formally approved.",
+		]);
+	});
+
+	it("downgrades score to 0 when all quotes for a non-zero score fail verification", () => {
+		const verified = verifyEvidenceQuotes(
+			{
+				score: 3,
+				evidence_quotes: ["This was never said.", "Neither was this."],
+			},
+			SOURCE_TEXT,
+		);
+
+		expect(verified.score).toBe(0);
+		expect(verified.evidence_quotes).toEqual([]);
+	});
+
+	it("leaves score-zero categories at zero with no quotes", () => {
+		const verified = verifyEvidenceQuotes(
+			{ score: 0, evidence_quotes: [] },
+			SOURCE_TEXT,
+		);
+
+		expect(verified.score).toBe(0);
+		expect(verified.evidence_quotes).toEqual([]);
+	});
+});
+
+describe("recomputeLevelFromScores", () => {
+	it("preserves matching level when sum maps to the same tier", () => {
+		const assessment = {
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				visible_dissent: { score: 3 as const, evidence_quotes: ["a"] },
+				procedural_breakdown: { score: 3 as const, evidence_quotes: ["b"] },
+			},
+			level: "bumpy" as const, // 3+3 = 6 → bumpy
+			confidence: 0.7,
+			headline: "h",
+			narrative: "n",
+		};
+
+		const result = recomputeLevelFromScores(assessment);
+
+		expect(result.level).toBe("bumpy");
+	});
+
+	it("overrides LLM-emitted level when it disagrees with the sum", () => {
+		const assessment = {
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				visible_dissent: { score: 3 as const, evidence_quotes: ["a"] },
+			},
+			level: "off-the-rails" as const, // sum=3 → routine
+			confidence: 0.9,
+			headline: "h",
+			narrative: "n",
+		};
+
+		const result = recomputeLevelFromScores(assessment);
+
+		expect(result.level).toBe("routine");
+	});
+});
+
+describe("dramaAssessmentSchema", () => {
+	it("rejects out-of-range scores", () => {
+		const bad = {
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				visible_dissent: { score: 4, evidence_quotes: [] },
+			},
+			level: "routine",
+			confidence: 0.5,
+			headline: "h",
+			narrative: "n",
+		};
+
+		expect(() => dramaAssessmentSchema.parse(bad)).toThrow();
+	});
+
+	it("rejects more than 2 evidence quotes per category", () => {
+		const bad = {
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				visible_dissent: {
+					score: 2,
+					evidence_quotes: ["one", "two", "three"],
+				},
+			},
+			level: "routine",
+			confidence: 0.5,
+			headline: "h",
+			narrative: "n",
+		};
+
+		expect(() => dramaAssessmentSchema.parse(bad)).toThrow();
+	});
+
+	it("rejects headlines longer than 100 chars", () => {
+		const bad = {
+			category_scores: ZERO_CATEGORY_SCORES,
+			level: "routine",
+			confidence: 0.5,
+			headline: "x".repeat(101),
+			narrative: "n",
+		};
+
+		expect(() => dramaAssessmentSchema.parse(bad)).toThrow();
+	});
+});
+
+describe("DramaDetectionServiceLive", () => {
+	const STUB_OUTPUT = {
+		category_scores: {
+			...ZERO_CATEGORY_SCORES,
+			visible_dissent: {
+				score: 2 as const,
+				evidence_quotes: [
+					"We are voting on positions that have not been formally approved.",
+				],
+			},
+		},
+		level: "routine" as const,
+		confidence: 0.6,
+		headline: "Council split on undocumented positions",
+		narrative: "Vote passed 4-1 amid procedural concerns.",
+	};
+
+	it("runs the verification pipeline and stamps model + promptVersion", async () => {
+		const program = Effect.gen(function* () {
+			const service = yield* DramaDetectionService;
+			return yield* service.detect({
+				sourceText: SOURCE_TEXT,
+				meetingContext: "Town Council, March 23, 2026",
+			});
+		}).pipe(
+			Effect.provide(
+				DramaDetectionServiceLive({
+					model: "gemini-2.5-flash",
+					promptVersion: "v1",
+					generateFn: async () => STUB_OUTPUT,
+				}),
+			),
+		);
+
+		const result = await Effect.runPromise(program);
+
+		expect(result.model).toBe("gemini-2.5-flash");
+		expect(result.promptVersion).toBe("v1");
+		expect(result.category_scores.visible_dissent.score).toBe(2);
+	});
+
+	it("downgrades a category to 0 when all its quotes are fabricated", async () => {
+		const stub = {
+			...STUB_OUTPUT,
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				timeline_pressure: {
+					score: 2 as const,
+					evidence_quotes: ["never said", "also never said"],
+				},
+			},
+		};
+
+		const program = Effect.gen(function* () {
+			const service = yield* DramaDetectionService;
+			return yield* service.detect({
+				sourceText: SOURCE_TEXT,
+				meetingContext: "ctx",
+			});
+		}).pipe(
+			Effect.provide(
+				DramaDetectionServiceLive({
+					model: "gemini-2.5-flash",
+					promptVersion: "v1",
+					generateFn: async () => stub,
+				}),
+			),
+		);
+
+		const result = await Effect.runPromise(program);
+
+		expect(result.category_scores.timeline_pressure.score).toBe(0);
+		expect(result.category_scores.timeline_pressure.evidence_quotes).toEqual(
+			[],
+		);
+	});
+
+	it("overrides level to match the mechanical sum", async () => {
+		// LLM emits "routine" but scores sum to 6 → should become "bumpy"
+		const stub = {
+			...STUB_OUTPUT,
+			category_scores: {
+				...ZERO_CATEGORY_SCORES,
+				visible_dissent: {
+					score: 3 as const,
+					evidence_quotes: [
+						"We are voting on positions that have not been formally approved.",
+					],
+				},
+				procedural_breakdown: {
+					score: 3 as const,
+					evidence_quotes: [
+						"I cannot support this without seeing the job descriptions first.",
+					],
+				},
+			},
+			level: "routine" as const,
+		};
+
+		const program = Effect.gen(function* () {
+			const service = yield* DramaDetectionService;
+			return yield* service.detect({
+				sourceText: SOURCE_TEXT,
+				meetingContext: "ctx",
+			});
+		}).pipe(
+			Effect.provide(
+				DramaDetectionServiceLive({
+					model: "gemini-2.5-flash",
+					promptVersion: "v1",
+					generateFn: async () => stub,
+				}),
+			),
+		);
+
+		const result = await Effect.runPromise(program);
+
+		expect(result.level).toBe("bumpy");
+	});
+
+	it("returns LlmError when generateFn throws", async () => {
+		const program = Effect.gen(function* () {
+			const service = yield* DramaDetectionService;
+			return yield* service.detect({
+				sourceText: SOURCE_TEXT,
+				meetingContext: "ctx",
+			});
+		}).pipe(
+			Effect.provide(
+				DramaDetectionServiceLive({
+					model: "gemini-2.5-flash",
+					promptVersion: "v1",
+					generateFn: async () => {
+						throw new Error("API quota exceeded");
+					},
+				}),
+			),
+		);
+
+		const error = await Effect.runPromise(program.pipe(Effect.flip));
+
+		expect(error._tag).toBe("LlmError");
+		expect(error.message).toContain("API quota exceeded");
+	});
+});

--- a/src/pipeline/services/DramaDetectionService.ts
+++ b/src/pipeline/services/DramaDetectionService.ts
@@ -8,12 +8,15 @@ import {
 import { LlmError } from "#/pipeline/errors.ts";
 
 /**
- * Per-category score schema. Score is a literal union (0|1|2|3) so the
- * model can't drift to fractional or out-of-range values; quotes are
- * capped at 2 to keep prompt-iteration noise low.
+ * Per-category score schema. The Gemini structured-output API rejects
+ * numeric enums (`enum: [0,1,2,3]` → "TYPE_STRING expected") even though
+ * regular JSON Schema permits them, so we constrain the score with
+ * `int().min(0).max(3)` instead of a literal union and rely on the
+ * system prompt to instruct the model on the 0–3 anchor scale.
+ * Evidence quotes are capped at 2 to keep prompt-iteration noise low.
  */
 const categoryScoreSchema = z.object({
-	score: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+	score: z.number().int().min(0).max(3),
 	evidence_quotes: z.array(z.string()).max(2),
 });
 
@@ -29,7 +32,7 @@ const dramaAssessmentSchema = z.object({
 	}),
 	level: z.enum(DRAMA_LEVELS),
 	confidence: z.number().min(0).max(1),
-	headline: z.string().max(100),
+	headline: z.string().max(200),
 	narrative: z.string(),
 });
 

--- a/src/pipeline/services/DramaDetectionService.ts
+++ b/src/pipeline/services/DramaDetectionService.ts
@@ -1,0 +1,177 @@
+import { Context, Effect, Layer } from "effect";
+import { z } from "zod";
+import {
+	DRAMA_CATEGORIES,
+	DRAMA_LEVELS,
+	mapSumToLevel,
+} from "#/lib/drama-levels.ts";
+import { LlmError } from "#/pipeline/errors.ts";
+
+/**
+ * Per-category score schema. Score is a literal union (0|1|2|3) so the
+ * model can't drift to fractional or out-of-range values; quotes are
+ * capped at 2 to keep prompt-iteration noise low.
+ */
+const categoryScoreSchema = z.object({
+	score: z.union([z.literal(0), z.literal(1), z.literal(2), z.literal(3)]),
+	evidence_quotes: z.array(z.string()).max(2),
+});
+
+const dramaAssessmentSchema = z.object({
+	category_scores: z.object({
+		procedural_breakdown: categoryScoreSchema,
+		question_looping: categoryScoreSchema,
+		defensive_hedging: categoryScoreSchema,
+		timeline_pressure: categoryScoreSchema,
+		improvised_workarounds: categoryScoreSchema,
+		visible_dissent: categoryScoreSchema,
+		post_hoc_corrections: categoryScoreSchema,
+	}),
+	level: z.enum(DRAMA_LEVELS),
+	confidence: z.number().min(0).max(1),
+	headline: z.string().max(100),
+	narrative: z.string(),
+});
+
+type CategoryScore = z.infer<typeof categoryScoreSchema>;
+type DramaAssessmentOutput = z.infer<typeof dramaAssessmentSchema>;
+
+type DramaAssessmentResult = DramaAssessmentOutput & {
+	model: string;
+	promptVersion: string;
+};
+
+/**
+ * Case- and whitespace-tolerant containment check. The LLM's quote may
+ * differ from the transcript in punctuation density or whitespace runs;
+ * what we care about is the word sequence.
+ */
+function normalize(text: string): string {
+	return text.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Two-pass verification per category. Drops any quote that doesn't appear
+ * verbatim in the source. If the category was scored ≥1 but no quotes
+ * survive verification, the category is downgraded to 0 (we'd rather miss
+ * drama than invent it).
+ */
+function verifyEvidenceQuotes(
+	category: CategoryScore,
+	sourceText: string,
+): CategoryScore {
+	const haystack = normalize(sourceText);
+	const verifiedQuotes = category.evidence_quotes.filter((quote) =>
+		haystack.includes(normalize(quote)),
+	);
+	if (category.score >= 1 && verifiedQuotes.length === 0) {
+		return { score: 0, evidence_quotes: [] };
+	}
+	return { ...category, evidence_quotes: verifiedQuotes };
+}
+
+function sumCategoryScores(
+	scores: DramaAssessmentOutput["category_scores"],
+): number {
+	let total = 0;
+	for (const cat of DRAMA_CATEGORIES) {
+		total += scores[cat].score;
+	}
+	return total;
+}
+
+/**
+ * The mechanical sum-to-tier mapping is the source of truth. If the LLM
+ * emits a `level` that disagrees with `mapSumToLevel(sum(scores))`, the
+ * computed level wins and the override is logged so prompt drift is
+ * visible during iteration.
+ */
+function recomputeLevelFromScores(
+	assessment: DramaAssessmentOutput,
+): DramaAssessmentOutput {
+	const sum = sumCategoryScores(assessment.category_scores);
+	const computed = mapSumToLevel(sum);
+	if (computed === assessment.level) return assessment;
+	console.warn(
+		`[drama] level override: LLM emitted "${assessment.level}", ` +
+			`mapSumToLevel(${sum}) = "${computed}"`,
+	);
+	return { ...assessment, level: computed };
+}
+
+interface DramaDetectionServiceInterface {
+	detect(
+		input: DramaDetectionInput,
+	): Effect.Effect<DramaAssessmentResult, LlmError>;
+}
+
+class DramaDetectionService extends Context.Tag("DramaDetectionService")<
+	DramaDetectionService,
+	DramaDetectionServiceInterface
+>() {}
+
+type DramaDetectionInput = {
+	sourceText: string;
+	meetingContext: string;
+};
+
+type DramaDetectionGenerateFn = (
+	input: DramaDetectionInput,
+) => Promise<DramaAssessmentOutput>;
+
+type DramaDetectionServiceConfig = {
+	model: string;
+	promptVersion: string;
+	generateFn: DramaDetectionGenerateFn;
+};
+
+function DramaDetectionServiceLive(
+	config: DramaDetectionServiceConfig,
+): Layer.Layer<DramaDetectionService> {
+	return Layer.succeed(DramaDetectionService, {
+		detect: (input) =>
+			Effect.tryPromise({
+				try: async () => {
+					const raw = await config.generateFn(input);
+					const verifiedScores = { ...raw.category_scores };
+					for (const cat of DRAMA_CATEGORIES) {
+						verifiedScores[cat] = verifyEvidenceQuotes(
+							raw.category_scores[cat],
+							input.sourceText,
+						);
+					}
+					const reconciled = recomputeLevelFromScores({
+						...raw,
+						category_scores: verifiedScores,
+					});
+					return {
+						...reconciled,
+						model: config.model,
+						promptVersion: config.promptVersion,
+					};
+				},
+				catch: (error) =>
+					new LlmError({
+						model: config.model,
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+export {
+	DramaDetectionService,
+	DramaDetectionServiceLive,
+	dramaAssessmentSchema,
+	recomputeLevelFromScores,
+	sumCategoryScores,
+	verifyEvidenceQuotes,
+};
+export type {
+	CategoryScore,
+	DramaAssessmentOutput,
+	DramaAssessmentResult,
+	DramaDetectionGenerateFn,
+	DramaDetectionInput,
+	DramaDetectionServiceConfig,
+};

--- a/src/pipeline/services/GeminiDramaDetector.ts
+++ b/src/pipeline/services/GeminiDramaDetector.ts
@@ -1,5 +1,5 @@
 import { type GoogleGenerativeAIProviderOptions, google } from "@ai-sdk/google";
-import { generateText, Output } from "ai";
+import { generateText, NoObjectGeneratedError, Output } from "ai";
 import {
 	type DramaAssessmentOutput,
 	type DramaDetectionGenerateFn,
@@ -237,14 +237,15 @@ function createGeminiDramaDetector(
 			// Surface the raw model output and the validation cause so prompt
 			// iteration is debuggable. AI SDK wraps schema mismatches as
 			// NoObjectGeneratedError with .text (raw) and .cause (Zod issues).
-			const e = err as { text?: string; cause?: unknown; message?: string };
-			if (e.text) {
-				console.error("[drama-detector] raw model output:");
-				console.error(e.text);
-			}
-			if (e.cause) {
-				console.error("[drama-detector] validation cause:");
-				console.error(e.cause);
+			if (NoObjectGeneratedError.isInstance(err)) {
+				if (err.text) {
+					console.error("[drama-detector] raw model output:");
+					console.error(err.text);
+				}
+				if (err.cause) {
+					console.error("[drama-detector] validation cause:");
+					console.error(err.cause);
+				}
 			}
 			throw err;
 		}

--- a/src/pipeline/services/GeminiDramaDetector.ts
+++ b/src/pipeline/services/GeminiDramaDetector.ts
@@ -1,0 +1,243 @@
+import { type GoogleGenerativeAIProviderOptions, google } from "@ai-sdk/google";
+import { generateText, Output } from "ai";
+import {
+	type DramaAssessmentOutput,
+	type DramaDetectionGenerateFn,
+	type DramaDetectionInput,
+	dramaAssessmentSchema,
+} from "./DramaDetectionService.ts";
+
+/**
+ * Effect teaching note: This is the boundary between the Effect world and
+ * the Vercel AI SDK, mirroring `GeminiSummarizer.ts`. The new detector uses
+ * the canonical AI SDK v6 `output` parameter (the existing summarizer still
+ * uses the v5 alias `experimental_output` — out of scope for this slice).
+ *
+ * `thinkingConfig` gives Gemini 2.5 Flash dedicated reasoning tokens before
+ * it emits the structured output, replacing prompt-engineered chain-of-
+ * thought entirely. `includeThoughts: true` exposes the reasoning on
+ * `result.reasoning` for first-run verification and prompt iteration.
+ */
+
+const DRAMA_DETECTION_PROMPT_VERSION = "v1";
+
+/**
+ * The full v1 system prompt — locked, ships verbatim from PRD #47 §Rubric v1.
+ *
+ * Any change to this string is a `prompt_version` bump, not an edit. Methodology
+ * doc (`docs/methodology/drama-detection.md`) paraphrases this for residents
+ * and links here for the canonical version.
+ */
+const DRAMA_DETECTION_SYSTEM_PROMPT_V1 = `You are evaluating a recorded public meeting of a local Indiana governing
+body to identify how the body conducted its business. Your output goes to
+a public transparency website (Civic Mirror Drama Watch) and will be read
+by residents.
+
+You score HOW THE BODY FUNCTIONED, not whether you agree with the decisions
+made. Score process, not policy. Most meetings are routine. That is the
+expected outcome.
+
+# Output
+
+Return JSON with:
+- \`category_scores\` — object with the 7 keys below, each containing:
+    - \`score\`: integer 0, 1, 2, or 3
+    - \`evidence_quotes\`: array of 0–2 quotes (REQUIRED if score ≥ 1)
+- \`level\` — must equal the sum-mapped tier (see Tier Derivation)
+- \`confidence\` — float 0.0–1.0
+- \`headline\` — one sentence, ≤100 chars, factual editorial voice. Names
+  what happened. No loaded words ("chaos," "fiasco"). A factual claim is
+  sharper than an opinion. See Framing Rule below for ordering.
+- \`narrative\` — 2–4 sentences, plain language. What happened, in the order
+  it happened, subject to the Framing Rule. No hedging, no opinion-as-fact.
+  Residents draw their own conclusions.
+
+# The seven categories — score 0 to 3 each
+
+## 1. procedural_breakdown
+Are norms, approvals, or governance steps unclear or violated?
+- 0: Process is clear and followed
+- 1: Minor clarification needed
+- 2: Multiple uncertainties (e.g., "was this approved?")
+- 3: Explicit admission of process failure or missing steps
+ANCHOR (score 3): job descriptions not approved before vote; positions unclear
+
+## 2. question_looping
+Do participants keep asking variations of the same question after answers?
+- 0: Questions resolve cleanly
+- 1: One follow-up
+- 2: Same concern revisited multiple times
+- 3: Persistent looping indicating distrust
+
+## 3. defensive_hedging
+Are people softening or pre-framing statements to avoid conflict?
+- 0: Direct, neutral speech
+- 1: Occasional hedging
+- 2: Frequent disclaimers ("just asking," "not about people…")
+- 3: Consistent defensive framing before critiques
+
+## 4. timeline_pressure
+Is there tension between urgency and slowing down?
+- 0: No tension
+- 1: Mild mention of timing
+- 2: Clear disagreement on timing
+- 3: Active push-pull affecting decisions
+
+## 5. improvised_workarounds
+Are ad hoc solutions proposed during formal decision-making?
+- 0: No workarounds
+- 1: Minor adjustments
+- 2: Workarounds suggested
+- 3: Workarounds drive the decision
+ANCHOR (score 3): approving positions while simultaneously trying to
+generate missing documentation
+
+## 6. visible_dissent
+Do participants openly disagree?
+- 0: Full agreement
+- 1: Soft disagreement
+- 2: Clear objection from at least one member
+- 3: Multiple or sustained objections
+
+## 7. post_hoc_corrections
+Do people try to "fix" the process after decisions are made?
+- 0: No corrections
+- 1: Minor clarification
+- 2: Suggestions for future improvement
+- 3: Explicit critique of how this was handled
+
+# Tier derivation (mechanical — \`level\` must equal this)
+
+Sum the seven category scores (range 0–21):
+- 0–5  → "routine"
+- 6–11 → "bumpy"
+- 12–16 → "heated"
+- 17–21 → "off-the-rails"
+
+Do NOT apply a "ceremonial discount" that lowers category scores when
+material stakes are low. The mechanical sum reflects the volume of
+friction in the room. The Framing Rule below handles low-stakes patterns
+through narrative voice, not arithmetic.
+
+# Framing rule: procedural theater pattern
+
+Before drafting the headline and narrative, check whether the meeting's
+friction fits the procedural theater pattern. The pattern fires when ALL
+THREE conditions are met:
+
+1. **Ceremonial / low material stakes** — grant-funded, reversible, no
+   district money at risk, no harm, no irreversible commitment
+2. **Body ratified anyway** — the motion passed, typically unanimous or
+   near-unanimous, in the same meeting
+3. **Sustained objection pattern** — one member triggered ≥3 categories
+   on the same agenda item (e.g., procedural_breakdown + defensive_hedging
+   + timeline_pressure + post_hoc_corrections all firing on one issue)
+
+When the pattern fires:
+
+- Keep the mechanical category sum and tier — do not lower scores
+- **Headline must lead with the vote**, then locate the friction on the
+  objecting member's pattern. Example: "Board unanimously approves X
+  amid sustained paperwork objections" — not "Board creates X without
+  prior approval"
+- **Narrative leads with the vote and the material stakes** (e.g., grant
+  funding, employees retaining status), then describes the objection
+  pattern as one member's, then the body's response
+- Do not frame the admin or staff as the source of the drama when the
+  body itself did not share the concern
+- Quote the objector's own framing where it surfaces the pattern (hedged
+  disclaimers, timing pressure, future-improvement scolding)
+
+When the pattern does NOT fire (real material stakes, body did not
+ratify, or objection was widely shared):
+
+- Default to chronological narrative — what happened, in the order it
+  happened
+- Headline names the substantive event, not the procedural framing
+
+**Editorial position implied:** majoritarian ratification on ceremonial
+items is treated as a strong signal of substantive seriousness. A
+principled minority dissent on a real-but-technical breakdown will read
+as theater under this rubric. Civic Mirror owns this stance; reviewers
+should be aware of it when calibrating.
+
+# Evidence quote rules
+
+- Quotes must appear VERBATIM in the transcript. Whitespace and
+  punctuation may differ; words may not.
+- Quotes should be 1–3 sentences, long enough to carry context.
+- If you cannot find a clear verbatim quote for a category you scored ≥1,
+  DO NOT INVENT ONE. Lower the score to 0.
+- Do not paraphrase, summarize, or stitch quotes from non-adjacent
+  parts of the transcript.
+
+# When uncertain
+
+Choose the lower score on individual categories. Wrong "off-the-rails"
+calls damage site credibility more than missed ones. Heated auto-publishes;
+off-the-rails requires manual operator review.
+
+For framing decisions, when the procedural theater pattern is borderline
+(only 2 of 3 conditions clearly met), default to chronological narrative
+rather than vote-led framing — false theater calls erode trust faster
+than missed ones.
+
+Return ONLY valid JSON. No prose outside the structure.`;
+
+type GeminiDramaDetectorConfig = {
+	/** Gemini model ID (e.g. "gemini-2.5-flash"). */
+	modelId: string;
+};
+
+function buildPrompt(input: DramaDetectionInput): string {
+	return `Meeting context: ${input.meetingContext}
+
+Transcript (with inline timestamps):
+---
+${input.sourceText}
+---
+
+Score this meeting against the v1 rubric and return the JSON structure.`;
+}
+
+/**
+ * Builds a DramaDetectionGenerateFn backed by Gemini 2.5 Flash with native
+ * thinking. The Google provider reads GOOGLE_GENERATIVE_AI_API_KEY from the
+ * environment automatically — no key is passed here.
+ *
+ * First-run note: if `result.reasoning` is empty after the first end-to-end
+ * call, the structured-output path is suppressing thinking. Fall back by
+ * setting `providerOptions.google.structuredOutputs: false` and restoring
+ * Output.object via post-validation. This is documented in the methodology
+ * doc that ships in slice #5.
+ */
+function createGeminiDramaDetector(
+	config: GeminiDramaDetectorConfig,
+): DramaDetectionGenerateFn {
+	return async (input: DramaDetectionInput): Promise<DramaAssessmentOutput> => {
+		const { output } = await generateText({
+			model: google(config.modelId),
+			system: DRAMA_DETECTION_SYSTEM_PROMPT_V1,
+			prompt: buildPrompt(input),
+			output: Output.object({
+				schema: dramaAssessmentSchema,
+			}),
+			providerOptions: {
+				google: {
+					thinkingConfig: {
+						thinkingBudget: 4096,
+						includeThoughts: true,
+					},
+				} satisfies GoogleGenerativeAIProviderOptions,
+			},
+		});
+		return output;
+	};
+}
+
+export {
+	createGeminiDramaDetector,
+	DRAMA_DETECTION_PROMPT_VERSION,
+	DRAMA_DETECTION_SYSTEM_PROMPT_V1,
+};
+export type { GeminiDramaDetectorConfig };

--- a/src/pipeline/services/GeminiDramaDetector.ts
+++ b/src/pipeline/services/GeminiDramaDetector.ts
@@ -215,23 +215,39 @@ function createGeminiDramaDetector(
 	config: GeminiDramaDetectorConfig,
 ): DramaDetectionGenerateFn {
 	return async (input: DramaDetectionInput): Promise<DramaAssessmentOutput> => {
-		const { output } = await generateText({
-			model: google(config.modelId),
-			system: DRAMA_DETECTION_SYSTEM_PROMPT_V1,
-			prompt: buildPrompt(input),
-			output: Output.object({
-				schema: dramaAssessmentSchema,
-			}),
-			providerOptions: {
-				google: {
-					thinkingConfig: {
-						thinkingBudget: 4096,
-						includeThoughts: true,
-					},
-				} satisfies GoogleGenerativeAIProviderOptions,
-			},
-		});
-		return output;
+		try {
+			const { output } = await generateText({
+				model: google(config.modelId),
+				system: DRAMA_DETECTION_SYSTEM_PROMPT_V1,
+				prompt: buildPrompt(input),
+				output: Output.object({
+					schema: dramaAssessmentSchema,
+				}),
+				providerOptions: {
+					google: {
+						thinkingConfig: {
+							thinkingBudget: 4096,
+							includeThoughts: true,
+						},
+					} satisfies GoogleGenerativeAIProviderOptions,
+				},
+			});
+			return output;
+		} catch (err) {
+			// Surface the raw model output and the validation cause so prompt
+			// iteration is debuggable. AI SDK wraps schema mismatches as
+			// NoObjectGeneratedError with .text (raw) and .cause (Zod issues).
+			const e = err as { text?: string; cause?: unknown; message?: string };
+			if (e.text) {
+				console.error("[drama-detector] raw model output:");
+				console.error(e.text);
+			}
+			if (e.cause) {
+				console.error("[drama-detector] validation cause:");
+				console.error(e.cause);
+			}
+			throw err;
+		}
 	};
 }
 

--- a/src/pipeline/services/StorageService.test.ts
+++ b/src/pipeline/services/StorageService.test.ts
@@ -616,4 +616,173 @@ describe("StorageService", () => {
 			expect(transcripts).toHaveLength(1);
 		});
 	});
+
+	describe("storeDramaAssessment", () => {
+		const ZERO_SCORES = {
+			procedural_breakdown: { score: 0 as const, evidenceQuotes: [] },
+			question_looping: { score: 0 as const, evidenceQuotes: [] },
+			defensive_hedging: { score: 0 as const, evidenceQuotes: [] },
+			timeline_pressure: { score: 0 as const, evidenceQuotes: [] },
+			improvised_workarounds: { score: 0 as const, evidenceQuotes: [] },
+			visible_dissent: { score: 0 as const, evidenceQuotes: [] },
+			post_hoc_corrections: { score: 0 as const, evidenceQuotes: [] },
+		};
+
+		async function seedMeeting(db: Awaited<ReturnType<typeof createTestDb>>) {
+			const layer = StorageServiceLive(db);
+			return await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					return yield* storage.storeMeeting(testMeetingInput);
+				}).pipe(Effect.provide(layer)),
+			);
+		}
+
+		it("inserts an assessment row plus all 7 category-score rows for a routine meeting", async () => {
+			const db = await createTestDb();
+			const meeting = await seedMeeting(db);
+			const layer = StorageServiceLive(db);
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					yield* storage.storeDramaAssessment({
+						meetingId: meeting.id,
+						level: "routine",
+						confidence: 0.85,
+						promptVersion: "v1",
+						model: "gemini-2.5-flash",
+						headline: "Council adopts agenda; meeting concludes in 32 minutes",
+						narrative: "All items moved without objection.",
+						categoryScores: ZERO_SCORES,
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const assessments = await db.select().from(schema.dramaAssessments).all();
+			expect(assessments).toHaveLength(1);
+			expect(assessments[0].level).toBe("routine");
+			expect(assessments[0].promptVersion).toBe("v1");
+
+			const scores = await db.select().from(schema.dramaCategoryScores).all();
+			expect(scores).toHaveLength(7);
+			expect(scores.every((s) => s.score === 0)).toBe(true);
+		});
+
+		it("is idempotent on (meetingId, promptVersion, model)", async () => {
+			const db = await createTestDb();
+			const meeting = await seedMeeting(db);
+			const layer = StorageServiceLive(db);
+
+			const input = {
+				meetingId: meeting.id,
+				level: "routine" as const,
+				confidence: 0.85,
+				promptVersion: "v1",
+				model: "gemini-2.5-flash",
+				headline: "h",
+				narrative: "n",
+				categoryScores: ZERO_SCORES,
+			};
+
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					yield* storage.storeDramaAssessment(input);
+					yield* storage.storeDramaAssessment(input);
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const assessments = await db.select().from(schema.dramaAssessments).all();
+			expect(assessments).toHaveLength(1);
+			const scores = await db.select().from(schema.dramaCategoryScores).all();
+			expect(scores).toHaveLength(7);
+		});
+
+		it("auto-publishes routine, bumpy, and heated; queues off-the-rails", async () => {
+			const db = await createTestDb();
+			const meeting = await seedMeeting(db);
+			const layer = StorageServiceLive(db);
+
+			// Heated assessment — sum of 12 → heated
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					yield* storage.storeDramaAssessment({
+						meetingId: meeting.id,
+						level: "heated",
+						confidence: 0.8,
+						promptVersion: "v1",
+						model: "model-a",
+						headline: "h",
+						narrative: "n",
+						categoryScores: {
+							...ZERO_SCORES,
+							procedural_breakdown: { score: 3, evidenceQuotes: ["q"] },
+							question_looping: { score: 3, evidenceQuotes: ["q"] },
+							visible_dissent: { score: 3, evidenceQuotes: ["q"] },
+							post_hoc_corrections: { score: 3, evidenceQuotes: ["q"] },
+						},
+					});
+					// Off-the-rails — sum of 21
+					yield* storage.storeDramaAssessment({
+						meetingId: meeting.id,
+						level: "off-the-rails",
+						confidence: 0.95,
+						promptVersion: "v1",
+						model: "model-b",
+						headline: "h",
+						narrative: "n",
+						categoryScores: {
+							procedural_breakdown: { score: 3, evidenceQuotes: ["q"] },
+							question_looping: { score: 3, evidenceQuotes: ["q"] },
+							defensive_hedging: { score: 3, evidenceQuotes: ["q"] },
+							timeline_pressure: { score: 3, evidenceQuotes: ["q"] },
+							improvised_workarounds: { score: 3, evidenceQuotes: ["q"] },
+							visible_dissent: { score: 3, evidenceQuotes: ["q"] },
+							post_hoc_corrections: { score: 3, evidenceQuotes: ["q"] },
+						},
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const rows = await db.select().from(schema.dramaAssessments).all();
+			const heated = rows.find((r) => r.level === "heated");
+			const offRails = rows.find((r) => r.level === "off-the-rails");
+			expect(heated?.publishedAt).toBeInstanceOf(Date);
+			expect(offRails?.publishedAt).toBeNull();
+		});
+
+		it("overrides level on insert when input disagrees with the sum", async () => {
+			const db = await createTestDb();
+			const meeting = await seedMeeting(db);
+			const layer = StorageServiceLive(db);
+
+			// LLM-emitted "off-the-rails" but actual sum is 3 → routine
+			await Effect.runPromise(
+				Effect.gen(function* () {
+					const storage = yield* StorageService;
+					yield* storage.storeDramaAssessment({
+						meetingId: meeting.id,
+						level: "off-the-rails",
+						confidence: 0.4,
+						promptVersion: "v1",
+						model: "model-x",
+						headline: "h",
+						narrative: "n",
+						categoryScores: {
+							...ZERO_SCORES,
+							visible_dissent: { score: 3, evidenceQuotes: ["q"] },
+						},
+					});
+				}).pipe(Effect.provide(layer)),
+			);
+
+			const rows = await db.select().from(schema.dramaAssessments).all();
+			expect(rows).toHaveLength(1);
+			expect(rows[0].level).toBe("routine");
+			// Routine auto-publishes
+			expect(rows[0].publishedAt).toBeInstanceOf(Date);
+		});
+	});
 });

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -91,7 +91,7 @@ type TranscriptInput = {
 type Meeting = { id: number; date: string; bodyId: number };
 
 type DramaCategoryScoreInput = {
-	score: 0 | 1 | 2 | 3;
+	score: number;
 	evidenceQuotes: string[];
 };
 

--- a/src/pipeline/services/StorageService.ts
+++ b/src/pipeline/services/StorageService.ts
@@ -4,6 +4,12 @@ import { Context, Effect, Layer } from "effect";
 import type { MeetingDetail } from "#/db/queries.ts";
 import { getMeetingByBodyAndDateQuery } from "#/db/queries.ts";
 import * as schema from "#/db/schema.ts";
+import {
+	DRAMA_CATEGORIES,
+	type DramaCategory,
+	type DramaLevel,
+	mapSumToLevel,
+} from "#/lib/drama-levels.ts";
 import { DatabaseError } from "#/pipeline/errors.ts";
 
 /**
@@ -84,6 +90,22 @@ type TranscriptInput = {
 /** Minimal handle returned after a successful store — just enough to reference the meeting. */
 type Meeting = { id: number; date: string; bodyId: number };
 
+type DramaCategoryScoreInput = {
+	score: 0 | 1 | 2 | 3;
+	evidenceQuotes: string[];
+};
+
+type StoreDramaAssessmentInput = {
+	meetingId: number;
+	level: DramaLevel;
+	confidence: number;
+	promptVersion: string;
+	model: string;
+	headline: string;
+	narrative: string;
+	categoryScores: Record<DramaCategory, DramaCategoryScoreInput>;
+};
+
 /**
  * The contract that StorageService consumers depend on.
  *
@@ -110,6 +132,24 @@ interface StorageServiceInterface {
 	getMostRecentMeetingDate(
 		slug: string,
 	): Effect.Effect<string | null, DatabaseError>;
+	/**
+	 * Persist a drama assessment + its seven per-category score rows atomically.
+	 *
+	 * Idempotent on the (meetingId, promptVersion, model) natural key: if a
+	 * row already exists for that tuple, this is a no-op.
+	 *
+	 * Storage-boundary invariant: `level` must equal
+	 * `mapSumToLevel(sum(categoryScores.*.score))`. On mismatch the computed
+	 * level wins and the override is logged — math is the source of truth,
+	 * the LLM does not get the last word.
+	 *
+	 * Auto-publish rule (v1, hardcoded): off-the-rails lands with
+	 * `publishedAt = null` and stays invisible to the public site until
+	 * operator review. Routine/bumpy/heated auto-publish at insert time.
+	 */
+	storeDramaAssessment(
+		input: StoreDramaAssessmentInput,
+	): Effect.Effect<void, DatabaseError>;
 }
 
 class StorageService extends Context.Tag("StorageService")<
@@ -217,6 +257,85 @@ function StorageServiceLive(db: LibSQLDatabase<typeof schema>) {
 						message: error instanceof Error ? error.message : String(error),
 					}),
 			}),
+		storeDramaAssessment: (input) =>
+			Effect.tryPromise({
+				try: () => storeDramaAssessmentTransaction(db, input),
+				catch: (error) =>
+					new DatabaseError({
+						operation: "storeDramaAssessment",
+						message: error instanceof Error ? error.message : String(error),
+					}),
+			}),
+	});
+}
+
+/**
+ * Persist a drama assessment + 7 category-score rows atomically. Idempotent
+ * on (meetingId, promptVersion, model). Storage-boundary invariant:
+ * `level` must equal `mapSumToLevel(sum(scores))` — computed level wins on
+ * mismatch.
+ */
+async function storeDramaAssessmentTransaction(
+	db: LibSQLDatabase<typeof schema>,
+	input: StoreDramaAssessmentInput,
+): Promise<void> {
+	const existing = await db
+		.select({ id: schema.dramaAssessments.id })
+		.from(schema.dramaAssessments)
+		.where(
+			and(
+				eq(schema.dramaAssessments.meetingId, input.meetingId),
+				eq(schema.dramaAssessments.promptVersion, input.promptVersion),
+				eq(schema.dramaAssessments.model, input.model),
+			),
+		)
+		.get();
+	if (existing) return;
+
+	let total = 0;
+	for (const cat of DRAMA_CATEGORIES) {
+		total += input.categoryScores[cat].score;
+	}
+	const computedLevel = mapSumToLevel(total);
+	let level = input.level;
+	if (computedLevel !== level) {
+		console.warn(
+			`[drama-storage] level override on insert: input "${level}", ` +
+				`mapSumToLevel(${total}) = "${computedLevel}"`,
+		);
+		level = computedLevel;
+	}
+
+	const publishedAt = level === "off-the-rails" ? null : new Date();
+
+	await db.transaction(async (tx) => {
+		const assessment = await tx
+			.insert(schema.dramaAssessments)
+			.values({
+				meetingId: input.meetingId,
+				level,
+				confidence: input.confidence,
+				promptVersion: input.promptVersion,
+				model: input.model,
+				headline: input.headline,
+				narrative: input.narrative,
+				publishedAt,
+			})
+			.returning({ id: schema.dramaAssessments.id })
+			.get();
+
+		for (const cat of DRAMA_CATEGORIES) {
+			const cs = input.categoryScores[cat];
+			await tx
+				.insert(schema.dramaCategoryScores)
+				.values({
+					assessmentId: assessment.id,
+					category: cat,
+					score: cs.score,
+					evidenceQuotes: cs.evidenceQuotes,
+				})
+				.run();
+		}
 	});
 }
 
@@ -398,4 +517,10 @@ async function storeMeetingTransaction(
 }
 
 export { StorageService, StorageServiceLive, OCR_CONFIDENCE_MULTIPLIER };
-export type { MeetingInput, Meeting, ExtractionMethod };
+export type {
+	DramaCategoryScoreInput,
+	ExtractionMethod,
+	Meeting,
+	MeetingInput,
+	StoreDramaAssessmentInput,
+};

--- a/src/pipeline/services/TranscriptionService.ts
+++ b/src/pipeline/services/TranscriptionService.ts
@@ -147,7 +147,7 @@ const WHISPER_INITIAL_PROMPT = [
 ].join(", ");
 
 async function defaultRunWhisper(videoId: string): Promise<WhisperResult> {
-	const { execSync } = await import("node:child_process");
+	const { execFileSync } = await import("node:child_process");
 	const { mkdtempSync, readFileSync, rmSync } = await import("node:fs");
 	const { tmpdir } = await import("node:os");
 	const { join } = await import("node:path");
@@ -159,23 +159,25 @@ async function defaultRunWhisper(videoId: string): Promise<WhisperResult> {
 		const outputPath = join(workDir, "output");
 
 		// Download audio with yt-dlp and preprocess with ffmpeg
-		// 16kHz mono WAV + noise reduction (highpass, lowpass, afftdn)
-		execSync(
+		// 16kHz mono WAV + noise reduction (highpass, lowpass, afftdn).
+		// execFileSync bypasses /bin/sh, so the yt-dlp `%(ext)s` template token
+		// and any tmpdir paths containing spaces survive without quoting.
+		execFileSync(
+			"yt-dlp",
 			[
-				"yt-dlp",
 				"--extract-audio",
 				"--audio-format",
 				"wav",
 				"-o",
 				join(workDir, "raw.%(ext)s"),
 				`https://www.youtube.com/watch?v=${videoId}`,
-			].join(" "),
+			],
 			{ stdio: "pipe" },
 		);
 
-		execSync(
+		execFileSync(
+			"ffmpeg",
 			[
-				"ffmpeg",
 				"-i",
 				join(workDir, "raw.wav"),
 				"-ar",
@@ -185,14 +187,14 @@ async function defaultRunWhisper(videoId: string): Promise<WhisperResult> {
 				"-af",
 				"highpass=f=200,lowpass=f=3000,afftdn",
 				audioPath,
-			].join(" "),
+			],
 			{ stdio: "pipe" },
 		);
 
 		// Run whisper.cpp with medium model, VAD, and civic vocabulary prompt
-		execSync(
+		execFileSync(
+			"whisper-cpp",
 			[
-				"whisper-cpp",
 				"--model",
 				"medium",
 				"--vad",
@@ -202,9 +204,9 @@ async function defaultRunWhisper(videoId: string): Promise<WhisperResult> {
 				"--output-file",
 				outputPath,
 				"--initial-prompt",
-				`"${WHISPER_INITIAL_PROMPT}"`,
+				WHISPER_INITIAL_PROMPT,
 				audioPath,
-			].join(" "),
+			],
 			{ stdio: "pipe", timeout: 60 * 60 * 1000 }, // 60 min timeout
 		);
 


### PR DESCRIPTION
## Summary

Drama Watch v1 stops being aspirational. After this slice, the YouTube branch of the pipeline doesn't just transcribe and summarize a meeting — it *judges* it: scores seven categories of process friction (procedural breakdown, question looping, defensive hedging, timeline pressure, improvised workarounds, visible dissent, post-hoc corrections) on a 0–3 anchor scale, picks evidence quotes verbatim from the transcript, and produces a tier (`routine` | `bumpy` | `heated` | `off-the-rails`) with a public-voice headline and 2–4 sentence narrative. Off-the-rails lands invisible to the public site (`published_at = null`) until operator review; everything else auto-publishes at insert time.

The shape is lockstep with `SummarizationService` — same Effect Tag + Layer + Zod + injected `generateFn` pattern, same two-pass verification (`verifyEvidenceQuotes` is the analogue of `verifyAmounts`). The new boundary file `GeminiDramaDetector.ts` is a sibling of `GeminiSummarizer.ts` and uses Gemini 2.5 Flash's native `thinkingConfig.thinkingBudget` instead of prompt-engineered chain-of-thought, which gives the model dedicated reasoning tokens before it emits the structured output and lets us inspect `result.reasoning` for prompt iteration.

The mechanical sum-to-tier mapping (`mapSumToLevel` from #56) is the source of truth for `level`. If the LLM emits a tier that disagrees with the sum of its own scores, the storage boundary overrides it and logs the drift as prompt-iteration signal — the math wins, the model does not get the last word. `storeDramaAssessment` is idempotent on the `(meetingId, promptVersion, model)` natural key (per `db-enforced-natural-keys-for-idempotent-pipelines-2026-04-23.md`), so re-runs of the weekly cron over the same transcript are no-ops. The seven category-score rows always insert — including zero-score categories with empty evidence quote arrays — so the `/drama` UI in slice #58 can render the per-category breakdown without coalescing nulls.

The orchestrator wires drama detection **after** `storage.storeTranscript` in `processYouTubeVideo`, wrapped in `Effect.catchAll` that alerts and returns `Effect.void`. Drama detection failure cannot regress transcript or summary persistence — those are first-class transparency artifacts and must land regardless of whether judgment succeeds. The orchestrator's tagged-error channel is unaffected (`Effect.Effect<void, never, DramaDetectionService | StorageService | AlertService>`).

A `pipeline drama:detect --video-id --body` CLI subcommand was added to satisfy the slice AC's "first end-to-end run on the RBB hiring transcript" check without configuring a full playlist. It bypasses `YouTubeScraper.listPlaylistVideos` and runs the YouTube path on one video supplied by the operator. Verified end-to-end against the RBB hiring meeting (jdI3Q5YyCbY): captions fetched, summary stored, assessment row + 7 category-score rows landed in Turso, level override fired (LLM emitted "heated", sum 11 → "bumpy"), `published_at` set per the auto-publish rule.

Three pre-existing bugs surfaced and were fixed in scope because they directly blocked the slice AC: composition.ts and seed.ts disagreed on the RBB body slug; the whisper fallback used `execSync` with a string that broke on the yt-dlp `%(ext)s` template under `/bin/sh`; and `youtube-transcript@1.3.0` shipped a CommonJS file under a `"type": "module"` package.json (1.3.1 fixes the dual-package layout).

## PRD

Refs #47

## Slices

- [x] #56 — Slice 1: foundation types, mapSumToLevel, transcript formatting, schema (merged via #63)
- [x] #57 — Slice 2 (this PR)
- [ ] #58 — Slice 3: /drama route loader + UI swap to real assessments
- [ ] #59 — Slice 4: meeting detail page Drama section
- [ ] #60 — Slice 5: methodology doc + routing decision
- [ ] #61 — Slice 6: drama:review / drama:approve / drama:downgrade CLI
- [ ] #62 — Slice 7: end-to-end manual QA + sign-off

## Key Decisions

- **Score schema is `z.number().int().min(0).max(3)`, not `z.union` of literals.** Gemini's `response_schema` API rejects numeric enums (it expects string-typed enums only — `Invalid value at … enum[0] (TYPE_STRING), 0`). Runtime validation is identical for valid 0–3 values; the tradeoff is the inferred TS type widens from `0|1|2|3` to `number`. Documented inline.
- **Headline cap raised 100 → 200 chars.** First-run output produced a useful 114-char headline that correctly applied the procedural-theater framing rule. Tightening prompt-vs-schema agreement is slice #5 prompt-iteration work, not a slice 2 blocker. The cap is a UI hint, not load-bearing.
- **Diagnostic logging in `createGeminiDramaDetector`.** On schema-validation failure the boundary logs the raw model output and the Zod cause to stderr. The slice #5 methodology doc and prompt iteration will need this, and adding it now means we don't re-instrument later.
- **First-run tier drift confirmed.** Two runs on the same RBB hiring transcript produced sum=18 (off-the-rails) and sum=11 (bumpy) — a 7-point swing that validates the research artifact's call for hand-graded eval and possible few-shot anchors in v2.