### PR TITLE
[drama-eval] Slice 1: extract v1 profile + widen detector config + profile-loader (#67)

### DIFF
--- a/evals/profiles/v1.ts
+++ b/evals/profiles/v1.ts
@@ -1,0 +1,188 @@
+/**
+ * EvalProfile — typed module shape for a drama-detection prompt profile.
+ *
+ * The eval harness loads every `evals/profiles/*.ts` and runs the production
+ * `createGeminiDramaDetector` against each profile so prompt iteration is
+ * type-checked and source-controlled. Production composition imports the
+ * blessed profile (today: `v1`) directly so the harness and prod path share
+ * exactly one detector implementation — no parallel eval-only factory.
+ */
+type EvalProfile = {
+	promptVersion: string;
+	systemPrompt: string;
+	temperature?: number;
+	thinkingBudget?: number;
+	includeThoughts?: boolean;
+};
+
+/**
+ * v1 system prompt — locked, ships verbatim from PRD #47 §Rubric v1.
+ *
+ * Any change to this string is a `promptVersion` bump (new file in this
+ * directory), not an edit. The methodology doc (`docs/methodology/
+ * drama-detection.md`) paraphrases this for residents and links here for
+ * the canonical version.
+ */
+const v1: EvalProfile = {
+	promptVersion: "v1",
+	systemPrompt: `You are evaluating a recorded public meeting of a local Indiana governing
+body to identify how the body conducted its business. Your output goes to
+a public transparency website (Civic Mirror Drama Watch) and will be read
+by residents.
+
+You score HOW THE BODY FUNCTIONED, not whether you agree with the decisions
+made. Score process, not policy. Most meetings are routine. That is the
+expected outcome.
+
+# Output
+
+Return JSON with:
+- \`category_scores\` — object with the 7 keys below, each containing:
+    - \`score\`: integer 0, 1, 2, or 3
+    - \`evidence_quotes\`: array of 0–2 quotes (REQUIRED if score ≥ 1)
+- \`level\` — must equal the sum-mapped tier (see Tier Derivation)
+- \`confidence\` — float 0.0–1.0
+- \`headline\` — one sentence, ≤100 chars, factual editorial voice. Names
+  what happened. No loaded words ("chaos," "fiasco"). A factual claim is
+  sharper than an opinion. See Framing Rule below for ordering.
+- \`narrative\` — 2–4 sentences, plain language. What happened, in the order
+  it happened, subject to the Framing Rule. No hedging, no opinion-as-fact.
+  Residents draw their own conclusions.
+
+# The seven categories — score 0 to 3 each
+
+## 1. procedural_breakdown
+Are norms, approvals, or governance steps unclear or violated?
+- 0: Process is clear and followed
+- 1: Minor clarification needed
+- 2: Multiple uncertainties (e.g., "was this approved?")
+- 3: Explicit admission of process failure or missing steps
+ANCHOR (score 3): job descriptions not approved before vote; positions unclear
+
+## 2. question_looping
+Do participants keep asking variations of the same question after answers?
+- 0: Questions resolve cleanly
+- 1: One follow-up
+- 2: Same concern revisited multiple times
+- 3: Persistent looping indicating distrust
+
+## 3. defensive_hedging
+Are people softening or pre-framing statements to avoid conflict?
+- 0: Direct, neutral speech
+- 1: Occasional hedging
+- 2: Frequent disclaimers ("just asking," "not about people…")
+- 3: Consistent defensive framing before critiques
+
+## 4. timeline_pressure
+Is there tension between urgency and slowing down?
+- 0: No tension
+- 1: Mild mention of timing
+- 2: Clear disagreement on timing
+- 3: Active push-pull affecting decisions
+
+## 5. improvised_workarounds
+Are ad hoc solutions proposed during formal decision-making?
+- 0: No workarounds
+- 1: Minor adjustments
+- 2: Workarounds suggested
+- 3: Workarounds drive the decision
+ANCHOR (score 3): approving positions while simultaneously trying to
+generate missing documentation
+
+## 6. visible_dissent
+Do participants openly disagree?
+- 0: Full agreement
+- 1: Soft disagreement
+- 2: Clear objection from at least one member
+- 3: Multiple or sustained objections
+
+## 7. post_hoc_corrections
+Do people try to "fix" the process after decisions are made?
+- 0: No corrections
+- 1: Minor clarification
+- 2: Suggestions for future improvement
+- 3: Explicit critique of how this was handled
+
+# Tier derivation (mechanical — \`level\` must equal this)
+
+Sum the seven category scores (range 0–21):
+- 0–5  → "routine"
+- 6–11 → "bumpy"
+- 12–16 → "heated"
+- 17–21 → "off-the-rails"
+
+Do NOT apply a "ceremonial discount" that lowers category scores when
+material stakes are low. The mechanical sum reflects the volume of
+friction in the room. The Framing Rule below handles low-stakes patterns
+through narrative voice, not arithmetic.
+
+# Framing rule: procedural theater pattern
+
+Before drafting the headline and narrative, check whether the meeting's
+friction fits the procedural theater pattern. The pattern fires when ALL
+THREE conditions are met:
+
+1. **Ceremonial / low material stakes** — grant-funded, reversible, no
+   district money at risk, no harm, no irreversible commitment
+2. **Body ratified anyway** — the motion passed, typically unanimous or
+   near-unanimous, in the same meeting
+3. **Sustained objection pattern** — one member triggered ≥3 categories
+   on the same agenda item (e.g., procedural_breakdown + defensive_hedging
+   + timeline_pressure + post_hoc_corrections all firing on one issue)
+
+When the pattern fires:
+
+- Keep the mechanical category sum and tier — do not lower scores
+- **Headline must lead with the vote**, then locate the friction on the
+  objecting member's pattern. Example: "Board unanimously approves X
+  amid sustained paperwork objections" — not "Board creates X without
+  prior approval"
+- **Narrative leads with the vote and the material stakes** (e.g., grant
+  funding, employees retaining status), then describes the objection
+  pattern as one member's, then the body's response
+- Do not frame the admin or staff as the source of the drama when the
+  body itself did not share the concern
+- Quote the objector's own framing where it surfaces the pattern (hedged
+  disclaimers, timing pressure, future-improvement scolding)
+
+When the pattern does NOT fire (real material stakes, body did not
+ratify, or objection was widely shared):
+
+- Default to chronological narrative — what happened, in the order it
+  happened
+- Headline names the substantive event, not the procedural framing
+
+**Editorial position implied:** majoritarian ratification on ceremonial
+items is treated as a strong signal of substantive seriousness. A
+principled minority dissent on a real-but-technical breakdown will read
+as theater under this rubric. Civic Mirror owns this stance; reviewers
+should be aware of it when calibrating.
+
+# Evidence quote rules
+
+- Quotes must appear VERBATIM in the transcript. Whitespace and
+  punctuation may differ; words may not.
+- Quotes should be 1–3 sentences, long enough to carry context.
+- If you cannot find a clear verbatim quote for a category you scored ≥1,
+  DO NOT INVENT ONE. Lower the score to 0.
+- Do not paraphrase, summarize, or stitch quotes from non-adjacent
+  parts of the transcript.
+
+# When uncertain
+
+Choose the lower score on individual categories. Wrong "off-the-rails"
+calls damage site credibility more than missed ones. Heated auto-publishes;
+off-the-rails requires manual operator review.
+
+For framing decisions, when the procedural theater pattern is borderline
+(only 2 of 3 conditions clearly met), default to chronological narrative
+rather than vote-led framing — false theater calls erode trust faster
+than missed ones.
+
+Return ONLY valid JSON. No prose outside the structure.`,
+	thinkingBudget: 4096,
+	includeThoughts: true,
+};
+
+export { v1 };
+export type { EvalProfile };

--- a/src/pipeline/composition.ts
+++ b/src/pipeline/composition.ts
@@ -6,10 +6,7 @@ import * as schema from "#/db/schema.ts";
 import { AlertServiceLive } from "#/pipeline/services/AlertService.ts";
 import { DramaDetectionServiceLive } from "#/pipeline/services/DramaDetectionService.ts";
 import { FinalsiteScraperLive } from "#/pipeline/services/FinalsiteScraper.ts";
-import {
-	createGeminiDramaDetector,
-	DRAMA_DETECTION_PROMPT_VERSION,
-} from "#/pipeline/services/GeminiDramaDetector.ts";
+import { createGeminiDramaDetector } from "#/pipeline/services/GeminiDramaDetector.ts";
 import { createGeminiSummarizer } from "#/pipeline/services/GeminiSummarizer.ts";
 import { extractPdfText } from "#/pipeline/services/PdfExtractor.ts";
 import { EgovScraperLive } from "#/pipeline/services/ScraperService.ts";
@@ -17,6 +14,7 @@ import { StorageServiceLive } from "#/pipeline/services/StorageService.ts";
 import { SummarizationServiceLive } from "#/pipeline/services/SummarizationService.ts";
 import { TranscriptionServiceLive } from "#/pipeline/services/TranscriptionService.ts";
 import { YouTubeScraperLive } from "#/pipeline/services/YouTubeScraper.ts";
+import { v1 as dramaProfileV1 } from "../../evals/profiles/v1.ts";
 
 /**
  * Effect teaching note: This file is the composition root — the single place
@@ -148,10 +146,23 @@ function buildProductionLayers(input: BuildLayersInput) {
 		generateFn: geminiGenerator,
 	});
 
-	const dramaDetector = createGeminiDramaDetector({ modelId: geminiModelId });
+	const dramaDetector = createGeminiDramaDetector({
+		modelId: geminiModelId,
+		promptVersion: dramaProfileV1.promptVersion,
+		systemPrompt: dramaProfileV1.systemPrompt,
+		...(dramaProfileV1.temperature !== undefined
+			? { temperature: dramaProfileV1.temperature }
+			: {}),
+		...(dramaProfileV1.thinkingBudget !== undefined
+			? { thinkingBudget: dramaProfileV1.thinkingBudget }
+			: {}),
+		...(dramaProfileV1.includeThoughts !== undefined
+			? { includeThoughts: dramaProfileV1.includeThoughts }
+			: {}),
+	});
 	const dramaDetection = DramaDetectionServiceLive({
 		model: geminiModelId,
-		promptVersion: DRAMA_DETECTION_PROMPT_VERSION,
+		promptVersion: dramaProfileV1.promptVersion,
 		generateFn: dramaDetector,
 	});
 

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/bad-optional-types/bad.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/bad-optional-types/bad.ts
@@ -1,0 +1,10 @@
+// Intentionally untyped: simulates a profile module that imports cleanly
+// at runtime but ships a wrong-typed optional field. The loader should
+// reject this rather than cast through to EvalProfile.
+const bad = {
+	promptVersion: "vbadtypes",
+	systemPrompt: "Profile with a bad-typed optional field.",
+	thinkingBudget: "huge",
+};
+
+export { bad };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/duplicates/a.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/duplicates/a.ts
@@ -1,0 +1,6 @@
+const a = {
+	promptVersion: "vdup",
+	systemPrompt: "Profile A.",
+};
+
+export { a };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/duplicates/b.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/duplicates/b.ts
@@ -1,0 +1,6 @@
+const b = {
+	promptVersion: "vdup",
+	systemPrompt: "Profile B.",
+};
+
+export { b };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/empty-prompt/bad.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/empty-prompt/bad.ts
@@ -1,0 +1,6 @@
+const bad = {
+	promptVersion: "vbad",
+	systemPrompt: "",
+};
+
+export { bad };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/valid/v1.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/valid/v1.ts
@@ -1,0 +1,8 @@
+const v1 = {
+	promptVersion: "v1",
+	systemPrompt: "Score this meeting. Return JSON.",
+	thinkingBudget: 4096,
+	includeThoughts: true,
+};
+
+export { v1 };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/valid/v2.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/valid/v2.ts
@@ -1,0 +1,6 @@
+const v2 = {
+	promptVersion: "v2",
+	systemPrompt: "Updated rubric. Return JSON.",
+};
+
+export { v2 };

--- a/src/pipeline/scripts/evals/__fixtures__/profile-loader/whitespace-prompt/whitespace.ts
+++ b/src/pipeline/scripts/evals/__fixtures__/profile-loader/whitespace-prompt/whitespace.ts
@@ -1,0 +1,6 @@
+const whitespace = {
+	promptVersion: "vws",
+	systemPrompt: "   \n\t  ",
+};
+
+export { whitespace };

--- a/src/pipeline/scripts/evals/profile-loader.test.ts
+++ b/src/pipeline/scripts/evals/profile-loader.test.ts
@@ -1,0 +1,81 @@
+import { fileURLToPath } from "node:url";
+import { Effect, Exit } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+	loadProfiles,
+	ProfileLoadError,
+} from "#/pipeline/scripts/evals/profile-loader.ts";
+
+const fixtureDir = (sub: string): string =>
+	fileURLToPath(
+		new URL(`./__fixtures__/profile-loader/${sub}`, import.meta.url),
+	);
+
+describe("loadProfiles", () => {
+	it("loads every *.ts profile under the directory and surfaces sourcePath", async () => {
+		const result = await Effect.runPromise(loadProfiles(fixtureDir("valid")));
+
+		expect(result.map((p) => p.promptVersion).sort()).toEqual(["v1", "v2"]);
+		const v1 = result.find((p) => p.promptVersion === "v1");
+		expect(v1).toBeDefined();
+		expect(v1?.systemPrompt).toContain("Score this meeting");
+		expect(v1?.thinkingBudget).toBe(4096);
+		expect(v1?.includeThoughts).toBe(true);
+		expect(v1?.sourcePath).toMatch(/valid\/v1\.ts$/);
+	});
+
+	it("rejects an empty systemPrompt with ProfileLoadError", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadProfiles(fixtureDir("empty-prompt")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("ProfileLoadError");
+			expect(err).toContain("systemPrompt");
+		}
+	});
+
+	it("rejects a whitespace-only systemPrompt with ProfileLoadError", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadProfiles(fixtureDir("whitespace-prompt")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(exit.cause.toString()).toContain("ProfileLoadError");
+		}
+	});
+
+	it("rejects two profiles with the same promptVersion", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadProfiles(fixtureDir("duplicates")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("ProfileLoadError");
+			expect(err).toContain("vdup");
+		}
+	});
+
+	it("rejects a non-existent directory", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadProfiles(fixtureDir("does-not-exist")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(exit.cause.toString()).toContain("ProfileLoadError");
+		}
+	});
+
+	it("ProfileLoadError is a tagged error", () => {
+		const err = new ProfileLoadError({ message: "x", path: "y" });
+		expect(err._tag).toBe("ProfileLoadError");
+		expect(err.message).toBe("x");
+		expect(err.path).toBe("y");
+	});
+});

--- a/src/pipeline/scripts/evals/profile-loader.test.ts
+++ b/src/pipeline/scripts/evals/profile-loader.test.ts
@@ -61,6 +61,17 @@ describe("loadProfiles", () => {
 		}
 	});
 
+	it("rejects a profile whose optional field has the wrong type", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadProfiles(fixtureDir("bad-optional-types")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(exit.cause.toString()).toContain("ProfileLoadError");
+		}
+	});
+
 	it("rejects a non-existent directory", async () => {
 		const exit = await Effect.runPromiseExit(
 			loadProfiles(fixtureDir("does-not-exist")),

--- a/src/pipeline/scripts/evals/profile-loader.ts
+++ b/src/pipeline/scripts/evals/profile-loader.ts
@@ -1,0 +1,135 @@
+import { readdir } from "node:fs/promises";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { Data, Effect } from "effect";
+import type { EvalProfile } from "../../../../evals/profiles/v1.ts";
+
+/**
+ * Effect teaching note: `Data.TaggedError` mints a discriminated error class
+ * we can pattern-match on with `Effect.catchTag("ProfileLoadError", ...)`.
+ * The harness uses one error tag for every failure mode (missing dir, empty
+ * prompt, duplicate version) because callers all want the same response —
+ * fail fast before any API call. The `path` field surfaces *which* file
+ * tripped the check so the operator doesn't have to grep.
+ */
+class ProfileLoadError extends Data.TaggedError("ProfileLoadError")<{
+	readonly message: string;
+	readonly path: string;
+}> {}
+
+type LoadedProfile = EvalProfile & { sourcePath: string };
+
+/**
+ * Heuristic: a profile is any exported value that has a string
+ * `promptVersion` and a string `systemPrompt`. The optional fields
+ * (`temperature`, `thinkingBudget`, `includeThoughts`) are coerced
+ * by structural assignment if present and pass `EvalProfile` typing
+ * downstream — we trust the TS shape at the import boundary.
+ */
+function findProfileExport(mod: Record<string, unknown>): EvalProfile | null {
+	for (const value of Object.values(mod)) {
+		if (
+			value !== null &&
+			typeof value === "object" &&
+			typeof (value as { promptVersion?: unknown }).promptVersion ===
+				"string" &&
+			typeof (value as { systemPrompt?: unknown }).systemPrompt === "string"
+		) {
+			return value as EvalProfile;
+		}
+	}
+	return null;
+}
+
+function listProfileFiles(
+	dir: string,
+): Effect.Effect<readonly string[], ProfileLoadError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const entries = await readdir(dir, { withFileTypes: true });
+			return entries
+				.filter((e) => e.isFile() && e.name.endsWith(".ts"))
+				.map((e) => path.join(dir, e.name))
+				.sort();
+		},
+		catch: (error) =>
+			new ProfileLoadError({
+				path: dir,
+				message: `failed to read profiles directory: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			}),
+	});
+}
+
+function importProfile(
+	filePath: string,
+): Effect.Effect<LoadedProfile, ProfileLoadError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const mod = (await import(pathToFileURL(filePath).href)) as Record<
+				string,
+				unknown
+			>;
+			const profile = findProfileExport(mod);
+			if (!profile) {
+				throw new Error(
+					"no exported value with string `promptVersion` and `systemPrompt` found",
+				);
+			}
+			if (profile.systemPrompt.trim().length === 0) {
+				throw new Error(
+					"systemPrompt is empty or whitespace — profile is not live",
+				);
+			}
+			return { ...profile, sourcePath: filePath };
+		},
+		catch: (error) =>
+			new ProfileLoadError({
+				path: filePath,
+				message: error instanceof Error ? error.message : String(error),
+			}),
+	});
+}
+
+function ensureUniqueVersions(
+	profiles: readonly LoadedProfile[],
+): Effect.Effect<readonly LoadedProfile[], ProfileLoadError> {
+	const seen = new Map<string, string>();
+	for (const p of profiles) {
+		const prior = seen.get(p.promptVersion);
+		if (prior !== undefined) {
+			return Effect.fail(
+				new ProfileLoadError({
+					path: p.sourcePath,
+					message: `duplicate promptVersion "${p.promptVersion}" — also defined in ${prior}`,
+				}),
+			);
+		}
+		seen.set(p.promptVersion, p.sourcePath);
+	}
+	return Effect.succeed(profiles);
+}
+
+const DEFAULT_PROFILE_DIR = path.resolve(process.cwd(), "evals/profiles");
+
+/**
+ * Load every `*.ts` profile under `dir`, validating that each is live
+ * (non-empty systemPrompt) and that no two profiles share a `promptVersion`.
+ * Defaults to `<cwd>/evals/profiles` when no directory is supplied.
+ *
+ * The harness calls this at the top of every `evals:run` so quota burn
+ * never reaches a profile that imports cleanly but ships empty.
+ */
+function loadProfiles(
+	dir: string = DEFAULT_PROFILE_DIR,
+): Effect.Effect<readonly LoadedProfile[], ProfileLoadError> {
+	return Effect.gen(function* () {
+		const files = yield* listProfileFiles(dir);
+		const profiles = yield* Effect.all(files.map(importProfile));
+		return yield* ensureUniqueVersions(profiles);
+	});
+}
+
+export { loadProfiles, ProfileLoadError };
+export type { LoadedProfile };

--- a/src/pipeline/scripts/evals/profile-loader.ts
+++ b/src/pipeline/scripts/evals/profile-loader.ts
@@ -20,23 +20,39 @@ class ProfileLoadError extends Data.TaggedError("ProfileLoadError")<{
 type LoadedProfile = EvalProfile & { sourcePath: string };
 
 /**
- * Heuristic: a profile is any exported value that has a string
- * `promptVersion` and a string `systemPrompt`. The optional fields
- * (`temperature`, `thinkingBudget`, `includeThoughts`) are coerced
- * by structural assignment if present and pass `EvalProfile` typing
- * downstream — we trust the TS shape at the import boundary.
+ * Type predicate validating the full `EvalProfile` shape — required
+ * string fields plus runtime checks on every optional field. Without
+ * this, a profile module exporting `{ thinkingBudget: "huge" }` would
+ * pass a two-field structural check and get cast to `EvalProfile`,
+ * carrying the bad type into the detector at runtime.
+ *
+ * Effect teaching note: a `value is T` return type extends narrowing
+ * through every branch the predicate verified, so `findProfileExport`
+ * does not need an `as` assertion — the compiler tracks what we proved.
  */
+function isEvalProfile(value: unknown): value is EvalProfile {
+	if (value === null || typeof value !== "object") return false;
+	const v = value as Partial<EvalProfile>;
+	if (typeof v.promptVersion !== "string") return false;
+	if (typeof v.systemPrompt !== "string") return false;
+	if (v.temperature !== undefined && typeof v.temperature !== "number") {
+		return false;
+	}
+	if (v.thinkingBudget !== undefined && typeof v.thinkingBudget !== "number") {
+		return false;
+	}
+	if (
+		v.includeThoughts !== undefined &&
+		typeof v.includeThoughts !== "boolean"
+	) {
+		return false;
+	}
+	return true;
+}
+
 function findProfileExport(mod: Record<string, unknown>): EvalProfile | null {
 	for (const value of Object.values(mod)) {
-		if (
-			value !== null &&
-			typeof value === "object" &&
-			typeof (value as { promptVersion?: unknown }).promptVersion ===
-				"string" &&
-			typeof (value as { systemPrompt?: unknown }).systemPrompt === "string"
-		) {
-			return value as EvalProfile;
-		}
+		if (isEvalProfile(value)) return value;
 	}
 	return null;
 }

--- a/src/pipeline/services/GeminiDramaDetector.ts
+++ b/src/pipeline/services/GeminiDramaDetector.ts
@@ -44,7 +44,10 @@ type GeminiDramaDetectorConfig = {
 	includeThoughts?: boolean;
 };
 
-function buildPrompt(input: DramaDetectionInput): string {
+function buildPrompt(
+	input: DramaDetectionInput,
+	promptVersion: string,
+): string {
 	return `Meeting context: ${input.meetingContext}
 
 Transcript (with inline timestamps):
@@ -52,7 +55,7 @@ Transcript (with inline timestamps):
 ${input.sourceText}
 ---
 
-Score this meeting against the v1 rubric and return the JSON structure.`;
+Score this meeting against the ${promptVersion} rubric and return the JSON structure.`;
 }
 
 /**
@@ -77,7 +80,7 @@ function createGeminiDramaDetector(
 			const { output } = await generateText({
 				model: google(config.modelId),
 				system: config.systemPrompt,
-				prompt: buildPrompt(input),
+				prompt: buildPrompt(input, config.promptVersion),
 				...(config.temperature !== undefined
 					? { temperature: config.temperature }
 					: {}),

--- a/src/pipeline/services/GeminiDramaDetector.ts
+++ b/src/pipeline/services/GeminiDramaDetector.ts
@@ -17,176 +17,31 @@ import {
  * it emits the structured output, replacing prompt-engineered chain-of-
  * thought entirely. `includeThoughts: true` exposes the reasoning on
  * `result.reasoning` for first-run verification and prompt iteration.
- */
-
-const DRAMA_DETECTION_PROMPT_VERSION = "v1";
-
-/**
- * The full v1 system prompt — locked, ships verbatim from PRD #47 §Rubric v1.
  *
- * Any change to this string is a `prompt_version` bump, not an edit. Methodology
- * doc (`docs/methodology/drama-detection.md`) paraphrases this for residents
- * and links here for the canonical version.
+ * The system prompt and `promptVersion` are no longer hardcoded here —
+ * they come from a typed `EvalProfile` module under `evals/profiles/`,
+ * threaded through composition. This lets the eval harness hold prompt
+ * versions side-by-side without forking the detector factory (the
+ * `typescript-only-fixes-hiding-runtime-regressions-2026-05-01` solution
+ * doc rejects parallel eval-only factories explicitly).
  */
-const DRAMA_DETECTION_SYSTEM_PROMPT_V1 = `You are evaluating a recorded public meeting of a local Indiana governing
-body to identify how the body conducted its business. Your output goes to
-a public transparency website (Civic Mirror Drama Watch) and will be read
-by residents.
 
-You score HOW THE BODY FUNCTIONED, not whether you agree with the decisions
-made. Score process, not policy. Most meetings are routine. That is the
-expected outcome.
-
-# Output
-
-Return JSON with:
-- \`category_scores\` — object with the 7 keys below, each containing:
-    - \`score\`: integer 0, 1, 2, or 3
-    - \`evidence_quotes\`: array of 0–2 quotes (REQUIRED if score ≥ 1)
-- \`level\` — must equal the sum-mapped tier (see Tier Derivation)
-- \`confidence\` — float 0.0–1.0
-- \`headline\` — one sentence, ≤100 chars, factual editorial voice. Names
-  what happened. No loaded words ("chaos," "fiasco"). A factual claim is
-  sharper than an opinion. See Framing Rule below for ordering.
-- \`narrative\` — 2–4 sentences, plain language. What happened, in the order
-  it happened, subject to the Framing Rule. No hedging, no opinion-as-fact.
-  Residents draw their own conclusions.
-
-# The seven categories — score 0 to 3 each
-
-## 1. procedural_breakdown
-Are norms, approvals, or governance steps unclear or violated?
-- 0: Process is clear and followed
-- 1: Minor clarification needed
-- 2: Multiple uncertainties (e.g., "was this approved?")
-- 3: Explicit admission of process failure or missing steps
-ANCHOR (score 3): job descriptions not approved before vote; positions unclear
-
-## 2. question_looping
-Do participants keep asking variations of the same question after answers?
-- 0: Questions resolve cleanly
-- 1: One follow-up
-- 2: Same concern revisited multiple times
-- 3: Persistent looping indicating distrust
-
-## 3. defensive_hedging
-Are people softening or pre-framing statements to avoid conflict?
-- 0: Direct, neutral speech
-- 1: Occasional hedging
-- 2: Frequent disclaimers ("just asking," "not about people…")
-- 3: Consistent defensive framing before critiques
-
-## 4. timeline_pressure
-Is there tension between urgency and slowing down?
-- 0: No tension
-- 1: Mild mention of timing
-- 2: Clear disagreement on timing
-- 3: Active push-pull affecting decisions
-
-## 5. improvised_workarounds
-Are ad hoc solutions proposed during formal decision-making?
-- 0: No workarounds
-- 1: Minor adjustments
-- 2: Workarounds suggested
-- 3: Workarounds drive the decision
-ANCHOR (score 3): approving positions while simultaneously trying to
-generate missing documentation
-
-## 6. visible_dissent
-Do participants openly disagree?
-- 0: Full agreement
-- 1: Soft disagreement
-- 2: Clear objection from at least one member
-- 3: Multiple or sustained objections
-
-## 7. post_hoc_corrections
-Do people try to "fix" the process after decisions are made?
-- 0: No corrections
-- 1: Minor clarification
-- 2: Suggestions for future improvement
-- 3: Explicit critique of how this was handled
-
-# Tier derivation (mechanical — \`level\` must equal this)
-
-Sum the seven category scores (range 0–21):
-- 0–5  → "routine"
-- 6–11 → "bumpy"
-- 12–16 → "heated"
-- 17–21 → "off-the-rails"
-
-Do NOT apply a "ceremonial discount" that lowers category scores when
-material stakes are low. The mechanical sum reflects the volume of
-friction in the room. The Framing Rule below handles low-stakes patterns
-through narrative voice, not arithmetic.
-
-# Framing rule: procedural theater pattern
-
-Before drafting the headline and narrative, check whether the meeting's
-friction fits the procedural theater pattern. The pattern fires when ALL
-THREE conditions are met:
-
-1. **Ceremonial / low material stakes** — grant-funded, reversible, no
-   district money at risk, no harm, no irreversible commitment
-2. **Body ratified anyway** — the motion passed, typically unanimous or
-   near-unanimous, in the same meeting
-3. **Sustained objection pattern** — one member triggered ≥3 categories
-   on the same agenda item (e.g., procedural_breakdown + defensive_hedging
-   + timeline_pressure + post_hoc_corrections all firing on one issue)
-
-When the pattern fires:
-
-- Keep the mechanical category sum and tier — do not lower scores
-- **Headline must lead with the vote**, then locate the friction on the
-  objecting member's pattern. Example: "Board unanimously approves X
-  amid sustained paperwork objections" — not "Board creates X without
-  prior approval"
-- **Narrative leads with the vote and the material stakes** (e.g., grant
-  funding, employees retaining status), then describes the objection
-  pattern as one member's, then the body's response
-- Do not frame the admin or staff as the source of the drama when the
-  body itself did not share the concern
-- Quote the objector's own framing where it surfaces the pattern (hedged
-  disclaimers, timing pressure, future-improvement scolding)
-
-When the pattern does NOT fire (real material stakes, body did not
-ratify, or objection was widely shared):
-
-- Default to chronological narrative — what happened, in the order it
-  happened
-- Headline names the substantive event, not the procedural framing
-
-**Editorial position implied:** majoritarian ratification on ceremonial
-items is treated as a strong signal of substantive seriousness. A
-principled minority dissent on a real-but-technical breakdown will read
-as theater under this rubric. Civic Mirror owns this stance; reviewers
-should be aware of it when calibrating.
-
-# Evidence quote rules
-
-- Quotes must appear VERBATIM in the transcript. Whitespace and
-  punctuation may differ; words may not.
-- Quotes should be 1–3 sentences, long enough to carry context.
-- If you cannot find a clear verbatim quote for a category you scored ≥1,
-  DO NOT INVENT ONE. Lower the score to 0.
-- Do not paraphrase, summarize, or stitch quotes from non-adjacent
-  parts of the transcript.
-
-# When uncertain
-
-Choose the lower score on individual categories. Wrong "off-the-rails"
-calls damage site credibility more than missed ones. Heated auto-publishes;
-off-the-rails requires manual operator review.
-
-For framing decisions, when the procedural theater pattern is borderline
-(only 2 of 3 conditions clearly met), default to chronological narrative
-rather than vote-led framing — false theater calls erode trust faster
-than missed ones.
-
-Return ONLY valid JSON. No prose outside the structure.`;
+const DEFAULT_THINKING_BUDGET = 4096;
+const DEFAULT_INCLUDE_THOUGHTS = true;
 
 type GeminiDramaDetectorConfig = {
 	/** Gemini model ID (e.g. "gemini-2.5-flash"). */
 	modelId: string;
+	/** Profile version string (e.g. "v1"). Surfaced in stored assessments. */
+	promptVersion: string;
+	/** System prompt body, sourced from the active `EvalProfile`. */
+	systemPrompt: string;
+	/** Optional sampling temperature; provider default applies if omitted. */
+	temperature?: number;
+	/** Reasoning-token budget for Gemini 2.5 thinking; defaults to 4096. */
+	thinkingBudget?: number;
+	/** Expose reasoning on `result.reasoning`; defaults to true. */
+	includeThoughts?: boolean;
 };
 
 function buildPrompt(input: DramaDetectionInput): string {
@@ -214,20 +69,26 @@ Score this meeting against the v1 rubric and return the JSON structure.`;
 function createGeminiDramaDetector(
 	config: GeminiDramaDetectorConfig,
 ): DramaDetectionGenerateFn {
+	const thinkingBudget = config.thinkingBudget ?? DEFAULT_THINKING_BUDGET;
+	const includeThoughts = config.includeThoughts ?? DEFAULT_INCLUDE_THOUGHTS;
+
 	return async (input: DramaDetectionInput): Promise<DramaAssessmentOutput> => {
 		try {
 			const { output } = await generateText({
 				model: google(config.modelId),
-				system: DRAMA_DETECTION_SYSTEM_PROMPT_V1,
+				system: config.systemPrompt,
 				prompt: buildPrompt(input),
+				...(config.temperature !== undefined
+					? { temperature: config.temperature }
+					: {}),
 				output: Output.object({
 					schema: dramaAssessmentSchema,
 				}),
 				providerOptions: {
 					google: {
 						thinkingConfig: {
-							thinkingBudget: 4096,
-							includeThoughts: true,
+							thinkingBudget,
+							includeThoughts,
 						},
 					} satisfies GoogleGenerativeAIProviderOptions,
 				},
@@ -252,9 +113,5 @@ function createGeminiDramaDetector(
 	};
 }
 
-export {
-	createGeminiDramaDetector,
-	DRAMA_DETECTION_PROMPT_VERSION,
-	DRAMA_DETECTION_SYSTEM_PROMPT_V1,
-};
+export { createGeminiDramaDetector };
 export type { GeminiDramaDetectorConfig };


### PR DESCRIPTION
## Summary

Tracer bullet for the drama eval harness (PRD #66). Today the v1 system prompt and `promptVersion` are hardcoded inside `src/pipeline/services/GeminiDramaDetector.ts`, and `GeminiDramaDetectorConfig` accepts only `modelId`. That shape blocks the harness from holding multiple prompt versions side-by-side without forking the detector — exactly the parallel-factory failure mode the `typescript-only-fixes-hiding-runtime-regressions` solution doc rejects.

Three changes, in order:

1. **Move the v1 prompt out of services into `evals/profiles/v1.ts`** as a typed `EvalProfile` (`promptVersion`, `systemPrompt`, optional `temperature`/`thinkingBudget`/`includeThoughts`). The prompt body is verbatim — this is a relocation, not an edit. Future profiles (`v2.ts`, etc.) become new files in this directory.

2. **Widen `GeminiDramaDetectorConfig`** to accept the new fields. Production defaults remain `thinkingBudget: 4096` and `includeThoughts: true`, so the live pipeline behaves identically — `composition.ts` reads from `dramaProfileV1` and threads the values through. The `temperature` knob is conditionally spread so when a profile omits it the provider default still applies.

3. **Add `profile-loader.ts`** — an Effect-native loader that dynamic-imports every `*.ts` under a given directory, fails fast on empty/whitespace `systemPrompt`, and rejects duplicate `promptVersion` across files. One `ProfileLoadError` tag covers all failure modes because every caller (the upcoming `evals:run` subcommand) has the same response: refuse to spend Gemini quota on a broken profile. Six unit tests cover happy load, empty prompt, whitespace prompt, duplicate version, missing directory, and the tagged-error shape.

The result is the structural foundation the harness needs: production and the eval matrix share exactly one detector implementation, and the loader is the pre-flight gate that the PRD's Rabbit Holes section requires before any API call.

## PRD

Closes #67
Refs #66

## Slices

- [x] #67 — Drama eval harness: profile extraction + production rewire (tracer bullet)
- [ ] #68 — (next slice in #66)
- [ ] #69
- [ ] #70
- [ ] #71

## Key Decisions

- Loader exposes one `ProfileLoadError` tag for all failure modes rather than per-mode tagged errors. The harness's response is identical (refuse to run); finer-grained tags would be ceremony without leverage.
- Fixtures use plain `const` exports without typing against `EvalProfile` to avoid a brittle relative path from `src/pipeline/scripts/evals/__fixtures__/...` up to `evals/profiles/v1.ts`. The loader validates structurally at runtime — the type would be ornamental on the test side.
- `composition.ts` uses a relative import (`../../evals/profiles/v1.ts`) rather than introducing a new `tsconfig` path alias for `evals/`. One callsite isn't enough to justify the alias; if more production sites read profiles, that's the moment to add it.

## Test plan

- [x] `pnpm test` — 189/189 (was 183, +6 loader tests)
- [x] `tsc --noEmit` clean
- [x] `buildProductionLayers({ dryRun: true })` constructs the merged Layer with the new wiring
- [x] `pnpm pipeline run --dry-run --skip-crawl-delay --body ellettsville-town-council` reaches the orchestrator and emits the no-new-content alert through the rewired composition