### PR TITLE
Pipeline stage logs: per-stage observability for egov/finalsite/youtube paths

### DIFF
--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -1168,6 +1168,59 @@ describe("runPipeline stage logging", () => {
 		expect(downloadStarts[1]?.annotations.uuid).toBe("uuid-minutes");
 		expect(downloadStarts[0]?.annotations.body).toBe("school-board");
 	});
+
+	it("emits transcribe/summarize/drama stage logs for a youtube video", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			youtubeVideos: [
+				{
+					videoId: "vid-001",
+					title: "School Board April 15 2026",
+					publishedAt: "2026-04-15T00:00:00Z",
+					hasCaptions: true,
+				},
+			],
+		});
+		const { captured, layer: loggerLayer } = buildLogCapture();
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "school-board",
+					name: "School Board",
+					youtubePlaylistId: "PL-XYZ",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({ text: "", method: "unreadable" }),
+			dryRun: false,
+		}).pipe(Effect.provide(layers), Effect.provide(loggerLayer));
+
+		await Effect.runPromise(program);
+
+		const tags = captured
+			.flatMap((c) =>
+				c.message.filter((m): m is string => typeof m === "string"),
+			)
+			.filter((m) => m.startsWith("youtube."));
+
+		expect(tags).toEqual([
+			"youtube.transcribe.start",
+			"youtube.transcribe.finish",
+			"youtube.summarize.start",
+			"youtube.summarize.finish",
+			"youtube.drama.start",
+			"youtube.drama.finish",
+		]);
+
+		const transcribeStart = findStageLog(captured, "youtube.transcribe.start");
+		expect(transcribeStart?.annotations.body).toBe("school-board");
+		expect(transcribeStart?.annotations.videoId).toBe("vid-001");
+	});
 });
 
 describe("runDramaDetectForVideo", () => {

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -1091,6 +1091,83 @@ describe("runPipeline stage logging", () => {
 		const extractFinish = findStageLog(captured, "egov.extract.finish");
 		expect(extractFinish?.annotations.method).toBe("ocr");
 	});
+
+	it("emits per-document finalsite download/extract logs and a single summarize pair", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			finalsiteListings: [
+				{
+					date: "January 20, 2026",
+					meetingType: "Regular Meeting",
+					year: 2026,
+					documents: [
+						{
+							uuid: "uuid-agenda",
+							documentType: "agenda",
+							downloadUrl: "/fs/resource-manager/view/uuid-agenda",
+							fileName: "agenda.pdf",
+						},
+						{
+							uuid: "uuid-minutes",
+							documentType: "minutes",
+							downloadUrl: "/fs/resource-manager/view/uuid-minutes",
+							fileName: "minutes.pdf",
+						},
+					],
+				},
+			],
+		});
+		const { captured, layer: loggerLayer } = buildLogCapture();
+
+		const program = runPipeline({
+			bodies: [
+				{
+					slug: "school-board",
+					name: "School Board",
+					finalsiteUrl: "https://example.com/school-board",
+				},
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({
+				text: "school board text",
+				method: "text-layer",
+			}),
+			dryRun: true,
+		}).pipe(Effect.provide(layers), Effect.provide(loggerLayer));
+
+		await Effect.runPromise(program);
+
+		const tags = captured
+			.flatMap((c) =>
+				c.message.filter((m): m is string => typeof m === "string"),
+			)
+			.filter((m) => m.startsWith("finalsite."));
+
+		expect(tags).toEqual([
+			"finalsite.download.start",
+			"finalsite.download.finish",
+			"finalsite.extract.start",
+			"finalsite.extract.finish",
+			"finalsite.download.start",
+			"finalsite.download.finish",
+			"finalsite.extract.start",
+			"finalsite.extract.finish",
+			"finalsite.summarize.start",
+			"finalsite.summarize.finish",
+		]);
+
+		const downloadStarts = captured.filter((c) =>
+			c.message.includes("finalsite.download.start"),
+		);
+		expect(downloadStarts).toHaveLength(2);
+		expect(downloadStarts[0]?.annotations.uuid).toBe("uuid-agenda");
+		expect(downloadStarts[1]?.annotations.uuid).toBe("uuid-minutes");
+		expect(downloadStarts[0]?.annotations.body).toBe("school-board");
+	});
 });
 
 describe("runDramaDetectForVideo", () => {

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -1035,6 +1035,62 @@ describe("runPipeline stage logging", () => {
 		expect(downloadStart?.annotations.body).toBe("town-council");
 		expect(downloadStart?.annotations.url).toBe("https://example.com/doc/1");
 	});
+
+	it("emits ordered download/extract/summarize stage logs for a readable egov listing", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 1,
+					title: "Town Council Meeting Minutes February 4, 2026",
+					date: "02/04/2026",
+					downloadUrl: "https://example.com/doc/1",
+					meetingDate: "2026-02-04",
+					documentType: "minutes",
+				},
+			],
+		});
+		const { captured, layer: loggerLayer } = buildLogCapture();
+
+		const program = runPipeline({
+			bodies: [
+				{ slug: "town-council", name: "Town Council", egovSearchType: "12" },
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({
+				text: "body text",
+				method: "ocr",
+			}),
+			dryRun: true,
+		}).pipe(Effect.provide(layers), Effect.provide(loggerLayer));
+
+		await Effect.runPromise(program);
+
+		const tags = captured
+			.flatMap((c) =>
+				c.message.filter((m): m is string => typeof m === "string"),
+			)
+			.filter((m) => m.startsWith("egov."));
+
+		expect(tags).toEqual([
+			"egov.download.start",
+			"egov.download.finish",
+			"egov.extract.start",
+			"egov.extract.finish",
+			"egov.summarize.start",
+			"egov.summarize.finish",
+		]);
+
+		const downloadFinish = findStageLog(captured, "egov.download.finish");
+		expect(downloadFinish?.annotations.bytes).toBe("fake pdf".length);
+
+		const extractFinish = findStageLog(captured, "egov.extract.finish");
+		expect(extractFinish?.annotations.method).toBe("ocr");
+	});
 });
 
 describe("runDramaDetectForVideo", () => {

--- a/src/pipeline/orchestrator.test.ts
+++ b/src/pipeline/orchestrator.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect";
+import { Effect, HashMap, Layer, Logger } from "effect";
 import { describe, expect, it } from "vitest";
 import type { MeetingDetail } from "#/db/queries.ts";
 import { LlmError } from "#/pipeline/errors.ts";
@@ -949,6 +949,91 @@ describe("runPipeline", () => {
 		expect(result.processed).toBe(1);
 		expect(result.errors).toBe(0);
 		expect(log.alert).toHaveLength(0);
+	});
+});
+
+/**
+ * Effect teaching note: `Logger.replace(Logger.defaultLogger, captureLogger)`
+ * swaps the root logger for the duration of the provided effect — every
+ * `Effect.log(...)` call inside the program is routed through `captureLogger`
+ * instead of the default logfmt-to-stdout one. The capture stores message
+ * varargs and the annotation HashMap from `Effect.annotateLogs(...)` so the
+ * test can assert on the structured stage events the orchestrator emits.
+ */
+type CapturedLog = {
+	message: ReadonlyArray<unknown>;
+	annotations: Record<string, unknown>;
+};
+
+function buildLogCapture(): {
+	captured: Array<CapturedLog>;
+	layer: Layer.Layer<never>;
+} {
+	const captured: Array<CapturedLog> = [];
+	const logger = Logger.make<unknown, void>(({ message, annotations }) => {
+		const annObj: Record<string, unknown> = {};
+		HashMap.forEach(annotations, (value, key) => {
+			annObj[key] = value;
+		});
+		captured.push({
+			message: Array.isArray(message)
+				? (message as ReadonlyArray<unknown>)
+				: [message],
+			annotations: annObj,
+		});
+	});
+	return {
+		captured,
+		layer: Logger.replace(Logger.defaultLogger, logger),
+	};
+}
+
+function findStageLog(
+	captured: ReadonlyArray<CapturedLog>,
+	tag: string,
+): CapturedLog | undefined {
+	return captured.find((c) => c.message.some((m) => m === tag));
+}
+
+describe("runPipeline stage logging", () => {
+	it("emits a download.start stage log with body and url annotations during egov processing", async () => {
+		const log = emptyCallLog();
+		const layers = buildStubLayers({
+			log,
+			egovListings: [
+				{
+					id: 1,
+					title: "Town Council Meeting Minutes February 4, 2026",
+					date: "02/04/2026",
+					downloadUrl: "https://example.com/doc/1",
+					meetingDate: "2026-02-04",
+					documentType: "minutes",
+				},
+			],
+		});
+		const { captured, layer: loggerLayer } = buildLogCapture();
+
+		const program = runPipeline({
+			bodies: [
+				{ slug: "town-council", name: "Town Council", egovSearchType: "12" },
+			],
+			crawlDelayMs: 0,
+			youtubeDelayMs: 0,
+			networkRetry: { attempts: 0, baseDelayMs: 0 },
+			llmRetry: { attempts: 0, baseDelayMs: 0 },
+			extractPdfText: async () => ({
+				text: "body text",
+				method: "text-layer",
+			}),
+			dryRun: true,
+		}).pipe(Effect.provide(layers), Effect.provide(loggerLayer));
+
+		await Effect.runPromise(program);
+
+		const downloadStart = findStageLog(captured, "egov.download.start");
+		expect(downloadStart).toBeDefined();
+		expect(downloadStart?.annotations.body).toBe("town-council");
+		expect(downloadStart?.annotations.url).toBe("https://example.com/doc/1");
 	});
 });
 

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -395,6 +395,7 @@ function processEgovListing(
 		const summarizer = yield* SummarizationService;
 		const storage = yield* StorageService;
 
+		yield* Effect.log("egov.download.start");
 		const bytes = yield* scraper
 			.downloadDocument(listing.downloadUrl)
 			.pipe(Effect.retry(config.networkSchedule));
@@ -472,7 +473,13 @@ function processEgovListing(
 		yield* storage.storeMeeting(meetingInput);
 
 		return { processed: 1, errors: 0 };
-	});
+	}).pipe(
+		Effect.annotateLogs({
+			body: body.slug,
+			source: "egov",
+			url: listing.downloadUrl,
+		}),
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -539,27 +539,38 @@ function processFinalsiteListing(
 		let combinedText = "";
 
 		for (const doc of listing.documents) {
-			const bytes = yield* scraper
-				.downloadDocument(doc.uuid)
-				.pipe(Effect.retry(config.networkSchedule));
+			yield* Effect.gen(function* () {
+				yield* Effect.log("finalsite.download.start");
+				const bytes = yield* scraper
+					.downloadDocument(doc.uuid)
+					.pipe(Effect.retry(config.networkSchedule));
+				yield* Effect.log("finalsite.download.finish").pipe(
+					Effect.annotateLogs({ bytes: bytes.byteLength }),
+				);
 
-			const extraction = yield* Effect.tryPromise({
-				try: () => config.extractPdfText(bytes),
-				catch: (error) =>
-					new PipelineExtractError({
-						message: error instanceof Error ? error.message : String(error),
-					}),
-			});
-			documents.push({
-				sourceUrl: doc.downloadUrl,
-				rawText: extraction.text,
-				documentType:
-					doc.documentType === "notice" ? "agenda" : doc.documentType,
-				extractionMethod: extraction.method,
-			});
-			if (extraction.method !== "unreadable") {
-				combinedText += `\n${extraction.text}`;
-			}
+				yield* Effect.log("finalsite.extract.start");
+				const extraction = yield* Effect.tryPromise({
+					try: () => config.extractPdfText(bytes),
+					catch: (error) =>
+						new PipelineExtractError({
+							message: error instanceof Error ? error.message : String(error),
+						}),
+				});
+				yield* Effect.log("finalsite.extract.finish").pipe(
+					Effect.annotateLogs({ method: extraction.method }),
+				);
+
+				documents.push({
+					sourceUrl: doc.downloadUrl,
+					rawText: extraction.text,
+					documentType:
+						doc.documentType === "notice" ? "agenda" : doc.documentType,
+					extractionMethod: extraction.method,
+				});
+				if (extraction.method !== "unreadable") {
+					combinedText += `\n${extraction.text}`;
+				}
+			}).pipe(Effect.annotateLogs({ uuid: doc.uuid, url: doc.downloadUrl }));
 		}
 
 		// If every document for the meeting came back unreadable, skip
@@ -583,12 +594,14 @@ function processFinalsiteListing(
 			return { processed: 1, errors: 0 };
 		}
 
+		yield* Effect.log("finalsite.summarize.start");
 		const summary = yield* summarizer
 			.summarize({
 				sourceText: combinedText,
 				meetingContext: `${body.name}, ${listing.date}`,
 			})
 			.pipe(Effect.retry(config.llmSchedule));
+		yield* Effect.log("finalsite.summarize.finish");
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 
@@ -607,7 +620,7 @@ function processFinalsiteListing(
 		});
 
 		return { processed: 1, errors: 0 };
-	});
+	}).pipe(Effect.annotateLogs({ body: body.slug, source: "finalsite" }));
 }
 
 // ---------------------------------------------------------------------------

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -399,7 +399,11 @@ function processEgovListing(
 		const bytes = yield* scraper
 			.downloadDocument(listing.downloadUrl)
 			.pipe(Effect.retry(config.networkSchedule));
+		yield* Effect.log("egov.download.finish").pipe(
+			Effect.annotateLogs({ bytes: bytes.byteLength }),
+		);
 
+		yield* Effect.log("egov.extract.start");
 		const extraction = yield* Effect.tryPromise({
 			try: () => config.extractPdfText(bytes),
 			catch: (error) =>
@@ -407,6 +411,9 @@ function processEgovListing(
 					message: error instanceof Error ? error.message : String(error),
 				}),
 		});
+		yield* Effect.log("egov.extract.finish").pipe(
+			Effect.annotateLogs({ method: extraction.method }),
+		);
 
 		// Meeting date comes from the title when present — the eGov listing cell
 		// is the publish/upload date, which collapses to the day staff posted a
@@ -440,12 +447,14 @@ function processEgovListing(
 			return { processed: 1, errors: 0 };
 		}
 
+		yield* Effect.log("egov.summarize.start");
 		const summary = yield* summarizer
 			.summarize({
 				sourceText: extraction.text,
 				meetingContext: `${body.name}, ${listing.date}`,
 			})
 			.pipe(Effect.retry(config.llmSchedule));
+		yield* Effect.log("egov.summarize.finish");
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 

--- a/src/pipeline/orchestrator.ts
+++ b/src/pipeline/orchestrator.ts
@@ -680,16 +680,22 @@ function processYouTubeVideo(
 		const summarizer = yield* SummarizationService;
 		const storage = yield* StorageService;
 
+		yield* Effect.log("youtube.transcribe.start");
 		const transcript = yield* transcription
 			.transcribe(video.videoId)
 			.pipe(Effect.retry(config.networkSchedule));
+		yield* Effect.log("youtube.transcribe.finish").pipe(
+			Effect.annotateLogs({ source: transcript.source }),
+		);
 
+		yield* Effect.log("youtube.summarize.start");
 		const summary = yield* summarizer
 			.summarize({
 				sourceText: transcript.rawText,
 				meetingContext: `${body.name}, ${video.title}`,
 			})
 			.pipe(Effect.retry(config.llmSchedule));
+		yield* Effect.log("youtube.summarize.finish");
 
 		if (config.dryRun) return { processed: 1, errors: 0 };
 
@@ -720,15 +726,17 @@ function processYouTubeVideo(
 		// transparency artifacts. The catchAll below absorbs any error,
 		// alerts the operator, and returns Effect.void so the orchestrator's
 		// tagged-error channel is unaffected.
+		yield* Effect.log("youtube.drama.start");
 		yield* runDramaDetection({
 			body,
 			video,
 			meetingId: meeting.id,
 			transcript,
 		}).pipe(Effect.catchAll((error) => alertDramaFailure(body, error)));
+		yield* Effect.log("youtube.drama.finish");
 
 		return { processed: 1, errors: 0 };
-	});
+	}).pipe(Effect.annotateLogs({ body: body.slug, videoId: video.videoId }));
 }
 
 function runDramaDetection(input: {


### PR DESCRIPTION
## Summary

The pipeline orchestrator's three source paths (eGov, Finalsite, YouTube) ran their long-running per-listing work — PDF download, OCR, Gemini summarization, Whisper transcription, drama detection — without emitting any per-stage stdout. An operator running `pnpm pipeline run --dry-run --skip-crawl-delay` saw the no-content alert and then nothing else for 10+ minutes while Tesseract OCR'd 25 scanned PDFs sequentially. That silent stretch was reported as a hang in #73; investigation in #74 falsified the "stuck Effect fiber / unclosed libsql client / NodeRuntime shutdown" hypotheses and traced it to *real work without observable signal*.

This PR adds canonical Effect-style logging at every stage boundary: `Effect.log("egov.download.start")` paired with `…finish`, `extract.start/finish` with the chosen extraction method, `summarize.start/finish`, plus `transcribe`, `drama`, and finalsite per-document analogs. Each per-listing/per-video scope wraps the body in `Effect.annotateLogs({ body, source, url|videoId })` so every stage event automatically carries the right context — no repetition at each call site. The downstream consequence is concrete: a real `pnpm pipeline run --dry-run --skip-crawl-delay --body ellettsville-town-council` invocation on this branch now prints structured per-stage logs with timestamps, so an operator can distinguish "30s of OCR is happening" from "deadlock" without attaching a profiler.

This is the smallest of the three logical slices in #74 (observability, dedup gate, alert rewording). It does not change pipeline behavior — only what the operator sees while behavior is happening. It does not close #74 on its own; the dedup gate (the structural fix that lets dry-run actually be fast) and the alert rewording follow as separate slices.

## Refs

- Refs #74 (parent) — observability slice; dedup gate + alert rewording remain
- Closes the "looks like a hang" symptom from #73, but does not close #73 itself (the underlying performance question — "why does dry-run do full OCR on every listing" — is the dedup slice's territory)

## Key Decisions

- **`Effect.log` + `Effect.annotateLogs` over `console.log`.** Effect's logger system is testable (capture via `Logger.replace(Logger.defaultLogger, …)`) and produces structured logfmt output by default, so future log routing (JSON to stdout, file appender, OTel) is a one-layer change rather than rewriting every call site.
- **Lexical scope annotation.** The per-listing scope sets `body`/`source`/`url`; per-stage scopes layer on `bytes`/`method`. This means each `Effect.log("…")` call is a single line with no annotation boilerplate, and adding a new per-listing dimension (e.g. body's parent jurisdiction) is a single annotation change instead of N call-site edits.
- **Tests assert on captured logger output, not stdout.** Each test routes the program through a custom `Logger.make` that pushes records into an array, then asserts on message tags + annotations. This survives refactors that change formatting and works without a stdout-capture harness.