### PR TITLE
[drama-eval] Slice 2: corpus authoring + corpus loader (RBB hiring)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
 			"**/index.html",
 			"**/vite.config.ts",
 			"!**/src/routeTree.gen.ts",
-			"!**/src/styles.css"
+			"!**/src/styles.css",
+			"!**/__fixtures__/corpus-loader/malformed"
 		]
 	},
 	"formatter": {

--- a/evals/corpus/rbb-hiring.json
+++ b/evals/corpus/rbb-hiring.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": 1,
+  "id": "rbb-hiring",
+  "transcript_path": "transcripts/rbb-hiring.txt",
+  "meeting_context": "Richland-Bean Blossom School Board, regular meeting, 2026-04-21 (clip 22:01–37:08, ~15 min). Discussion + vote on creating a 'school psychologist in training' position funded by an IU/SEEDS grant; sustained objection from one board member about advertising scope and approving a position before its job description; motion carries with a single 'I opposed' vote.",
+  "graded_at": "2026-05-09",
+  "graded_by": "chrislacey89",
+  "ground_truth": {
+    "category_scores": {
+      "procedural_breakdown": {
+        "score": 3,
+        "evidence_quotes": [
+          "[32:09] The position of psychologists in training, we wouldn't we don't [32:14] actually approve job descriptions, but [32:16] we'd be creating it without looking at a [32:19] job description.",
+          "[32:24] if you're comfortable in doing that, we could move [32:26] forward that way and then fill those [32:28] positions. Um or [32:33] again, we could table [32:33] those appointments until they bring the [32:36] position to us.",
+          "[33:38] no, because I won't have time to look [33:40] through the job description."
+        ]
+      },
+      "question_looping": {
+        "score": 3,
+        "evidence_quotes": [
+          "[31:20] I guess [31:22] that's a question. The four that [31:22] that you're recommending, are they [31:24] internal or was [31:26] one of those an external [31:26] maybe or two of them?",
+          "[31:39] Okay. So we had so we had six internal [31:41] and two [31:42] external then.",
+          "[35:23] please bring job descriptions [35:27] and positions to us first um so that we [35:31] know what we're uh looking at.",
+          "[36:21] I hadn't heard anything about it until [36:23] till this. So, that's why I'm really [36:26] surprised because I I do think there [36:30] would have been more applicants if they [36:33] known what the benefits of being a [36:36] psychologist in training were."
+        ]
+      },
+      "defensive_hedging": {
+        "score": 2,
+        "evidence_quotes": [
+          "[35:45] um you know yes [35:45] getting it posted you know Robin putting [35:47] out there but if I would have looked and [35:49] saw psych psychologist in training as a [35:52] position [35:54] to me that's not going to sound [35:55] very [35:55] exciting uh honestly",
+          "[33:02] Yeah. that that that'll postpone us [33:05] because"
+        ]
+      },
+      "timeline_pressure": {
+        "score": 2,
+        "evidence_quotes": [
+          "[33:11] and we we have [33:13] another meeting in May so [33:13] it gives us a",
+          "[33:15] right but we're [33:16] making staffing [33:16] decisions now",
+          "[33:33] Are you okay with creating it tonight?"
+        ]
+      },
+      "improvised_workarounds": {
+        "score": 3,
+        "evidence_quotes": [
+          "[32:38] Can I make a suggestion? Can we take the [32:41] job description that was in the [32:43] posting, [32:45] have Jennifer [32:45] uh go print it off and give the board [32:49] that job [32:49] description and approve that?",
+          "[32:52] We've approved we've approved before the [32:56] job [32:56] description the same night we voted [32:58] the person in. We've done that before",
+          "[32:14] we don't [32:14] actually approve job descriptions, but [32:16] we'd be creating it without looking at a [32:19] job [32:19] description."
+        ]
+      },
+      "visible_dissent": {
+        "score": 3,
+        "evidence_quotes": [
+          "[37:04] um any other comments? [37:06] All those in favor say I. I [37:08] I opposed. Motion carries.",
+          "[35:21] I'll just make two comments for the [35:23] vote. one, please bring job descriptions [35:27] and positions to us first um so that we [35:31] know what we're uh looking at. And two, [35:35] if a position like this comes up before, [35:39] I [35:39] think extra efforts need to be made in [35:42] getting that out there.",
+          "[33:38] no, because I won't have time to look [33:40] through the job description."
+        ]
+      },
+      "post_hoc_corrections": {
+        "score": 1,
+        "evidence_quotes": [
+          "[33:24] and they did post the position [33:26] they did post it just wasn't created"
+        ]
+      }
+    },
+    "level": "off-the-rails",
+    "headline": "Board approves new psychologist-in-training role 6-1 over sustained objection that no job description was reviewed",
+    "narrative": "The board voted to create a grant-funded 'school psychologist in training' position before any job description had been brought to them, after one member spent ~15 minutes pressing administrators on whether the underlying posting had been advertised broadly enough and on the internal vs. external candidate split. The chair acknowledged mid-discussion that the board does not normally approve job descriptions but in this case 'we'd be creating it without looking at one.' A second member proposed an in-meeting workaround — have staff print the existing posting so the board could approve it the same night — which the dissenting member rejected for lack of review time. The motion carried with a single audible 'I opposed' vote, after the dissenter had already stated two for-the-record demands: that future job descriptions arrive before positions, and that uncommon benefits be advertised more aggressively.",
+    "notes": "Per project drama-watch rubric: sustained objection on a ratified item is the drama; this clip is a textbook case. Hand-graded sum (3+3+2+2+3+3+1=17) maps mechanically to off-the-rails, which matches the spirit of the rubric here even though the 17 threshold is the floor of that tier. Defensive_hedging is held at 2 because the administrator's responses are mostly substantive even when the questioner is dismissive of them; visible_dissent is held at 3 (not higher) because the dissenter never escalates beyond two for-the-record statements + an 'I opposed' — there is no procedural objection, no roll-call request, no walk-out. Question_looping is held at 3 because the same board member returns to advertising scope and internal/external counts at least four distinct times across the 15-minute window. Improvised_workarounds is high because the 'have Jennifer print the posting and approve it tonight' suggestion is exactly the on-the-fly redefinition of approval scope that the rubric flags."
+  }
+}

--- a/evals/transcripts/rbb-hiring.txt
+++ b/evals/transcripts/rbb-hiring.txt
@@ -1,0 +1,168 @@
+[22:01] they're still our employees, I don't I [22:03] don't see how we could not promise them 
+[22:06] uh a position when they come back. It [22:08] may not be the exact same position they 
+[22:10] have right now, but uh they're they're [22:14] all highly qualified, highly effective 
+[22:19] employees, teachers, and uh I think we [22:22] would um jump at the chance to have have 
+[22:25] them back if if they would like to. [22:29] If attrition didn't happen though, it's [22:33] 
+possible they may they could have to [22:35] displace somebody in a classroom. [22:38] >> Uh, you 
+know, in my uh [22:42] what, eight, nine years, [22:45] that's never happened, [22:46] >> right? 
+[22:47] >> It seems unlikely. [22:48] >> So, we're, you know, I don't want us to [22:51] um hold us 
+back on, [22:53] >> right, [22:54] >> a possibility that we just never see, [22:56] >> right? 
+[22:59] What happens if [23:02] they get halfway through and decide it's [23:04] not for them? 
+[23:06] >> What, you know, they're halfway through [23:07] the program, [23:09] >> somebody else 
+can't come in because [23:11] there's not enough time left to do it. [23:14] >> So, we have what 
+happens? [23:15] >> Yeah, we actually had that happen on a [23:17] couple of the grants, the temps 
+and the [23:18] smart where we've had some people leave [23:20] in the middle. Um, we don't have 
+them [23:23] sign anything um that they're going to [23:25] stay with us for four years. Um, we 
+have [23:28] had a couple that have started their [23:29] degrees and have dropped out of the 
+[23:31] program and for different reasons. [23:33] They've either left positions to take [23:36] 
+something else or to move out of state. [23:38] Um, [23:40] this one is a little bit different 
+[23:41] because the degree is three or four [23:45] years depending on the school that they [23:46] 
+go with and it's a four-year grant. um [23:50] the temps and smart with the counselors [23:53] was 
+a two-year degree but a four-year [23:57] grant. So in those cases we were able to [23:60] pick up 
+some people and go ahead and [24:02] finish paying for schooling. Um, in [24:05] fact, we just 
+hired uh a teacher or [24:08] sorry, a counselor at the beginning of [24:14] goodness, November, 
+December, [24:18] something like that. Um, into the smart [24:21] grant who had already started her 
+[24:23] counseling license. Um, and we would [24:26] have we still had time to help her [24:28] 
+finish on that and she works for a [24:31] counsel as a counselor for us at EECC. [24:34] Um, so 
+there are it's hard to say [24:37] because you don't know exactly what the [24:38] situations are 
+going to be or when they [24:40] arise. Um, but thankfully with these [24:43] federal grants, we 
+work really closely [24:44] with our liaison there. Um, and they're [24:47] really good about 
+helping us come up [24:49] with alternatives. Um, they don't want [24:51] to take the money back. I 
+know that [24:52] sounds silly, but it's actually more of [24:55] a hassle for them to take the 
+money [24:57] back. Um, [24:59] they're bugging me constantly to spend [25:01] excess cost. And in 
+a lot of ways, it's [25:03] hard to spend the excess cost once once [25:06] it starts to build up. 
+Um, just for the [25:09] seeds grant alone, [25:11] we received our first year of funding [25:13] 
+for the seeds grant um just shortly into [25:16] January. And that first year, Debbie, [25:19] 
+you'd have to help me on it that we've [25:21] received was [25:24] 750 800,000 [25:27] um that we 
+received from them in order [25:29] to go ahead and start the grant. Well, [25:31] what happens on 
+these federal grants is [25:33] when they start on January 1st, but we [25:36] don't start the 
+school year until [25:39] July 1, August one on contracts, then [25:43] we're already 7 to 8 months 
+behind [25:45] because we haven't been paying anybody [25:47] on these grants. So that's where all 
+of [25:52] these grants that are going out to [25:53] public schools across the entire [25:55] 
+country, we're already starting to build [25:58] up excess cost just simply because of [26:01] 
+timing with it. So that's where we have [26:04] to, as the the government says, they [26:07] don't 
+want us to plan ahead for excess [26:09] costs, but they want us to plan ahead [26:10] for excess 
+cost. In other words, we want [26:13] you to think about how you can make [26:14] modifications to 
+the grant down the [26:16] road. we just w don't want to know that [26:18] you're thinking about 
+how to make [26:20] modifications. [26:21] Um so it's an interesting situation to [26:24] be in 
+because I can't really talk with [26:26] our federal um contractor through the [26:29] grant about 
+how we would do this and and [26:32] in our case we were able to hire four [26:34] instead of three 
+um and still have an [26:37] excess cost at the end of this grant of [26:38] over $200,000. [26:41] 
+Um but she does not want to know that [26:43] now. she wants to wait until the grant [26:44] is up 
+and running and then we put in [26:46] modifications to the financial the bud [26:48] the budget 
+side of the grant. Um so it [26:51] is you do have to plan ahead but they [26:53] don't necessarily 
+want you to start [26:55] submitting those things right away. [26:58] So to answer your question 
+Dana I don't [27:01] know exactly how that would work out. [27:03] Um, a lot of it would depend on 
+what the [27:05] government allows us to do with the [27:06] grant in order to open that position 
+[27:10] back up. And then would they allow us to [27:12] hire someone with a counseling degree? 
+[27:13] Would they allow us to hire someone with [27:16] a social work degree? Um, would it have 
+[27:18] to be a school psychologist? [27:20] Um, would we be able to to have someone [27:23] We 
+actually have someone now who has a [27:25] license as a school psychologist, but [27:26] she's let 
+that expire. if we were able [27:29] to pick her up on the grant. Um, you [27:31] know, if she was 
+interested, would we be [27:33] able to get her rellicensed and bring [27:35] her back in in that 
+capacity. So, a lot [27:38] of different options there and it's just [27:40] hard to say exactly 
+what would happen [27:42] until the scenario pops up. Um, but we [27:45] have experienced that with 
+the TIMS [27:47] grant and the smart grant. Um, and [27:49] thankfully we found a lot of 
+flexibility [27:51] in what we can do with that. Um, in [27:54] fact, Mr. Dixon's probably tired of 
+me [27:57] talking about what do we do? How do we [27:59] spend this? Um, is there any anybody 
+[28:01] else that we can hire? So, [28:04] >> any other question? [28:06] >> Well, I was going to 
+just mention too on [28:07] the on the grants. I I talked to to Dr. [28:10] Miss Barrett. We've 
+been we've been more [28:13] than blessed with grants. And when I [28:16] started seven years ago, 
+my biggest [28:18] concern was grant money runs out at some [28:22] point. [28:23] >> And then can 
+we maintain those positions [28:26] with our internal funding as the [28:28] legislators [28:30] 
+guidelines change that's going to become [28:31] tougher and tougher with the education [28:33] 
+fund. [28:34] >> But we've that that grant is from the [28:36] federal government. Correct. [28:37] 
+>> Correct. And I'm guessing there's a big [28:40] shortage of school psychologists is what [28:42] 
+they're trying to to backfill that. So [28:45] they're providing the funding for it. It [28:48] 
+takes them out of our education fund. [28:50] Correct. [28:50] >> Yes. [28:51] >> Including the 
+benefits and everything. [28:54] >> Teachers stay on the pay schedule. [28:56] >> Okay. [28:57] >> 
+They stay on turf. [28:58] >> Okay. And then in four years, like you [29:01] said, we're not we may 
+not need four [29:02] people. [29:03] >> We definitely will not need four. Need [29:06] is 
+definitely different than want. Mr. [29:08] Dixon would say, "I would want four [29:10] school 
+psychologists and I would want to [29:12] hire every single one of them." [29:14] >> Um the budget 
+says we cannot afford to [29:17] do that, [29:17] >> right? [29:18] >> Um we're already looking 
+ahead. Um we [29:20] have a school psychologist position open [29:22] right now. We don't have one 
+single [29:24] applicant for it. Um and this position [29:26] opened up back in [29:29] January, 
+February, [29:31] >> right? [29:32] >> We don't have have a person for this. So [29:34] we have two 
+school psychologists right [29:36] now trying to man our entire district [29:38] and so we are 
+paying contracted services [29:42] for [29:42] >> that's what I so but that'll come off of [29:44] 
+our that'll come off of our pay payroll [29:46] then the contract services correct [29:48] >> yeah 
+we have to use contracted services [29:50] we either use that through uh the [29:51] education fund 
+or through Medicaid one [29:55] or the other depending on on where we [29:57] are at that time um 
+so we already have a [30:00] need for a school psychologist Um, Karen [30:04] Nastrom is never 
+going to retire and I'm [30:06] just going to put that out into the [30:07] universe so that we 
+don't see any [30:10] retirement come from Karen Nastrom [30:12] anytime soon. Um, but I know that 
+she's [30:15] not going to be here forever. And I do [30:17] know that there will come a time 
+[30:19] probably here in the near future that [30:21] Karen will say, "I'm done." Probably [30:24] 
+when she's one of two school [30:25] psychologists in a district of almost [30:27] 2700 is when 
+she's gonna say, "I'm [30:29] done." But um we have a need. I know our [30:33] surrounding school 
+districts have a [30:35] need, right? [30:36] >> There will be jobs for these people. And [30:38] 
+the whole point of the grant was to um [30:42] have additional school psychologist in [30:45] the 
+field. [30:46] >> That's when we see these jobs pop up on [30:48] the federal grant side of things, 
+it's [30:50] because there's a need, right? [30:52] >> And so they start pouring money into [30:54] 
+that to get people licensed and get [30:56] people into these careers. [30:58] >> Okay. Yes. that 
+yeah, makes sense to me. [31:00] It's we're getting the advantage of it. [31:03] >> So, let's take 
+another education fund as [31:05] well. [31:14] >> Oh, eight of them internal. [31:20] >> I guess 
+that's a question. The four that [31:22] that you're recommending, are they [31:24] internal or was 
+one of those an external [31:26] maybe or two of them? I don't know. They [31:27] are all internal. 
+[31:29] >> Okay. [31:30] >> Um we also had [31:34] two external and we interviewed one of [31:37] 
+those external candidates. [31:39] >> Okay. So we had so we had six internal [31:41] and two 
+external then. [31:42] >> Correct. [31:43] >> Okay. [31:44] All right. Thank you. [31:46] >> You're 
+welcome. [31:49] >> These are our policies. We have [31:52] two choices to make and I'll leave it 
+up [31:54] to my colleagues to decide which choice [31:56] they want to do. We could um [31:60] 
+table those to the next meeting or we [32:03] could uh actually create those positions [32:09] 
+right now. The position of psychologists [32:12] in training, we wouldn't we don't [32:14] actually 
+approve job descriptions, but [32:16] we'd be creating it without looking at a [32:19] job 
+description. um based on what we've [32:21] heard tonight. Um so if you're [32:24] comfortable in 
+doing that, we could move [32:26] forward that way and then fill those [32:28] positions. Um or 
+again, we could table [32:33] those appointments until they bring the [32:36] position to us. 
+[32:38] >> Can I make a suggestion? Can we take the [32:41] job description that was in the 
+posting, [32:43] have Jennifer [32:45] uh go print it off and give the board [32:49] that job 
+description and approve that? [32:52] We've approved we've approved before the [32:56] job 
+description the same night we voted [32:58] the person in. We've done that before, [33:02] >> 
+right? [33:02] >> Yeah. that that that'll postpone us [33:05] because [33:06] >> these the 
+positions that are these folks [33:09] are leaving have to be advertised too [33:11] and we we have 
+another meeting in May so [33:13] it gives us a [33:14] >> correct [33:15] >> right but we're 
+making staffing [33:16] decisions now [33:18] >> correct I get it we need to know uh what [33:22] 
+positions are going to be available or [33:24] not [33:24] >> and they did post the position 
+[33:26] >> they did post it just wasn't created [33:27] >> yeah okay [33:29] >> all right [33:30] 
+>> that's created [33:32] Yeah. [33:33] >> Are you okay with creating it tonight? [33:35] >> Yeah, 
+that'd be great. [33:37] >> Um, [33:38] >> no, because I won't have time to look [33:40] through 
+the job description. [33:41] >> It's fairly short. Um, but I can do [33:43] either way. [33:44] >> 
+You okay with moving forward? [33:46] >> Okay. There's a general consensus that [33:49] we should 
+move forward. So, is there a [33:52] motion to create a position of [33:56] psychologist in 
+training? [33:59] >> I will move to create position school [34:02] psychologist and training. 
+[34:03] >> Yeah, I'll second. [34:04] >> Moved and seconded. Had lots of [34:06] discussion. Any 
+more discussion? [34:08] >> This is all funded through the grant for [34:10] four years [34:11] >> 
+100%. [34:12] >> And we start off with three, but the [34:13] budget allows us to do four across 
+the [34:15] board. [34:16] >> Yes. And and IU also made um they did [34:20] not want their 
+full-time school [34:22] psychologist uh to be employed by RBB. [34:26] They wanted to keep her 
+under the IU [34:28] umbrella. So they actually took her in [34:30] through contracted services 
+which [34:32] allowed us a little bit more of a [34:33] cushion there as well. [34:35] >> And 
+that's the one I can't say her name [34:37] starts with [34:37] >> it does Hannah Kasab [34:40] >> 
+she is she works with us now on the [34:42] smart grant. She will actually continue [34:44] on the 
+smart grant um about a third of [34:47] the time. She'll be working on the seeds [34:48] grant 
+about a third of the time. And she [34:51] received IE received another it's not [34:54] called 
+seeds but another school [34:56] psychologist grant in a neighboring [34:57] corporation. and 
+she'll be working in [34:59] that as well. [35:00] >> Okay. As an employee [35:02] >> as an 
+employee through contracted [35:04] services with all as an employee of IU [35:06] through 
+contracted services with all of [35:08] these schools. So the subawward [35:10] agreement that you 
+all approved last [35:12] month [35:13] part of that the funds that are going to [35:15] IU are 
+paying for Hannah's services to [35:18] us. [35:21] >> I'll just make two comments for the [35:23] 
+vote. one, please bring job descriptions [35:27] and positions to us first um so that we [35:31] 
+know what we're uh looking at. And two, [35:35] if a position like this comes up before, [35:39] I 
+think extra efforts need to be made in [35:42] getting that out there. um you know yes [35:45] 
+getting it posted you know Robin putting [35:47] out there but if I would have looked and [35:49] 
+saw psych psychologist in training as a [35:52] position [35:54] to me that's not going to sound 
+very [35:55] exciting uh honestly but if I found out [35:59] that wow that in training is going to 
+[36:02] get me a highle degree and it's going to [36:05] be paid for [36:06] >> and I'm going to 
+get my regular salary [36:10] >> and regular increases in salary while [36:13] all that's 
+happening. [36:14] >> Mhm. [36:15] >> That's a whole lot different. [36:17] >> So, I think a a 
+really [36:21] I hadn't heard anything about it until [36:23] till this. So, that's why I'm really 
+[36:26] surprised because I I do think there [36:30] would have been more applicants if they 
+[36:33] known what the benefits of being a [36:36] psychologist in training were. So, I [36:39] 
+would like it that when there's those [36:42] kind of extra benefits that extra [36:45] efforts be 
+made to make sure that the [36:48] word gets out there so people know. Um [36:52] because again the 
+the wording of what [36:54] the title of the position is not doesn't [36:57] look like it's very 
+much a high high [37:00] paying job or high fruitful job. So, [37:04] >> um any other comments? 
+[37:06] All those in favor say I. I [37:08] >> I opposed. Motion carries. Um now we're 

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/extra-category/corpus/extra.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/extra-category/corpus/extra.json
@@ -1,0 +1,23 @@
+{
+	"schema_version": 1,
+	"id": "extra",
+	"transcript_path": "transcripts/extra.txt",
+	"meeting_context": "Fixture with all 7 canonical categories plus a typo/extra category",
+	"graded_at": "2026-05-10",
+	"graded_by": "fixture",
+	"ground_truth": {
+		"category_scores": {
+			"procedural_breakdown": { "score": 0, "evidence_quotes": [] },
+			"question_looping": { "score": 0, "evidence_quotes": [] },
+			"defensive_hedging": { "score": 0, "evidence_quotes": [] },
+			"timeline_pressure": { "score": 0, "evidence_quotes": [] },
+			"improvised_workarounds": { "score": 0, "evidence_quotes": [] },
+			"visible_dissent": { "score": 0, "evidence_quotes": [] },
+			"post_hoc_corrections": { "score": 0, "evidence_quotes": [] },
+			"weather_disruption": { "score": 0, "evidence_quotes": [] }
+		},
+		"level": "routine",
+		"headline": "x",
+		"narrative": "x"
+	}
+}

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/extra-category/transcripts/extra.txt
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/extra-category/transcripts/extra.txt
@@ -1,0 +1,1 @@
+[00:00] placeholder

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/malformed/corpus/bad.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/malformed/corpus/bad.json
@@ -1,0 +1,1 @@
+{ "schema_version": 1, "id": "bad",

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-category/corpus/incomplete.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-category/corpus/incomplete.json
@@ -1,0 +1,21 @@
+{
+	"schema_version": 1,
+	"id": "incomplete",
+	"transcript_path": "transcripts/incomplete.txt",
+	"meeting_context": "Fixture missing post_hoc_corrections category",
+	"graded_at": "2026-05-02",
+	"graded_by": "fixture",
+	"ground_truth": {
+		"category_scores": {
+			"procedural_breakdown": { "score": 0, "evidence_quotes": [] },
+			"question_looping": { "score": 0, "evidence_quotes": [] },
+			"defensive_hedging": { "score": 0, "evidence_quotes": [] },
+			"timeline_pressure": { "score": 0, "evidence_quotes": [] },
+			"improvised_workarounds": { "score": 0, "evidence_quotes": [] },
+			"visible_dissent": { "score": 0, "evidence_quotes": [] }
+		},
+		"level": "routine",
+		"headline": "x",
+		"narrative": "x"
+	}
+}

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-category/transcripts/incomplete.txt
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-category/transcripts/incomplete.txt
@@ -1,0 +1,1 @@
+[00:00:00] placeholder

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-transcript/corpus/orphan.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/missing-transcript/corpus/orphan.json
@@ -1,0 +1,22 @@
+{
+	"schema_version": 1,
+	"id": "orphan",
+	"transcript_path": "transcripts/does-not-exist.txt",
+	"meeting_context": "Fixture pointing at nonexistent transcript",
+	"graded_at": "2026-05-02",
+	"graded_by": "fixture",
+	"ground_truth": {
+		"category_scores": {
+			"procedural_breakdown": { "score": 0, "evidence_quotes": [] },
+			"question_looping": { "score": 0, "evidence_quotes": [] },
+			"defensive_hedging": { "score": 0, "evidence_quotes": [] },
+			"timeline_pressure": { "score": 0, "evidence_quotes": [] },
+			"improvised_workarounds": { "score": 0, "evidence_quotes": [] },
+			"visible_dissent": { "score": 0, "evidence_quotes": [] },
+			"post_hoc_corrections": { "score": 0, "evidence_quotes": [] }
+		},
+		"level": "routine",
+		"headline": "x",
+		"narrative": "x"
+	}
+}

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/schema-version-mismatch/corpus/old.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/schema-version-mismatch/corpus/old.json
@@ -1,0 +1,22 @@
+{
+	"schema_version": 2,
+	"id": "old",
+	"transcript_path": "transcripts/old.txt",
+	"meeting_context": "Fixture with future schema_version",
+	"graded_at": "2026-05-02",
+	"graded_by": "fixture",
+	"ground_truth": {
+		"category_scores": {
+			"procedural_breakdown": { "score": 0, "evidence_quotes": [] },
+			"question_looping": { "score": 0, "evidence_quotes": [] },
+			"defensive_hedging": { "score": 0, "evidence_quotes": [] },
+			"timeline_pressure": { "score": 0, "evidence_quotes": [] },
+			"improvised_workarounds": { "score": 0, "evidence_quotes": [] },
+			"visible_dissent": { "score": 0, "evidence_quotes": [] },
+			"post_hoc_corrections": { "score": 0, "evidence_quotes": [] }
+		},
+		"level": "routine",
+		"headline": "x",
+		"narrative": "x"
+	}
+}

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/schema-version-mismatch/transcripts/old.txt
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/schema-version-mismatch/transcripts/old.txt
@@ -1,0 +1,1 @@
+[00:00:00] placeholder

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/valid/corpus/sample.json
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/valid/corpus/sample.json
@@ -1,0 +1,23 @@
+{
+	"schema_version": 1,
+	"id": "sample",
+	"transcript_path": "transcripts/sample.txt",
+	"meeting_context": "Fixture meeting, 2026-01-01, agenda approval",
+	"graded_at": "2026-05-02",
+	"graded_by": "fixture",
+	"ground_truth": {
+		"category_scores": {
+			"procedural_breakdown": { "score": 0, "evidence_quotes": [] },
+			"question_looping": { "score": 0, "evidence_quotes": [] },
+			"defensive_hedging": { "score": 0, "evidence_quotes": [] },
+			"timeline_pressure": { "score": 0, "evidence_quotes": [] },
+			"improvised_workarounds": { "score": 0, "evidence_quotes": [] },
+			"visible_dissent": { "score": 0, "evidence_quotes": [] },
+			"post_hoc_corrections": { "score": 0, "evidence_quotes": [] }
+		},
+		"level": "routine",
+		"headline": "Routine agenda approval",
+		"narrative": "Standard motion-second-vote pattern, no friction observed.",
+		"notes": ""
+	}
+}

--- a/src/pipeline/scripts/evals/__fixtures__/corpus-loader/valid/transcripts/sample.txt
+++ b/src/pipeline/scripts/evals/__fixtures__/corpus-loader/valid/transcripts/sample.txt
@@ -1,0 +1,4 @@
+[00:00:00] Chair: Let's call the meeting to order.
+[00:00:05] Member A: I move we approve the agenda as presented.
+[00:00:08] Member B: Second.
+[00:00:10] Chair: All in favor? Motion carries.

--- a/src/pipeline/scripts/evals/corpus-loader.test.ts
+++ b/src/pipeline/scripts/evals/corpus-loader.test.ts
@@ -55,6 +55,19 @@ describe("loadCorpus", () => {
 		}
 	});
 
+	it("rejects a corpus entry with a non-canonical extra category key", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadCorpus(fixtureCorpusDir("extra-category")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("CorpusLoadError");
+			expect(err).toContain("weather_disruption");
+		}
+	});
+
 	it("rejects malformed JSON with a useful error", async () => {
 		const exit = await Effect.runPromiseExit(
 			loadCorpus(fixtureCorpusDir("malformed")),

--- a/src/pipeline/scripts/evals/corpus-loader.test.ts
+++ b/src/pipeline/scripts/evals/corpus-loader.test.ts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from "node:url";
+import { Effect } from "effect";
+import { describe, expect, it } from "vitest";
+import { loadCorpus } from "#/pipeline/scripts/evals/corpus-loader.ts";
+
+const fixtureCorpusDir = (sub: string): string =>
+	fileURLToPath(
+		new URL(`./__fixtures__/corpus-loader/${sub}/corpus`, import.meta.url),
+	);
+
+describe("loadCorpus", () => {
+	it("loads a valid corpus entry with transcriptText resolved from disk", async () => {
+		const result = await Effect.runPromise(
+			loadCorpus(fixtureCorpusDir("valid")),
+		);
+
+		expect(result).toHaveLength(1);
+		const entry = result[0];
+		expect(entry.id).toBe("sample");
+		expect(entry.schema_version).toBe(1);
+		expect(entry.ground_truth.level).toBe("routine");
+		expect(entry.ground_truth.category_scores.procedural_breakdown.score).toBe(
+			0,
+		);
+		expect(entry.transcriptText).toContain("Let's call the meeting to order");
+		expect(entry.sourcePath).toMatch(/valid\/corpus\/sample\.json$/);
+	});
+});

--- a/src/pipeline/scripts/evals/corpus-loader.test.ts
+++ b/src/pipeline/scripts/evals/corpus-loader.test.ts
@@ -1,7 +1,10 @@
 import { fileURLToPath } from "node:url";
-import { Effect } from "effect";
+import { Effect, Exit } from "effect";
 import { describe, expect, it } from "vitest";
-import { loadCorpus } from "#/pipeline/scripts/evals/corpus-loader.ts";
+import {
+	CorpusLoadError,
+	loadCorpus,
+} from "#/pipeline/scripts/evals/corpus-loader.ts";
 
 const fixtureCorpusDir = (sub: string): string =>
 	fileURLToPath(
@@ -24,5 +27,74 @@ describe("loadCorpus", () => {
 		);
 		expect(entry.transcriptText).toContain("Let's call the meeting to order");
 		expect(entry.sourcePath).toMatch(/valid\/corpus\/sample\.json$/);
+	});
+
+	it("rejects a corpus entry whose transcript file is missing", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadCorpus(fixtureCorpusDir("missing-transcript")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("CorpusLoadError");
+			expect(err).toContain("transcript file not found");
+		}
+	});
+
+	it("rejects a corpus entry missing one of the 7 canonical category keys", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadCorpus(fixtureCorpusDir("missing-category")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("CorpusLoadError");
+			expect(err).toContain("post_hoc_corrections");
+		}
+	});
+
+	it("rejects malformed JSON with a useful error", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadCorpus(fixtureCorpusDir("malformed")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			const err = exit.cause.toString();
+			expect(err).toContain("CorpusLoadError");
+			expect(err).toContain("malformed JSON");
+		}
+	});
+
+	it("rejects a corpus entry with a non-1 schema_version", async () => {
+		const exit = await Effect.runPromiseExit(
+			loadCorpus(fixtureCorpusDir("schema-version-mismatch")),
+		);
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(exit.cause.toString()).toContain("CorpusLoadError");
+		}
+	});
+
+	it("rejects a non-existent corpus directory", async () => {
+		const missingDir = fileURLToPath(
+			new URL("./__fixtures__/corpus-loader/does-not-exist", import.meta.url),
+		);
+		const exit = await Effect.runPromiseExit(loadCorpus(missingDir));
+
+		expect(Exit.isFailure(exit)).toBe(true);
+		if (Exit.isFailure(exit)) {
+			expect(exit.cause.toString()).toContain("CorpusLoadError");
+		}
+	});
+
+	it("CorpusLoadError is a tagged error", () => {
+		const err = new CorpusLoadError({ message: "x", path: "y" });
+		expect(err._tag).toBe("CorpusLoadError");
+		expect(err.message).toBe("x");
+		expect(err.path).toBe("y");
 	});
 });

--- a/src/pipeline/scripts/evals/corpus-loader.ts
+++ b/src/pipeline/scripts/evals/corpus-loader.ts
@@ -1,0 +1,128 @@
+import { readdir, readFile } from "node:fs/promises";
+import * as path from "node:path";
+import { Data, Effect } from "effect";
+import { z } from "zod";
+import {
+	DRAMA_CATEGORIES,
+	DRAMA_LEVELS,
+	type DramaCategory,
+	type DramaLevel,
+} from "#/lib/drama-levels.ts";
+
+class CorpusLoadError extends Data.TaggedError("CorpusLoadError")<{
+	readonly message: string;
+	readonly path: string;
+}> {}
+
+const CategoryScoreSchema = z.object({
+	score: z.number().int().min(0).max(3),
+	evidence_quotes: z.array(z.string()),
+});
+
+const CategoryScoresSchema = z.object(
+	Object.fromEntries(
+		DRAMA_CATEGORIES.map((c) => [c, CategoryScoreSchema]),
+	) as Record<DramaCategory, typeof CategoryScoreSchema>,
+);
+
+const CorpusEntrySchema = z.object({
+	schema_version: z.literal(1),
+	id: z.string().min(1),
+	transcript_path: z.string().min(1),
+	meeting_context: z.string(),
+	graded_at: z.string(),
+	graded_by: z.string(),
+	ground_truth: z.object({
+		category_scores: CategoryScoresSchema,
+		level: z.enum(DRAMA_LEVELS as readonly [DramaLevel, ...DramaLevel[]]),
+		headline: z.string(),
+		narrative: z.string(),
+		notes: z.string().optional(),
+	}),
+});
+
+type CorpusEntry = z.infer<typeof CorpusEntrySchema>;
+
+type LoadedCorpusEntry = CorpusEntry & {
+	readonly sourcePath: string;
+	readonly transcriptText: string;
+};
+
+function listCorpusFiles(
+	dir: string,
+): Effect.Effect<readonly string[], CorpusLoadError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const entries = await readdir(dir, { withFileTypes: true });
+			return entries
+				.filter((e) => e.isFile() && e.name.endsWith(".json"))
+				.map((e) => path.join(dir, e.name))
+				.sort();
+		},
+		catch: (error) =>
+			new CorpusLoadError({
+				path: dir,
+				message: `failed to read corpus directory: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			}),
+	});
+}
+
+function loadCorpusEntry(
+	filePath: string,
+	corpusDir: string,
+): Effect.Effect<LoadedCorpusEntry, CorpusLoadError> {
+	return Effect.tryPromise({
+		try: async () => {
+			const raw = await readFile(filePath, "utf8");
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(raw);
+			} catch (e) {
+				throw new Error(
+					`malformed JSON: ${e instanceof Error ? e.message : String(e)}`,
+				);
+			}
+			const result = CorpusEntrySchema.safeParse(parsed);
+			if (!result.success) {
+				throw new Error(`schema validation failed: ${result.error.message}`);
+			}
+			const entry = result.data;
+			const transcriptResolved = path.resolve(
+				path.dirname(corpusDir),
+				entry.transcript_path,
+			);
+			let transcriptText: string;
+			try {
+				transcriptText = await readFile(transcriptResolved, "utf8");
+			} catch (e) {
+				throw new Error(
+					`transcript file not found at ${transcriptResolved}: ${
+						e instanceof Error ? e.message : String(e)
+					}`,
+				);
+			}
+			return { ...entry, sourcePath: filePath, transcriptText };
+		},
+		catch: (error) =>
+			new CorpusLoadError({
+				path: filePath,
+				message: error instanceof Error ? error.message : String(error),
+			}),
+	});
+}
+
+const DEFAULT_CORPUS_DIR = path.resolve(process.cwd(), "evals/corpus");
+
+function loadCorpus(
+	dir: string = DEFAULT_CORPUS_DIR,
+): Effect.Effect<readonly LoadedCorpusEntry[], CorpusLoadError> {
+	return Effect.gen(function* () {
+		const files = yield* listCorpusFiles(dir);
+		return yield* Effect.all(files.map((f) => loadCorpusEntry(f, dir)));
+	});
+}
+
+export { loadCorpus, CorpusLoadError };
+export type { LoadedCorpusEntry };

--- a/src/pipeline/scripts/evals/corpus-loader.ts
+++ b/src/pipeline/scripts/evals/corpus-loader.ts
@@ -19,11 +19,13 @@ const CategoryScoreSchema = z.object({
 	evidence_quotes: z.array(z.string()),
 });
 
-const CategoryScoresSchema = z.object(
-	Object.fromEntries(
-		DRAMA_CATEGORIES.map((c) => [c, CategoryScoreSchema]),
-	) as Record<DramaCategory, typeof CategoryScoreSchema>,
-);
+const CategoryScoresSchema = z
+	.object(
+		Object.fromEntries(
+			DRAMA_CATEGORIES.map((c) => [c, CategoryScoreSchema]),
+		) as Record<DramaCategory, typeof CategoryScoreSchema>,
+	)
+	.strict();
 
 const CorpusEntrySchema = z.object({
 	schema_version: z.literal(1),


### PR DESCRIPTION
## Summary

Stands up the loader the eval harness's pre-flight gate leans on, and lands the first hand-graded ground-truth entry the harness will measure prompt versions against.

`src/pipeline/scripts/evals/corpus-loader.ts` is an Effect-native loader that walks `evals/corpus/*.json`, validates each entry against a Zod schema bound to the canonical 7-category list (`DRAMA_CATEGORIES` from `src/lib/drama-levels.ts`), resolves the entry's `transcript_path` against the corpus directory's parent, reads the transcript file from disk, and returns `LoadedCorpusEntry[]` with `transcriptText` already populated. Every documented failure mode — missing transcript file, missing canonical category key, malformed JSON, `schema_version != 1`, missing directory — fails fast with a single tagged `CorpusLoadError`, mirroring the shape of the profile-loader from slice 1 so the runner can pattern-match both with one `Effect.catchTag` later. The schema is closed: scores are integers in `[0..3]`, `level` is constrained to `DRAMA_LEVELS`, and the seven category keys are required. Tests are fixture-driven (`__fixtures__/corpus-loader/`) so each rejection mode owns its minimal failing case rather than mutating one shared fixture.

`evals/transcripts/rbb-hiring.txt` is a ~15-min clip (22:01–37:08) of the RBB School Board 2026-04-21 regular meeting, covering the school-psychologist-in-training discussion through the single-dissent vote. The clip is converted from YouTube auto-caption format into the inline `[MM:SS]` whisper format the production transcript pipeline emits, so the harness sees the same shape Gemini will see in production.

`evals/corpus/rbb-hiring.json` is the hand-graded ground truth. The clip captures the rubric's namesake pattern — sustained objection on a ratified item, with a single audible "I opposed" — and grades to a category sum of 17 (`procedural_breakdown` 3, `question_looping` 3, `defensive_hedging` 2, `timeline_pressure` 2, `improvised_workarounds` 3, `visible_dissent` 3, `post_hoc_corrections` 1), which `mapSumToLevel` resolves to `off-the-rails`. The `notes` field captures the judgment calls that aren't visible from the scores alone — most importantly why `defensive_hedging` is held at 2 (the administrator's answers are mostly substantive even when the questioner dismisses them) and why `visible_dissent` is held at 3 not higher (no roll-call, no walk-out — the dissenter delivers two for-the-record statements then casts a single audible "I opposed").

This is slice 2 of PRD #66 and is parallel-safe with slice 1 (#67) — the only intra-repo consume is `DRAMA_CATEGORIES` / `DRAMA_LEVELS` / `mapSumToLevel` from `src/lib/drama-levels.ts`, which has been on `prod` since the first drama-watch slice. The runner (slice #70) will compose this loader and the profile-loader at the top of every `evals:run` so quota burn never reaches a corpus entry that imports cleanly but ships missing data.

## PRD

Refs #66

## Slices

- [x] #67 — profile extraction + production rewire (tracer bullet)
- [x] #68 — corpus authoring + corpus loader (RBB hiring) ← this PR
- [ ] #69 — pure agreement + report modules
- [ ] #70 — runner + `evals:run` CLI subcommand
- [ ] #71 — QA: real-API smoke + acceptance verification

## Key Decisions

- **`transcript_path` resolves against the corpus directory's parent.** The PRD's example schema uses `"transcripts/rbb-hiring.txt"` and pairs `evals/corpus/` with `evals/transcripts/`. `path.resolve(path.dirname(corpusDir), entry.transcript_path)` keeps the JSON portable and avoids forcing absolute paths into the corpus.
- **`biome.json` excludes the `__fixtures__/corpus-loader/malformed/**` subtree.** The malformed-JSON rejection test relies on a fixture biome's parser refuses to accept; rather than rename or escape it, the formatter's `includes` simply skips that one subtree.
- **Inline-timestamp transcript format.** The downloaded YouTube auto-caption format (`MM:SS prefix per line`) was converted to the production whisper format (`[MM:SS] inline`) so the harness sees the same transcript shape Gemini sees in production. Future corpus entries should use the same `awk` conversion.