### PR TITLE
[drama-eval] Slice 3: pure agreement + report modules (#69)

### DIFF
--- a/src/pipeline/scripts/evals/__fixtures__/report/REPORT.golden.csv
+++ b/src/pipeline/scripts/evals/__fixtures__/report/REPORT.golden.csv
@@ -1,0 +1,3 @@
+profile,transcript,gt_tier,tier_mode,tier_min,tier_max,sigma,total_category_mae,drift_event_count,otr_boundary_drift_count,empty_output_count,tier_match_count,trials_counted,trials_excluded,promote
+v1,rbb-hiring,off-the-rails,off-the-rails,off-the-rails,off-the-rails,0,0,0,0,0,3,3,0,true
+v2,rbb-hiring,off-the-rails,heated,bumpy,off-the-rails,3.09,4.5,1,1,0,1,3,0,false

--- a/src/pipeline/scripts/evals/__fixtures__/report/REPORT.golden.md
+++ b/src/pipeline/scripts/evals/__fixtures__/report/REPORT.golden.md
@@ -1,0 +1,26 @@
+# Drama Eval Report — test-run-2026-05-10
+
+| Field | Value |
+| --- | --- |
+| Started | 2026-05-10T12:00:00.000Z |
+| Completed | 2026-05-10T12:15:00.000Z |
+| Model | gemini-2.5-flash |
+| Profiles | v1, v2 |
+| Transcripts | rbb-hiring |
+| Prod profile | v1 |
+
+## Promotion Criteria
+
+A profile may replace the production prompt iff, across ≥3 trials per transcript:
+
+- Tier match in ≥ 67% of trials (`minTierMatchFraction = 2/3`)
+- Total category MAE ≤ prod profile MAE (`maeComparator = <=prod`)
+- Zero empty-output trials (`maxEmptyOutputs = 0`)
+- No drift events crossing the off-the-rails boundary (`maxOffTheRailsBoundaryDrift = 0`)
+
+## Cells
+
+| Profile | Transcript | GT Tier | Tier Mode | Tier Range | σ | MAE | Drift | OTR Drift | Empty | Tier Match | Trials | Promote? |
+| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | :---: | :---: | :---: |
+| v1 | rbb-hiring | Off the Rails | Off the Rails | Off the Rails | 0.00 | 0.00 | 0 | 0 | 0 | 3/3 | 3/3 | ✓ |
+| v2 | rbb-hiring | Off the Rails | Heated | Bumpy–Off the Rails | 3.09 | 4.50 | 1 | 1 | 0 | 1/3 | 3/3 | ✗ |

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -321,6 +321,61 @@ describe("computeTrialSummary", () => {
 		expect(summary.sigma).toBeNull();
 		expect(summary.totalCategoryMae).toBeNull();
 		expect(summary.driftEventCount).toBe(0);
+		expect(summary.tierMatchCount).toBe(0);
+		// Ground-truth tier is still computed from corpus scores even when
+		// no trial data is usable.
+		expect(summary.groundTruthTier).toBe("heated");
+	});
+
+	it("recomputes groundTruthTier from corpus scores, ignoring corpus level", () => {
+		// Corpus level says "routine" but scores sum to 18 → off-the-rails
+		const gt = buildGroundTruth(scoresForSum(18), "routine");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+		];
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.groundTruthTier).toBe("off-the-rails");
+		// All 1 trial matches recomputed GT tier
+		expect(summary.tierMatchCount).toBe(1);
+	});
+
+	it("tierMatchCount counts only trials whose mechanical tier equals groundTruthTier", () => {
+		// GT scores sum to 12 → heated
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				// sum=11 → bumpy, doesn't match GT heated
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(13, "heated"),
+			}),
+		];
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.groundTruthTier).toBe("heated");
+		expect(summary.tierMatchCount).toBe(2);
+		expect(summary.trialsCounted).toBe(3);
+		// 2/3 ≥ 2/3 → meets PROMOTION_CRITERIA.minTierMatchFraction
+		expect(
+			summary.tierMatchCount / summary.trialsCounted,
+		).toBeGreaterThanOrEqual(PROMOTION_CRITERIA.minTierMatchFraction);
 	});
 
 	it("counts drift events from trial assessments", () => {

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -5,6 +5,7 @@ import {
 	type AgreementSummary,
 	computeTrialSummary,
 	detectDriftEvent,
+	type EvaluatedSummary,
 	PROMOTION_CRITERIA,
 	type TrialResult,
 } from "#/pipeline/scripts/evals/agreement.ts";
@@ -52,6 +53,20 @@ function buildTrial(
 		durationMs: 1000,
 		...overrides,
 	};
+}
+
+/**
+ * Assertion helper: most tests below expect a fully-evaluated cell, and
+ * the discriminated-union shape requires narrowing before metrics can be
+ * read. This converts the runtime check + narrowing into a one-liner so
+ * each test stays focused on its assertion subject.
+ */
+function expectEvaluated(
+	summary: AgreementSummary,
+): asserts summary is EvaluatedSummary {
+	if (summary.kind !== "evaluated") {
+		throw new Error(`expected evaluated summary, got ${summary.kind}`);
+	}
 }
 
 function buildGroundTruth(
@@ -148,6 +163,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		// The fields that *would* be wrong if the impl read gt.level: groundTruthTier
 		// is the recomputed tier, and tierMatchCount counts trials whose mechanical
 		// tier equals groundTruthTier. If the impl read gt.level, both would
@@ -180,6 +196,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.tierMode).toBe("off-the-rails");
 		expect(summary.tierMin).toBe("bumpy");
 		expect(summary.tierMax).toBe("off-the-rails");
@@ -218,6 +235,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.tierMode).toBe("heated");
 	});
 
@@ -268,6 +286,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		// Mean of [7, 14] per-trial absolute error sums = 10.5
 		expect(summary.totalCategoryMae).toBe(10.5);
 	});
@@ -296,6 +315,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.trialsCounted).toBe(2);
 		expect(summary.trialsExcluded).toBe(1);
 		expect(summary.emptyOutputCount).toBe(1);
@@ -305,7 +325,7 @@ describe("computeTrialSummary", () => {
 		expect(summary.sigma).toBe(0);
 	});
 
-	it("produces null metrics when every trial is empty_output", () => {
+	it("produces a no-evidence summary when every trial is empty_output", () => {
 		const gt = buildGroundTruth(scoresForSum(12), "heated");
 		const trials: TrialResult[] = [
 			buildTrial({ profile, transcriptId, trial: 1, status: "empty_output" }),
@@ -314,18 +334,13 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
-		expect(summary.trialsCounted).toBe(0);
+		expect(summary.kind).toBe("no-evidence");
+		if (summary.kind !== "no-evidence") return;
 		expect(summary.trialsExcluded).toBe(3);
 		expect(summary.emptyOutputCount).toBe(3);
-		expect(summary.tierMode).toBeNull();
-		expect(summary.tierMin).toBeNull();
-		expect(summary.tierMax).toBeNull();
-		expect(summary.sigma).toBeNull();
-		expect(summary.totalCategoryMae).toBeNull();
-		expect(summary.driftEventCount).toBe(0);
-		expect(summary.tierMatchCount).toBe(0);
 		// Ground-truth tier is still computed from corpus scores even when
-		// no trial data is usable.
+		// no trial data is usable — the report uses it to show what the
+		// model *should* have said.
 		expect(summary.groundTruthTier).toBe("heated");
 	});
 
@@ -341,6 +356,7 @@ describe("computeTrialSummary", () => {
 			}),
 		];
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.groundTruthTier).toBe("off-the-rails");
 		// All 1 trial matches recomputed GT tier
 		expect(summary.tierMatchCount).toBe(1);
@@ -371,6 +387,7 @@ describe("computeTrialSummary", () => {
 			}),
 		];
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.groundTruthTier).toBe("heated");
 		expect(summary.tierMatchCount).toBe(2);
 		expect(summary.trialsCounted).toBe(3);
@@ -406,6 +423,7 @@ describe("computeTrialSummary", () => {
 			}),
 		];
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.driftEventCount).toBe(3);
 		expect(summary.offTheRailsBoundaryDriftCount).toBe(2);
 	});
@@ -437,6 +455,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.driftEventCount).toBe(2);
 	});
 
@@ -468,8 +487,8 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
-		expect(summary.sigma).not.toBeNull();
-		expect(summary.sigma as number).toBeCloseTo(3.0912, 3);
+		expectEvaluated(summary);
+		expect(summary.sigma).toBeCloseTo(3.0912, 3);
 	});
 
 	it("returns sigma=0 for a single ok trial (N=1 still defined)", () => {
@@ -482,7 +501,8 @@ describe("computeTrialSummary", () => {
 				assessment: buildAssessment(12, "heated"),
 			}),
 		];
-		const summary: AgreementSummary = computeTrialSummary(trials, gt);
+		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.sigma).toBe(0);
 	});
 
@@ -498,6 +518,7 @@ describe("computeTrialSummary", () => {
 			buildTrial({ profile, transcriptId, trial: 2, status: "error" }),
 		];
 		const summary = computeTrialSummary(trials, gt);
+		expectEvaluated(summary);
 		expect(summary.trialsCounted).toBe(1);
 		expect(summary.trialsExcluded).toBe(1);
 		// emptyOutputCount counts only `empty_output` status, not `error`

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -148,10 +148,12 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
-		// If the function read gt.level it would conclude tier=routine vs trial-tier=off-the-rails
-		// → MAE on tier would be huge; in fact the trial scores match gt scores so MAE is 0.
-		expect(summary.totalCategoryMae).toBe(0);
-		expect(summary.tierMode).toBe("off-the-rails");
+		// The fields that *would* be wrong if the impl read gt.level: groundTruthTier
+		// is the recomputed tier, and tierMatchCount counts trials whose mechanical
+		// tier equals groundTruthTier. If the impl read gt.level, both would
+		// disagree with the trials' tier (tier-match=0 instead of 3).
+		expect(summary.groundTruthTier).toBe("off-the-rails");
+		expect(summary.tierMatchCount).toBe(3);
 	});
 
 	it("computes tier mode/min/max across N=3 ok trials", () => {

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -1,0 +1,432 @@
+import { describe, expect, it } from "vitest";
+import type { DramaLevel } from "#/lib/drama-levels.ts";
+import { DRAMA_CATEGORIES } from "#/lib/drama-levels.ts";
+import {
+	type AgreementSummary,
+	computeTrialSummary,
+	detectDriftEvent,
+	PROMOTION_CRITERIA,
+	type TrialResult,
+} from "#/pipeline/scripts/evals/agreement.ts";
+import type { LoadedCorpusEntry } from "#/pipeline/scripts/evals/corpus-loader.ts";
+import type { DramaAssessmentOutput } from "#/pipeline/services/DramaDetectionService.ts";
+
+/**
+ * Build a `category_scores` object that places `sum` worth of score evenly
+ * across the 7 categories. With 7 categories scored 0–3 (max sum = 21), this
+ * lets a test fix the sum exactly without caring how it's distributed.
+ */
+function scoresForSum(sum: number): DramaAssessmentOutput["category_scores"] {
+	const result = {} as DramaAssessmentOutput["category_scores"];
+	let remaining = sum;
+	for (const cat of DRAMA_CATEGORIES) {
+		const score = Math.min(3, remaining);
+		result[cat] = { score, evidence_quotes: [] };
+		remaining -= score;
+	}
+	return result;
+}
+
+function buildAssessment(
+	sum: number,
+	level: DramaLevel,
+): DramaAssessmentOutput {
+	return {
+		category_scores: scoresForSum(sum),
+		level,
+		confidence: 0.8,
+		headline: "test",
+		narrative: "test narrative",
+	};
+}
+
+function buildTrial(
+	overrides: Partial<TrialResult> & {
+		profile: string;
+		transcriptId: string;
+		trial: number;
+	},
+): TrialResult {
+	return {
+		status: "ok",
+		durationMs: 1000,
+		...overrides,
+	};
+}
+
+function buildGroundTruth(
+	scores: DramaAssessmentOutput["category_scores"],
+	level: DramaLevel,
+): LoadedCorpusEntry {
+	return {
+		schema_version: 1,
+		id: "test-corpus",
+		transcript_path: "transcripts/test.txt",
+		meeting_context: "test",
+		graded_at: "2026-05-10",
+		graded_by: "test",
+		ground_truth: {
+			category_scores: scores,
+			level,
+			headline: "gt headline",
+			narrative: "gt narrative",
+		},
+		sourcePath: "/tmp/corpus/test.json",
+		transcriptText: "fake transcript",
+	};
+}
+
+describe("detectDriftEvent", () => {
+	it("returns null when LLM-emitted level matches mapSumToLevel(sum)", () => {
+		// sum=18 → off-the-rails (≥17), LLM agrees
+		const assessment = buildAssessment(18, "off-the-rails");
+		expect(detectDriftEvent(assessment)).toBeNull();
+	});
+
+	it("returns null when LLM-emitted level matches at every tier boundary", () => {
+		expect(detectDriftEvent(buildAssessment(0, "routine"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(5, "routine"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(6, "bumpy"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(11, "bumpy"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(12, "heated"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(16, "heated"))).toBeNull();
+		expect(detectDriftEvent(buildAssessment(17, "off-the-rails"))).toBeNull();
+	});
+
+	it("returns a DriftEvent when LLM emits a tier inconsistent with sum", () => {
+		// sum=11 → bumpy mechanically; LLM said "heated"
+		const assessment = buildAssessment(11, "heated");
+		const drift = detectDriftEvent(assessment);
+		expect(drift).toEqual({
+			type: "level_override",
+			llmEmitted: "heated",
+			computed: "bumpy",
+			sum: 11,
+		});
+	});
+
+	it("returns a DriftEvent across the off-the-rails boundary", () => {
+		// sum=18 → off-the-rails; LLM said "heated" (under-call)
+		const assessment = buildAssessment(18, "heated");
+		expect(detectDriftEvent(assessment)).toEqual({
+			type: "level_override",
+			llmEmitted: "heated",
+			computed: "off-the-rails",
+			sum: 18,
+		});
+	});
+});
+
+describe("computeTrialSummary", () => {
+	const profile = "v1";
+	const transcriptId = "rbb-hiring";
+
+	it("recomputes ground-truth tier from category_scores, never reading groundTruth.level", () => {
+		// Ground truth has level="routine" (wrong) but scores sum to 18 → off-the-rails
+		const gt = buildGroundTruth(scoresForSum(18), "routine");
+
+		// All trials emit off-the-rails (matching the *mechanical* gt tier)
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		// If the function read gt.level it would conclude tier=routine vs trial-tier=off-the-rails
+		// → MAE on tier would be huge; in fact the trial scores match gt scores so MAE is 0.
+		expect(summary.totalCategoryMae).toBe(0);
+		expect(summary.tierMode).toBe("off-the-rails");
+	});
+
+	it("computes tier mode/min/max across N=3 ok trials", () => {
+		const gt = buildGroundTruth(scoresForSum(18), "off-the-rails");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.tierMode).toBe("off-the-rails");
+		expect(summary.tierMin).toBe("bumpy");
+		expect(summary.tierMax).toBe("off-the-rails");
+		expect(summary.trialsCounted).toBe(3);
+		expect(summary.trialsExcluded).toBe(0);
+	});
+
+	it("breaks bimodal tier-mode ties deterministically (higher tier wins)", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		// Two heated, two bumpy → tied. Per locked tiebreak, higher tier (heated) wins.
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 4,
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.tierMode).toBe("heated");
+	});
+
+	it("computes total category MAE on partial agreement", () => {
+		// Build ground truth with score=2 in every category (sum=14 → heated)
+		const gtScores = {} as DramaAssessmentOutput["category_scores"];
+		for (const cat of DRAMA_CATEGORIES) {
+			gtScores[cat] = { score: 2, evidence_quotes: [] };
+		}
+		const gt = buildGroundTruth(gtScores, "heated");
+
+		// Trial 1: score=3 in every category → |3-2| × 7 = 7 absolute error
+		const trialScores1 = {} as DramaAssessmentOutput["category_scores"];
+		for (const cat of DRAMA_CATEGORIES) {
+			trialScores1[cat] = { score: 3, evidence_quotes: [] };
+		}
+		// Trial 2: score=0 in every category → |0-2| × 7 = 14 absolute error
+		const trialScores2 = {} as DramaAssessmentOutput["category_scores"];
+		for (const cat of DRAMA_CATEGORIES) {
+			trialScores2[cat] = { score: 0, evidence_quotes: [] };
+		}
+
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: {
+					category_scores: trialScores1,
+					level: "off-the-rails",
+					confidence: 0.9,
+					headline: "h",
+					narrative: "n",
+				},
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				assessment: {
+					category_scores: trialScores2,
+					level: "routine",
+					confidence: 0.9,
+					headline: "h",
+					narrative: "n",
+				},
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		// Mean of [7, 14] per-trial absolute error sums = 10.5
+		expect(summary.totalCategoryMae).toBe(10.5);
+	});
+
+	it("excludes empty_output trials from numeric aggregates and counts them separately", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				status: "empty_output",
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(12, "heated"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.trialsCounted).toBe(2);
+		expect(summary.trialsExcluded).toBe(1);
+		expect(summary.emptyOutputCount).toBe(1);
+		// Numeric aggregates use only the 2 ok trials
+		expect(summary.tierMode).toBe("heated");
+		expect(summary.totalCategoryMae).toBe(0);
+		expect(summary.sigma).toBe(0);
+	});
+
+	it("produces null metrics when every trial is empty_output", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		const trials: TrialResult[] = [
+			buildTrial({ profile, transcriptId, trial: 1, status: "empty_output" }),
+			buildTrial({ profile, transcriptId, trial: 2, status: "empty_output" }),
+			buildTrial({ profile, transcriptId, trial: 3, status: "empty_output" }),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.trialsCounted).toBe(0);
+		expect(summary.trialsExcluded).toBe(3);
+		expect(summary.emptyOutputCount).toBe(3);
+		expect(summary.tierMode).toBeNull();
+		expect(summary.tierMin).toBeNull();
+		expect(summary.tierMax).toBeNull();
+		expect(summary.sigma).toBeNull();
+		expect(summary.totalCategoryMae).toBeNull();
+		expect(summary.driftEventCount).toBe(0);
+	});
+
+	it("counts drift events from trial assessments", () => {
+		const gt = buildGroundTruth(scoresForSum(11), "bumpy");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				// LLM said heated, sum=11 → bumpy: drift
+				assessment: buildAssessment(11, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				// LLM said bumpy, sum=11 → bumpy: no drift
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				// LLM said routine, sum=11 → bumpy: drift
+				assessment: buildAssessment(11, "routine"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.driftEventCount).toBe(2);
+	});
+
+	it("computes population sigma of category-score sums across ok trials", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		// Sums: 11, 12, 18 → mean = 41/3 ≈ 13.667
+		// Population variance = ((11-13.667)² + (12-13.667)² + (18-13.667)²) / 3
+		//                     = (7.111 + 2.778 + 18.778) / 3 = 28.667 / 3 ≈ 9.556
+		// σ ≈ 3.0912
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(11, "bumpy"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				assessment: buildAssessment(18, "off-the-rails"),
+			}),
+		];
+
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.sigma).not.toBeNull();
+		expect(summary.sigma as number).toBeCloseTo(3.0912, 3);
+	});
+
+	it("returns sigma=0 for a single ok trial (N=1 still defined)", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(12, "heated"),
+			}),
+		];
+		const summary: AgreementSummary = computeTrialSummary(trials, gt);
+		expect(summary.sigma).toBe(0);
+	});
+
+	it("treats `error`-status trials the same as empty for exclusion", () => {
+		const gt = buildGroundTruth(scoresForSum(12), "heated");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				assessment: buildAssessment(12, "heated"),
+			}),
+			buildTrial({ profile, transcriptId, trial: 2, status: "error" }),
+		];
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.trialsCounted).toBe(1);
+		expect(summary.trialsExcluded).toBe(1);
+		// emptyOutputCount counts only `empty_output` status, not `error`
+		expect(summary.emptyOutputCount).toBe(0);
+	});
+});
+
+describe("PROMOTION_CRITERIA", () => {
+	it("locks the four documented thresholds in a single revisable place", () => {
+		expect(PROMOTION_CRITERIA.minTierMatchFraction).toBeCloseTo(2 / 3, 5);
+		expect(PROMOTION_CRITERIA.maxEmptyOutputs).toBe(0);
+		// "No off-the-rails-boundary drift" means: zero drift events that
+		// cross the off-the-rails boundary in either direction.
+		expect(PROMOTION_CRITERIA.maxOffTheRailsBoundaryDrift).toBe(0);
+		// MAE threshold is set per-run against the prod profile baseline,
+		// so the constant only fixes the comparator (≤), not a number.
+		expect(PROMOTION_CRITERIA.maeComparator).toBe("<=prod");
+	});
+});

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -378,6 +378,36 @@ describe("computeTrialSummary", () => {
 		).toBeGreaterThanOrEqual(PROMOTION_CRITERIA.minTierMatchFraction);
 	});
 
+	it("counts off-the-rails-boundary drift events as a distinct subset of total drift", () => {
+		const gt = buildGroundTruth(scoresForSum(18), "off-the-rails");
+		const trials: TrialResult[] = [
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 1,
+				// LLM said "heated" (not OTR), sum=18 → OTR. CROSSES boundary.
+				assessment: buildAssessment(18, "heated"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 2,
+				// LLM said "off-the-rails", sum=11 → bumpy. CROSSES boundary other way.
+				assessment: buildAssessment(11, "off-the-rails"),
+			}),
+			buildTrial({
+				profile,
+				transcriptId,
+				trial: 3,
+				// LLM said "heated", sum=11 → bumpy. Drift, but does NOT cross OTR boundary.
+				assessment: buildAssessment(11, "heated"),
+			}),
+		];
+		const summary = computeTrialSummary(trials, gt);
+		expect(summary.driftEventCount).toBe(3);
+		expect(summary.offTheRailsBoundaryDriftCount).toBe(2);
+	});
+
 	it("counts drift events from trial assessments", () => {
 		const gt = buildGroundTruth(scoresForSum(11), "bumpy");
 		const trials: TrialResult[] = [

--- a/src/pipeline/scripts/evals/agreement.test.ts
+++ b/src/pipeline/scripts/evals/agreement.test.ts
@@ -6,6 +6,7 @@ import {
 	computeTrialSummary,
 	detectDriftEvent,
 	type EvaluatedSummary,
+	type NoEvidenceSummary,
 	PROMOTION_CRITERIA,
 	type TrialResult,
 } from "#/pipeline/scripts/evals/agreement.ts";
@@ -56,16 +57,26 @@ function buildTrial(
 }
 
 /**
- * Assertion helper: most tests below expect a fully-evaluated cell, and
- * the discriminated-union shape requires narrowing before metrics can be
- * read. This converts the runtime check + narrowing into a one-liner so
- * each test stays focused on its assertion subject.
+ * Assertion helpers: the discriminated-union shape requires narrowing
+ * before variant-specific fields can be read. Asserting at the top of
+ * a test converts the runtime check + narrowing into a one-liner so
+ * each test stays focused on its actual subject. Mirror helpers for
+ * both variants so the no-evidence path stays as ergonomic as the
+ * evaluated path.
  */
 function expectEvaluated(
 	summary: AgreementSummary,
 ): asserts summary is EvaluatedSummary {
 	if (summary.kind !== "evaluated") {
 		throw new Error(`expected evaluated summary, got ${summary.kind}`);
+	}
+}
+
+function expectNoEvidence(
+	summary: AgreementSummary,
+): asserts summary is NoEvidenceSummary {
+	if (summary.kind !== "no-evidence") {
+		throw new Error(`expected no-evidence summary, got ${summary.kind}`);
 	}
 }
 
@@ -334,8 +345,7 @@ describe("computeTrialSummary", () => {
 		];
 
 		const summary = computeTrialSummary(trials, gt);
-		expect(summary.kind).toBe("no-evidence");
-		if (summary.kind !== "no-evidence") return;
+		expectNoEvidence(summary);
 		expect(summary.trialsExcluded).toBe(3);
 		expect(summary.emptyOutputCount).toBe(3);
 		// Ground-truth tier is still computed from corpus scores even when

--- a/src/pipeline/scripts/evals/agreement.ts
+++ b/src/pipeline/scripts/evals/agreement.ts
@@ -44,6 +44,12 @@ type TrialResult = {
 };
 
 type AgreementSummary = {
+	/**
+	 * Recomputed from `groundTruth.ground_truth.category_scores` via
+	 * `mapSumToLevel` — never read from `groundTruth.ground_truth.level`.
+	 * Always defined (corpus always has scores), regardless of trial outcomes.
+	 */
+	groundTruthTier: DramaLevel;
 	tierMode: DramaLevel | null;
 	tierMin: DramaLevel | null;
 	tierMax: DramaLevel | null;
@@ -51,6 +57,8 @@ type AgreementSummary = {
 	totalCategoryMae: number | null;
 	driftEventCount: number;
 	emptyOutputCount: number;
+	/** Count of `ok` trials whose mechanical tier equals `groundTruthTier`. */
+	tierMatchCount: number;
 	trialsCounted: number;
 	trialsExcluded: number;
 };
@@ -167,8 +175,13 @@ function computeTrialSummary(
 	const trialsCounted = okTrials.length;
 	const trialsExcluded = trials.length - trialsCounted;
 
+	const groundTruthTier = mapSumToLevel(
+		sumCategoryScores(groundTruth.ground_truth.category_scores),
+	);
+
 	if (trialsCounted === 0) {
 		return {
+			groundTruthTier,
 			tierMode: null,
 			tierMin: null,
 			tierMax: null,
@@ -176,6 +189,7 @@ function computeTrialSummary(
 			totalCategoryMae: null,
 			driftEventCount: 0,
 			emptyOutputCount,
+			tierMatchCount: 0,
 			trialsCounted,
 			trialsExcluded,
 		};
@@ -198,7 +212,12 @@ function computeTrialSummary(
 	const totalCategoryMae =
 		perTrialAbsErr.reduce((a, b) => a + b, 0) / perTrialAbsErr.length;
 
+	const tierMatchCount = tiersPerTrial.filter(
+		(t) => t === groundTruthTier,
+	).length;
+
 	return {
+		groundTruthTier,
 		tierMode: pickTierMode(tiersPerTrial),
 		tierMin: tierMin(tiersPerTrial),
 		tierMax: tierMax(tiersPerTrial),
@@ -206,6 +225,7 @@ function computeTrialSummary(
 		totalCategoryMae,
 		driftEventCount,
 		emptyOutputCount,
+		tierMatchCount,
 		trialsCounted,
 		trialsExcluded,
 	};

--- a/src/pipeline/scripts/evals/agreement.ts
+++ b/src/pipeline/scripts/evals/agreement.ts
@@ -56,6 +56,13 @@ type AgreementSummary = {
 	sigma: number | null;
 	totalCategoryMae: number | null;
 	driftEventCount: number;
+	/**
+	 * Subset of `driftEventCount` where the LLM-emitted tier and the
+	 * mechanical tier sit on different sides of the off-the-rails boundary
+	 * (one is `"off-the-rails"` and the other is not). Promotion criterion
+	 * §3 from PRD #66 forbids these.
+	 */
+	offTheRailsBoundaryDriftCount: number;
 	emptyOutputCount: number;
 	/** Count of `ok` trials whose mechanical tier equals `groundTruthTier`. */
 	tierMatchCount: number;
@@ -82,6 +89,18 @@ function detectDriftEvent(
 		computed,
 		sum,
 	};
+}
+
+/**
+ * A drift event crosses the off-the-rails boundary iff exactly one of
+ * `llmEmitted` and `computed` is `"off-the-rails"`. These are the events
+ * PRD #66 promotion criteria forbid because they would have flipped a
+ * cell's queue/auto-publish decision under the prod detector's override.
+ */
+function isOffTheRailsBoundaryDrift(event: DriftEvent): boolean {
+	const a = event.llmEmitted === "off-the-rails";
+	const b = event.computed === "off-the-rails";
+	return a !== b;
 }
 
 const TIER_RANK: Record<DramaLevel, number> = (() => {
@@ -188,6 +207,7 @@ function computeTrialSummary(
 			sigma: null,
 			totalCategoryMae: null,
 			driftEventCount: 0,
+			offTheRailsBoundaryDriftCount: 0,
 			emptyOutputCount,
 			tierMatchCount: 0,
 			trialsCounted,
@@ -200,10 +220,13 @@ function computeTrialSummary(
 	);
 	const tiersPerTrial = sums.map((s) => mapSumToLevel(s));
 
-	const driftEventCount = okTrials.reduce(
-		(acc, t) => acc + (detectDriftEvent(t.assessment) === null ? 0 : 1),
-		0,
-	);
+	const driftEvents = okTrials
+		.map((t) => detectDriftEvent(t.assessment))
+		.filter((e): e is DriftEvent => e !== null);
+	const driftEventCount = driftEvents.length;
+	const offTheRailsBoundaryDriftCount = driftEvents.filter(
+		isOffTheRailsBoundaryDrift,
+	).length;
 
 	const gtScores = groundTruth.ground_truth.category_scores;
 	const perTrialAbsErr = okTrials.map((t) =>
@@ -224,6 +247,7 @@ function computeTrialSummary(
 		sigma: populationSigma(sums),
 		totalCategoryMae,
 		driftEventCount,
+		offTheRailsBoundaryDriftCount,
 		emptyOutputCount,
 		tierMatchCount,
 		trialsCounted,

--- a/src/pipeline/scripts/evals/agreement.ts
+++ b/src/pipeline/scripts/evals/agreement.ts
@@ -43,18 +43,43 @@ type TrialResult = {
 	durationMs: number;
 };
 
-type AgreementSummary = {
+/**
+ * A cell whose trials produced no usable evidence — every trial was
+ * `empty_output` or `error`. The report layer must render this case
+ * structurally distinct from a fully-evaluated cell so the operator can
+ * tell "the model said nothing" apart from "the model said this is fine".
+ *
+ * `groundTruthTier` is still present (corpus is always graded) so the
+ * report can show what the model *should* have said.
+ *
+ * Carries the `docs/solutions/patterns/empty-output-silent-degradation`
+ * lesson into eval-result aggregation: the no-evidence path is a tagged
+ * outcome rather than a soup of nullable fields.
+ */
+type NoEvidenceSummary = {
+	kind: "no-evidence";
+	groundTruthTier: DramaLevel;
+	emptyOutputCount: number;
+	trialsExcluded: number;
+};
+
+/**
+ * A cell with at least one `ok` trial. Every metric is defined — no
+ * nullable fields — so report.ts cannot accidentally render a "0" that
+ * means "no evidence" instead of "evidence says zero".
+ */
+type EvaluatedSummary = {
+	kind: "evaluated";
 	/**
 	 * Recomputed from `groundTruth.ground_truth.category_scores` via
 	 * `mapSumToLevel` — never read from `groundTruth.ground_truth.level`.
-	 * Always defined (corpus always has scores), regardless of trial outcomes.
 	 */
 	groundTruthTier: DramaLevel;
-	tierMode: DramaLevel | null;
-	tierMin: DramaLevel | null;
-	tierMax: DramaLevel | null;
-	sigma: number | null;
-	totalCategoryMae: number | null;
+	tierMode: DramaLevel;
+	tierMin: DramaLevel;
+	tierMax: DramaLevel;
+	sigma: number;
+	totalCategoryMae: number;
 	driftEventCount: number;
 	/**
 	 * Subset of `driftEventCount` where the LLM-emitted tier and the
@@ -66,9 +91,12 @@ type AgreementSummary = {
 	emptyOutputCount: number;
 	/** Count of `ok` trials whose mechanical tier equals `groundTruthTier`. */
 	tierMatchCount: number;
+	/** Strictly > 0 in this variant. */
 	trialsCounted: number;
 	trialsExcluded: number;
 };
+
+type AgreementSummary = NoEvidenceSummary | EvaluatedSummary;
 
 /**
  * Compares the LLM-emitted `level` against `mapSumToLevel(sum_of_scores)`.
@@ -200,17 +228,9 @@ function computeTrialSummary(
 
 	if (trialsCounted === 0) {
 		return {
+			kind: "no-evidence",
 			groundTruthTier,
-			tierMode: null,
-			tierMin: null,
-			tierMax: null,
-			sigma: null,
-			totalCategoryMae: null,
-			driftEventCount: 0,
-			offTheRailsBoundaryDriftCount: 0,
 			emptyOutputCount,
-			tierMatchCount: 0,
-			trialsCounted,
 			trialsExcluded,
 		};
 	}
@@ -240,6 +260,7 @@ function computeTrialSummary(
 	).length;
 
 	return {
+		kind: "evaluated",
 		groundTruthTier,
 		tierMode: pickTierMode(tiersPerTrial),
 		tierMin: tierMin(tiersPerTrial),
@@ -256,4 +277,11 @@ function computeTrialSummary(
 }
 
 export { computeTrialSummary, detectDriftEvent, PROMOTION_CRITERIA };
-export type { AgreementSummary, DriftEvent, TrialResult, TrialStatus };
+export type {
+	AgreementSummary,
+	DriftEvent,
+	EvaluatedSummary,
+	NoEvidenceSummary,
+	TrialResult,
+	TrialStatus,
+};

--- a/src/pipeline/scripts/evals/agreement.ts
+++ b/src/pipeline/scripts/evals/agreement.ts
@@ -1,6 +1,5 @@
 import {
 	DRAMA_CATEGORIES,
-	DRAMA_LEVELS,
 	type DramaLevel,
 	mapSumToLevel,
 } from "#/lib/drama-levels.ts";
@@ -39,7 +38,6 @@ type TrialResult = {
 	trial: number;
 	status: TrialStatus;
 	assessment?: DramaAssessmentOutput;
-	driftEvent?: DriftEvent | null;
 	durationMs: number;
 };
 
@@ -131,13 +129,17 @@ function isOffTheRailsBoundaryDrift(event: DriftEvent): boolean {
 	return a !== b;
 }
 
-const TIER_RANK: Record<DramaLevel, number> = (() => {
-	const ranks = {} as Record<DramaLevel, number>;
-	DRAMA_LEVELS.forEach((level, idx) => {
-		ranks[level] = idx;
-	});
-	return ranks;
-})();
+/**
+ * Inline literal so adding a fifth `DramaLevel` fails compilation here
+ * until the rank is assigned — `satisfies Record<DramaLevel, number>`
+ * enforces exhaustiveness without widening the literal value types away.
+ */
+const TIER_RANK = {
+	routine: 0,
+	bumpy: 1,
+	heated: 2,
+	"off-the-rails": 3,
+} as const satisfies Record<DramaLevel, number>;
 
 /**
  * Bimodal tiebreak: when two tiers tie for most-frequent, the higher-ranked

--- a/src/pipeline/scripts/evals/agreement.ts
+++ b/src/pipeline/scripts/evals/agreement.ts
@@ -1,0 +1,215 @@
+import {
+	DRAMA_CATEGORIES,
+	DRAMA_LEVELS,
+	type DramaLevel,
+	mapSumToLevel,
+} from "#/lib/drama-levels.ts";
+import type { LoadedCorpusEntry } from "#/pipeline/scripts/evals/corpus-loader.ts";
+import {
+	type DramaAssessmentOutput,
+	sumCategoryScores,
+} from "#/pipeline/services/DramaDetectionService.ts";
+
+/**
+ * Locked promotion criteria from PRD #66 §Promotion Criteria.
+ *
+ * `maeComparator` is symbolic ("≤ prod") because the actual MAE bound is set
+ * per-run against the prod profile's MAE; the rule pins the comparator, not a
+ * number. The other thresholds are absolute and locked.
+ */
+const PROMOTION_CRITERIA = {
+	minTierMatchFraction: 2 / 3,
+	maxEmptyOutputs: 0,
+	maxOffTheRailsBoundaryDrift: 0,
+	maeComparator: "<=prod" as const,
+} as const;
+
+type TrialStatus = "ok" | "empty_output" | "error";
+
+type DriftEvent = {
+	type: "level_override";
+	llmEmitted: DramaLevel;
+	computed: DramaLevel;
+	sum: number;
+};
+
+type TrialResult = {
+	profile: string;
+	transcriptId: string;
+	trial: number;
+	status: TrialStatus;
+	assessment?: DramaAssessmentOutput;
+	driftEvent?: DriftEvent | null;
+	durationMs: number;
+};
+
+type AgreementSummary = {
+	tierMode: DramaLevel | null;
+	tierMin: DramaLevel | null;
+	tierMax: DramaLevel | null;
+	sigma: number | null;
+	totalCategoryMae: number | null;
+	driftEventCount: number;
+	emptyOutputCount: number;
+	trialsCounted: number;
+	trialsExcluded: number;
+};
+
+/**
+ * Compares the LLM-emitted `level` against `mapSumToLevel(sum_of_scores)`.
+ * Returns `null` when they match. Returns a `DriftEvent` when the LLM's tier
+ * label disagrees with the mechanical mapping — these are the cases the prod
+ * detector silently overrides, and the harness surfaces them as evidence
+ * during prompt iteration.
+ */
+function detectDriftEvent(
+	assessment: DramaAssessmentOutput,
+): DriftEvent | null {
+	const sum = sumCategoryScores(assessment.category_scores);
+	const computed = mapSumToLevel(sum);
+	if (computed === assessment.level) return null;
+	return {
+		type: "level_override",
+		llmEmitted: assessment.level,
+		computed,
+		sum,
+	};
+}
+
+const TIER_RANK: Record<DramaLevel, number> = (() => {
+	const ranks = {} as Record<DramaLevel, number>;
+	DRAMA_LEVELS.forEach((level, idx) => {
+		ranks[level] = idx;
+	});
+	return ranks;
+})();
+
+/**
+ * Bimodal tiebreak: when two tiers tie for most-frequent, the higher-ranked
+ * tier wins. Locked by PRD acceptance criterion so the harness's verdict is
+ * deterministic across reruns of the same trial set.
+ */
+function pickTierMode(tiers: readonly DramaLevel[]): DramaLevel {
+	const counts = new Map<DramaLevel, number>();
+	for (const t of tiers) counts.set(t, (counts.get(t) ?? 0) + 1);
+	let best: DramaLevel = tiers[0];
+	let bestCount = -1;
+	for (const [tier, count] of counts) {
+		if (count > bestCount) {
+			best = tier;
+			bestCount = count;
+		} else if (count === bestCount && TIER_RANK[tier] > TIER_RANK[best]) {
+			best = tier;
+		}
+	}
+	return best;
+}
+
+function tierMin(tiers: readonly DramaLevel[]): DramaLevel {
+	let min = tiers[0];
+	for (const t of tiers) {
+		if (TIER_RANK[t] < TIER_RANK[min]) min = t;
+	}
+	return min;
+}
+
+function tierMax(tiers: readonly DramaLevel[]): DramaLevel {
+	let max = tiers[0];
+	for (const t of tiers) {
+		if (TIER_RANK[t] > TIER_RANK[max]) max = t;
+	}
+	return max;
+}
+
+function populationSigma(values: readonly number[]): number {
+	if (values.length === 0) return 0;
+	const mean = values.reduce((a, b) => a + b, 0) / values.length;
+	const variance =
+		values.reduce((acc, v) => acc + (v - mean) ** 2, 0) / values.length;
+	return Math.sqrt(variance);
+}
+
+function totalAbsoluteError(
+	trial: DramaAssessmentOutput["category_scores"],
+	gt: DramaAssessmentOutput["category_scores"],
+): number {
+	let sum = 0;
+	for (const cat of DRAMA_CATEGORIES) {
+		sum += Math.abs(trial[cat].score - gt[cat].score);
+	}
+	return sum;
+}
+
+/**
+ * Collapses one (profile × transcript) cell's trial outputs into the
+ * distribution evidence the report renders.
+ *
+ * INVARIANT (PRD #66 §Key invariants): never reads `groundTruth.ground_truth.level`.
+ * Per-trial tier labels come from `mapSumToLevel(sum_of_scores)`, not from the
+ * LLM's emitted `level`; the LLM's `level` only feeds drift detection. MAE is
+ * computed against `groundTruth.ground_truth.category_scores` directly.
+ *
+ * Both `empty_output` and `error` trials are excluded from numeric aggregates;
+ * `emptyOutputCount` distinguishes the two so report drift between modes is
+ * preserved (PRD #66 promotion criterion: zero empty outputs).
+ */
+function computeTrialSummary(
+	trials: readonly TrialResult[],
+	groundTruth: LoadedCorpusEntry,
+): AgreementSummary {
+	const okTrials = trials.filter(
+		(t): t is TrialResult & { assessment: DramaAssessmentOutput } =>
+			t.status === "ok" && t.assessment !== undefined,
+	);
+	const emptyOutputCount = trials.filter(
+		(t) => t.status === "empty_output",
+	).length;
+	const trialsCounted = okTrials.length;
+	const trialsExcluded = trials.length - trialsCounted;
+
+	if (trialsCounted === 0) {
+		return {
+			tierMode: null,
+			tierMin: null,
+			tierMax: null,
+			sigma: null,
+			totalCategoryMae: null,
+			driftEventCount: 0,
+			emptyOutputCount,
+			trialsCounted,
+			trialsExcluded,
+		};
+	}
+
+	const sums = okTrials.map((t) =>
+		sumCategoryScores(t.assessment.category_scores),
+	);
+	const tiersPerTrial = sums.map((s) => mapSumToLevel(s));
+
+	const driftEventCount = okTrials.reduce(
+		(acc, t) => acc + (detectDriftEvent(t.assessment) === null ? 0 : 1),
+		0,
+	);
+
+	const gtScores = groundTruth.ground_truth.category_scores;
+	const perTrialAbsErr = okTrials.map((t) =>
+		totalAbsoluteError(t.assessment.category_scores, gtScores),
+	);
+	const totalCategoryMae =
+		perTrialAbsErr.reduce((a, b) => a + b, 0) / perTrialAbsErr.length;
+
+	return {
+		tierMode: pickTierMode(tiersPerTrial),
+		tierMin: tierMin(tiersPerTrial),
+		tierMax: tierMax(tiersPerTrial),
+		sigma: populationSigma(sums),
+		totalCategoryMae,
+		driftEventCount,
+		emptyOutputCount,
+		trialsCounted,
+		trialsExcluded,
+	};
+}
+
+export { computeTrialSummary, detectDriftEvent, PROMOTION_CRITERIA };
+export type { AgreementSummary, DriftEvent, TrialResult, TrialStatus };

--- a/src/pipeline/scripts/evals/report.test.ts
+++ b/src/pipeline/scripts/evals/report.test.ts
@@ -16,6 +16,7 @@ const fixture = (name: string): string =>
 	fileURLToPath(new URL(`./__fixtures__/report/${name}`, import.meta.url));
 
 const v1Cell: AgreementSummary = {
+	kind: "evaluated",
 	groundTruthTier: "off-the-rails",
 	tierMode: "off-the-rails",
 	tierMin: "off-the-rails",
@@ -31,6 +32,7 @@ const v1Cell: AgreementSummary = {
 };
 
 const v2Cell: AgreementSummary = {
+	kind: "evaluated",
 	groundTruthTier: "off-the-rails",
 	tierMode: "heated",
 	tierMin: "bumpy",
@@ -69,17 +71,9 @@ describe("generateMarkdownReport", () => {
 
 	it("renders Promote=✗ when the cell has zero ok trials", () => {
 		const emptyCell: AgreementSummary = {
+			kind: "no-evidence",
 			groundTruthTier: "heated",
-			tierMode: null,
-			tierMin: null,
-			tierMax: null,
-			sigma: null,
-			totalCategoryMae: null,
-			driftEventCount: 0,
-			offTheRailsBoundaryDriftCount: 0,
 			emptyOutputCount: 3,
-			tierMatchCount: 0,
-			trialsCounted: 0,
 			trialsExcluded: 3,
 		};
 		const input: ReportInput = {

--- a/src/pipeline/scripts/evals/report.test.ts
+++ b/src/pipeline/scripts/evals/report.test.ts
@@ -1,0 +1,133 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+	type AgreementSummary,
+	PROMOTION_CRITERIA,
+} from "#/pipeline/scripts/evals/agreement.ts";
+import {
+	cellKey,
+	generateCsvReport,
+	generateMarkdownReport,
+	type ReportInput,
+} from "#/pipeline/scripts/evals/report.ts";
+
+const fixture = (name: string): string =>
+	fileURLToPath(new URL(`./__fixtures__/report/${name}`, import.meta.url));
+
+const v1Cell: AgreementSummary = {
+	groundTruthTier: "off-the-rails",
+	tierMode: "off-the-rails",
+	tierMin: "off-the-rails",
+	tierMax: "off-the-rails",
+	sigma: 0,
+	totalCategoryMae: 0,
+	driftEventCount: 0,
+	offTheRailsBoundaryDriftCount: 0,
+	emptyOutputCount: 0,
+	tierMatchCount: 3,
+	trialsCounted: 3,
+	trialsExcluded: 0,
+};
+
+const v2Cell: AgreementSummary = {
+	groundTruthTier: "off-the-rails",
+	tierMode: "heated",
+	tierMin: "bumpy",
+	tierMax: "off-the-rails",
+	sigma: 3.09,
+	totalCategoryMae: 4.5,
+	driftEventCount: 1,
+	offTheRailsBoundaryDriftCount: 1,
+	emptyOutputCount: 0,
+	tierMatchCount: 1,
+	trialsCounted: 3,
+	trialsExcluded: 0,
+};
+
+const sampleInput: ReportInput = {
+	runId: "test-run-2026-05-10",
+	startedAt: "2026-05-10T12:00:00.000Z",
+	completedAt: "2026-05-10T12:15:00.000Z",
+	modelId: "gemini-2.5-flash",
+	profiles: ["v1", "v2"],
+	transcripts: ["rbb-hiring"],
+	cells: new Map<string, AgreementSummary>([
+		[cellKey("v1", "rbb-hiring"), v1Cell],
+		[cellKey("v2", "rbb-hiring"), v2Cell],
+	]),
+	promotionCriteria: PROMOTION_CRITERIA,
+	prodProfile: "v1",
+};
+
+describe("generateMarkdownReport", () => {
+	it("renders the canonical golden REPORT.md exactly", async () => {
+		const golden = await readFile(fixture("REPORT.golden.md"), "utf8");
+		const actual = generateMarkdownReport(sampleInput);
+		expect(actual).toBe(golden);
+	});
+
+	it("renders Promote=✗ when the cell has zero ok trials", () => {
+		const emptyCell: AgreementSummary = {
+			groundTruthTier: "heated",
+			tierMode: null,
+			tierMin: null,
+			tierMax: null,
+			sigma: null,
+			totalCategoryMae: null,
+			driftEventCount: 0,
+			offTheRailsBoundaryDriftCount: 0,
+			emptyOutputCount: 3,
+			tierMatchCount: 0,
+			trialsCounted: 0,
+			trialsExcluded: 3,
+		};
+		const input: ReportInput = {
+			...sampleInput,
+			profiles: ["v1"],
+			cells: new Map([[cellKey("v1", "rbb-hiring"), emptyCell]]),
+			prodProfile: "v1",
+		};
+		const md = generateMarkdownReport(input);
+		// Every metric column should render an em dash for null values
+		expect(md).toContain("| — |");
+		// Promote? cell should be ✗ when no trials succeeded
+		expect(md).toContain("✗");
+	});
+
+	it("skips MAE comparison when prodProfile is omitted", () => {
+		const input: ReportInput = {
+			...sampleInput,
+			prodProfile: undefined,
+		};
+		const md = generateMarkdownReport(input);
+		expect(md).toContain("`maeComparator = manual`");
+		// v1 row would otherwise be the prod baseline; without prodProfile, both
+		// rows are evaluated by tier-match + empty + OTR-drift only.
+		// v1 has tier match 3/3, 0 empty, 0 OTR drift → ✓.
+		// v2 has tier match 1/3 (< 2/3) → ✗.
+		expect(md).toMatch(/v1.*?\| ✓ \|/s);
+		expect(md).toMatch(/v2.*?\| ✗ \|/s);
+	});
+});
+
+describe("generateCsvReport", () => {
+	it("renders the canonical golden REPORT.csv exactly", async () => {
+		const golden = await readFile(fixture("REPORT.golden.csv"), "utf8");
+		const actual = generateCsvReport(sampleInput);
+		expect(actual).toBe(golden);
+	});
+
+	it("emits one header row plus one row per (profile × transcript) cell", () => {
+		const csv = generateCsvReport(sampleInput);
+		const lines = csv.trimEnd().split("\n");
+		expect(lines).toHaveLength(3); // header + 2 cells
+		expect(lines[0]).toContain("profile,transcript,gt_tier");
+	});
+});
+
+describe("cellKey", () => {
+	it("uses the canonical `<profile>__<transcript>` form", () => {
+		expect(cellKey("v1", "rbb-hiring")).toBe("v1__rbb-hiring");
+	});
+});

--- a/src/pipeline/scripts/evals/report.ts
+++ b/src/pipeline/scripts/evals/report.ts
@@ -1,6 +1,7 @@
 import { type DramaLevel, LEVEL_DISPLAY } from "#/lib/drama-levels.ts";
 import type {
 	AgreementSummary,
+	EvaluatedSummary,
 	PROMOTION_CRITERIA,
 } from "#/pipeline/scripts/evals/agreement.ts";
 
@@ -31,33 +32,29 @@ function cellKey(profile: string, transcript: string): string {
 	return `${profile}__${transcript}`;
 }
 
-function fmtTier(tier: DramaLevel | null): string {
-	return tier === null ? "—" : LEVEL_DISPLAY[tier];
+const EM_DASH = "—";
+
+function fmtTier(tier: DramaLevel): string {
+	return LEVEL_DISPLAY[tier];
 }
 
-function fmtTierRange(min: DramaLevel | null, max: DramaLevel | null): string {
-	if (min === null || max === null) return "—";
+function fmtTierRange(min: DramaLevel, max: DramaLevel): string {
 	if (min === max) return LEVEL_DISPLAY[min];
 	return `${LEVEL_DISPLAY[min]}–${LEVEL_DISPLAY[max]}`;
 }
 
-function fmtNum(n: number | null, decimals: number): string {
-	return n === null ? "—" : n.toFixed(decimals);
-}
-
 /**
- * Auto-checks the four PRD #66 promotion criteria where the data is
- * available. Returns `false` when any criterion fails or when no ok trials
- * exist (cell has no evidence to evaluate). MAE check is skipped when
+ * Auto-checks the four PRD #66 promotion criteria. A `no-evidence` cell
+ * always fails — there is nothing to evaluate. MAE check is skipped when
  * `prodMae` is `undefined` (no prod profile declared, or the prod cell
- * itself has null MAE).
+ * itself is `no-evidence`).
  */
 function passesPromotion(
 	cell: AgreementSummary,
 	prodMae: number | undefined,
 	criteria: typeof PROMOTION_CRITERIA,
 ): boolean {
-	if (cell.trialsCounted === 0) return false;
+	if (cell.kind === "no-evidence") return false;
 	const tierMatchFraction = cell.tierMatchCount / cell.trialsCounted;
 	if (tierMatchFraction < criteria.minTierMatchFraction) return false;
 	if (cell.emptyOutputCount > criteria.maxEmptyOutputs) return false;
@@ -66,11 +63,7 @@ function passesPromotion(
 	) {
 		return false;
 	}
-	if (
-		prodMae !== undefined &&
-		cell.totalCategoryMae !== null &&
-		cell.totalCategoryMae > prodMae
-	) {
+	if (prodMae !== undefined && cell.totalCategoryMae > prodMae) {
 		return false;
 	}
 	return true;
@@ -82,7 +75,32 @@ function lookupProdMae(
 ): number | undefined {
 	if (input.prodProfile === undefined) return undefined;
 	const prod = input.cells.get(cellKey(input.prodProfile, transcript));
-	return prod?.totalCategoryMae ?? undefined;
+	if (prod === undefined || prod.kind === "no-evidence") return undefined;
+	return prod.totalCategoryMae;
+}
+
+/**
+ * Renders one cell row in the markdown table. Discriminates on
+ * `cell.kind` so the no-evidence case shows em dashes for every metric
+ * column rather than zeros that could be confused with "evaluated, score
+ * 0". Promote is always ✗ for no-evidence (no evidence to evaluate).
+ */
+function renderMarkdownRow(
+	profile: string,
+	transcript: string,
+	cell: AgreementSummary,
+	promote: boolean,
+): string {
+	const promoteStr = promote ? "✓" : "✗";
+	const gt = fmtTier(cell.groundTruthTier);
+	if (cell.kind === "no-evidence") {
+		const totalTrials = cell.trialsExcluded;
+		return `| ${profile} | ${transcript} | ${gt} | ${EM_DASH} | ${EM_DASH} | ${EM_DASH} | ${EM_DASH} | 0 | 0 | ${cell.emptyOutputCount} | 0/0 | 0/${totalTrials} | ${promoteStr} |`;
+	}
+	const tierMatchStr = `${cell.tierMatchCount}/${cell.trialsCounted}`;
+	const totalTrials = cell.trialsCounted + cell.trialsExcluded;
+	const trialsStr = `${cell.trialsCounted}/${totalTrials}`;
+	return `| ${profile} | ${transcript} | ${gt} | ${fmtTier(cell.tierMode)} | ${fmtTierRange(cell.tierMin, cell.tierMax)} | ${cell.sigma.toFixed(2)} | ${cell.totalCategoryMae.toFixed(2)} | ${cell.driftEventCount} | ${cell.offTheRailsBoundaryDriftCount} | ${cell.emptyOutputCount} | ${tierMatchStr} | ${trialsStr} | ${promoteStr} |`;
 }
 
 function generateMarkdownReport(input: ReportInput): string {
@@ -139,13 +157,7 @@ function generateMarkdownReport(input: ReportInput): string {
 			if (!cell) continue;
 			const prodMae = lookupProdMae(input, transcript);
 			const promote = passesPromotion(cell, prodMae, input.promotionCriteria);
-			const promoteStr = promote ? "✓" : "✗";
-			const tierMatchStr = `${cell.tierMatchCount}/${cell.trialsCounted}`;
-			const totalTrials = cell.trialsCounted + cell.trialsExcluded;
-			const trialsStr = `${cell.trialsCounted}/${totalTrials}`;
-			lines.push(
-				`| ${profile} | ${transcript} | ${fmtTier(cell.groundTruthTier)} | ${fmtTier(cell.tierMode)} | ${fmtTierRange(cell.tierMin, cell.tierMax)} | ${fmtNum(cell.sigma, 2)} | ${fmtNum(cell.totalCategoryMae, 2)} | ${cell.driftEventCount} | ${cell.offTheRailsBoundaryDriftCount} | ${cell.emptyOutputCount} | ${tierMatchStr} | ${trialsStr} | ${promoteStr} |`,
-			);
+			lines.push(renderMarkdownRow(profile, transcript, cell, promote));
 		}
 	}
 	lines.push("");
@@ -155,12 +167,57 @@ function generateMarkdownReport(input: ReportInput): string {
 const CSV_HEADER =
 	"profile,transcript,gt_tier,tier_mode,tier_min,tier_max,sigma,total_category_mae,drift_event_count,otr_boundary_drift_count,empty_output_count,tier_match_count,trials_counted,trials_excluded,promote";
 
-function csvNum(n: number | null): string {
-	return n === null ? "" : n.toString();
-}
-
-function csvTier(t: DramaLevel | null): string {
-	return t === null ? "" : t;
+/**
+ * One CSV row per cell. No-evidence cells emit empty strings for every
+ * metric column (tier_mode, tier_min, tier_max, sigma, total_category_mae)
+ * and zeros for the count columns; this lets a spreadsheet filter on
+ * `promote == false AND tier_mode == ''` to find no-evidence cells
+ * specifically.
+ */
+function renderCsvRow(
+	profile: string,
+	transcript: string,
+	cell: AgreementSummary,
+	promote: boolean,
+): string {
+	const gt = cell.groundTruthTier;
+	if (cell.kind === "no-evidence") {
+		return [
+			profile,
+			transcript,
+			gt,
+			"",
+			"",
+			"",
+			"",
+			"",
+			0,
+			0,
+			cell.emptyOutputCount,
+			0,
+			0,
+			cell.trialsExcluded,
+			String(promote),
+		].join(",");
+	}
+	const e: EvaluatedSummary = cell;
+	return [
+		profile,
+		transcript,
+		gt,
+		e.tierMode,
+		e.tierMin,
+		e.tierMax,
+		e.sigma.toString(),
+		e.totalCategoryMae.toString(),
+		e.driftEventCount,
+		e.offTheRailsBoundaryDriftCount,
+		e.emptyOutputCount,
+		e.tierMatchCount,
+		e.trialsCounted,
+		e.trialsExcluded,
+		String(promote),
+	].join(",");
 }
 
 /**
@@ -178,25 +235,7 @@ function generateCsvReport(input: ReportInput): string {
 			if (!cell) continue;
 			const prodMae = lookupProdMae(input, transcript);
 			const promote = passesPromotion(cell, prodMae, input.promotionCriteria);
-			lines.push(
-				[
-					profile,
-					transcript,
-					csvTier(cell.groundTruthTier),
-					csvTier(cell.tierMode),
-					csvTier(cell.tierMin),
-					csvTier(cell.tierMax),
-					csvNum(cell.sigma),
-					csvNum(cell.totalCategoryMae),
-					cell.driftEventCount,
-					cell.offTheRailsBoundaryDriftCount,
-					cell.emptyOutputCount,
-					cell.tierMatchCount,
-					cell.trialsCounted,
-					cell.trialsExcluded,
-					String(promote),
-				].join(","),
-			);
+			lines.push(renderCsvRow(profile, transcript, cell, promote));
 		}
 	}
 	return `${lines.join("\n")}\n`;

--- a/src/pipeline/scripts/evals/report.ts
+++ b/src/pipeline/scripts/evals/report.ts
@@ -1,0 +1,206 @@
+import { type DramaLevel, LEVEL_DISPLAY } from "#/lib/drama-levels.ts";
+import type {
+	AgreementSummary,
+	PROMOTION_CRITERIA,
+} from "#/pipeline/scripts/evals/agreement.ts";
+
+type ReportInput = {
+	runId: string;
+	startedAt: string;
+	completedAt: string;
+	modelId: string;
+	profiles: readonly string[];
+	transcripts: readonly string[];
+	cells: ReadonlyMap<string, AgreementSummary>;
+	promotionCriteria: typeof PROMOTION_CRITERIA;
+	/**
+	 * The promptVersion of the production profile. When provided, each cell's
+	 * MAE is auto-checked against the prod profile's MAE for the same
+	 * transcript. When omitted, the MAE criterion shows as `manual` in the
+	 * report and is excluded from the auto-checked Promote? column.
+	 */
+	prodProfile?: string;
+};
+
+/**
+ * Canonical key for `ReportInput.cells`. Single-source the convention so
+ * runner.ts and report.ts can never disagree about whether the separator is
+ * `__`, `:`, or `/`.
+ */
+function cellKey(profile: string, transcript: string): string {
+	return `${profile}__${transcript}`;
+}
+
+function fmtTier(tier: DramaLevel | null): string {
+	return tier === null ? "—" : LEVEL_DISPLAY[tier];
+}
+
+function fmtTierRange(min: DramaLevel | null, max: DramaLevel | null): string {
+	if (min === null || max === null) return "—";
+	if (min === max) return LEVEL_DISPLAY[min];
+	return `${LEVEL_DISPLAY[min]}–${LEVEL_DISPLAY[max]}`;
+}
+
+function fmtNum(n: number | null, decimals: number): string {
+	return n === null ? "—" : n.toFixed(decimals);
+}
+
+/**
+ * Auto-checks the four PRD #66 promotion criteria where the data is
+ * available. Returns `false` when any criterion fails or when no ok trials
+ * exist (cell has no evidence to evaluate). MAE check is skipped when
+ * `prodMae` is `undefined` (no prod profile declared, or the prod cell
+ * itself has null MAE).
+ */
+function passesPromotion(
+	cell: AgreementSummary,
+	prodMae: number | undefined,
+	criteria: typeof PROMOTION_CRITERIA,
+): boolean {
+	if (cell.trialsCounted === 0) return false;
+	const tierMatchFraction = cell.tierMatchCount / cell.trialsCounted;
+	if (tierMatchFraction < criteria.minTierMatchFraction) return false;
+	if (cell.emptyOutputCount > criteria.maxEmptyOutputs) return false;
+	if (
+		cell.offTheRailsBoundaryDriftCount > criteria.maxOffTheRailsBoundaryDrift
+	) {
+		return false;
+	}
+	if (
+		prodMae !== undefined &&
+		cell.totalCategoryMae !== null &&
+		cell.totalCategoryMae > prodMae
+	) {
+		return false;
+	}
+	return true;
+}
+
+function lookupProdMae(
+	input: ReportInput,
+	transcript: string,
+): number | undefined {
+	if (input.prodProfile === undefined) return undefined;
+	const prod = input.cells.get(cellKey(input.prodProfile, transcript));
+	return prod?.totalCategoryMae ?? undefined;
+}
+
+function generateMarkdownReport(input: ReportInput): string {
+	const lines: string[] = [];
+	lines.push(`# Drama Eval Report — ${input.runId}`);
+	lines.push("");
+	lines.push("| Field | Value |");
+	lines.push("| --- | --- |");
+	lines.push(`| Started | ${input.startedAt} |`);
+	lines.push(`| Completed | ${input.completedAt} |`);
+	lines.push(`| Model | ${input.modelId} |`);
+	lines.push(`| Profiles | ${input.profiles.join(", ")} |`);
+	lines.push(`| Transcripts | ${input.transcripts.join(", ")} |`);
+	lines.push(`| Prod profile | ${input.prodProfile ?? "(none)"} |`);
+	lines.push("");
+	lines.push("## Promotion Criteria");
+	lines.push("");
+	lines.push(
+		"A profile may replace the production prompt iff, across ≥3 trials per transcript:",
+	);
+	lines.push("");
+	const fracPct = Math.round(
+		input.promotionCriteria.minTierMatchFraction * 100,
+	);
+	lines.push(
+		`- Tier match in ≥ ${fracPct}% of trials (\`minTierMatchFraction = 2/3\`)`,
+	);
+	const maeText =
+		input.prodProfile === undefined
+			? "manual"
+			: input.promotionCriteria.maeComparator;
+	lines.push(
+		`- Total category MAE ≤ prod profile MAE (\`maeComparator = ${maeText}\`)`,
+	);
+	lines.push(
+		`- Zero empty-output trials (\`maxEmptyOutputs = ${input.promotionCriteria.maxEmptyOutputs}\`)`,
+	);
+	lines.push(
+		`- No drift events crossing the off-the-rails boundary (\`maxOffTheRailsBoundaryDrift = ${input.promotionCriteria.maxOffTheRailsBoundaryDrift}\`)`,
+	);
+	lines.push("");
+	lines.push("## Cells");
+	lines.push("");
+	lines.push(
+		"| Profile | Transcript | GT Tier | Tier Mode | Tier Range | σ | MAE | Drift | OTR Drift | Empty | Tier Match | Trials | Promote? |",
+	);
+	lines.push(
+		"| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | :---: | :---: | :---: |",
+	);
+
+	for (const profile of input.profiles) {
+		for (const transcript of input.transcripts) {
+			const cell = input.cells.get(cellKey(profile, transcript));
+			if (!cell) continue;
+			const prodMae = lookupProdMae(input, transcript);
+			const promote = passesPromotion(cell, prodMae, input.promotionCriteria);
+			const promoteStr = promote ? "✓" : "✗";
+			const tierMatchStr = `${cell.tierMatchCount}/${cell.trialsCounted}`;
+			const totalTrials = cell.trialsCounted + cell.trialsExcluded;
+			const trialsStr = `${cell.trialsCounted}/${totalTrials}`;
+			lines.push(
+				`| ${profile} | ${transcript} | ${fmtTier(cell.groundTruthTier)} | ${fmtTier(cell.tierMode)} | ${fmtTierRange(cell.tierMin, cell.tierMax)} | ${fmtNum(cell.sigma, 2)} | ${fmtNum(cell.totalCategoryMae, 2)} | ${cell.driftEventCount} | ${cell.offTheRailsBoundaryDriftCount} | ${cell.emptyOutputCount} | ${tierMatchStr} | ${trialsStr} | ${promoteStr} |`,
+			);
+		}
+	}
+	lines.push("");
+	return lines.join("\n");
+}
+
+const CSV_HEADER =
+	"profile,transcript,gt_tier,tier_mode,tier_min,tier_max,sigma,total_category_mae,drift_event_count,otr_boundary_drift_count,empty_output_count,tier_match_count,trials_counted,trials_excluded,promote";
+
+function csvNum(n: number | null): string {
+	return n === null ? "" : n.toString();
+}
+
+function csvTier(t: DramaLevel | null): string {
+	return t === null ? "" : t;
+}
+
+/**
+ * One row per (profile × transcript) cell, ordered by `profiles` then
+ * `transcripts`. Header included. Tier values use the raw ids (e.g.
+ * `off-the-rails`) for spreadsheet sortability; numbers use full JS
+ * precision via `toString()`. No quoting — the values cannot contain
+ * commas or quotes (tier ids and ASCII identifiers only).
+ */
+function generateCsvReport(input: ReportInput): string {
+	const lines: string[] = [CSV_HEADER];
+	for (const profile of input.profiles) {
+		for (const transcript of input.transcripts) {
+			const cell = input.cells.get(cellKey(profile, transcript));
+			if (!cell) continue;
+			const prodMae = lookupProdMae(input, transcript);
+			const promote = passesPromotion(cell, prodMae, input.promotionCriteria);
+			lines.push(
+				[
+					profile,
+					transcript,
+					csvTier(cell.groundTruthTier),
+					csvTier(cell.tierMode),
+					csvTier(cell.tierMin),
+					csvTier(cell.tierMax),
+					csvNum(cell.sigma),
+					csvNum(cell.totalCategoryMae),
+					cell.driftEventCount,
+					cell.offTheRailsBoundaryDriftCount,
+					cell.emptyOutputCount,
+					cell.tierMatchCount,
+					cell.trialsCounted,
+					cell.trialsExcluded,
+					String(promote),
+				].join(","),
+			);
+		}
+	}
+	return `${lines.join("\n")}\n`;
+}
+
+export { cellKey, generateCsvReport, generateMarkdownReport };
+export type { ReportInput };


### PR DESCRIPTION
## Summary

Adds the two pure-function boundaries that make distribution evidence legible during prompt iteration:

- `agreement.ts` collapses one (profile × transcript) cell's trial outputs into the structured evidence the report renders — tier mode (with deterministic bimodal tiebreak: higher tier wins), tier min/max, population σ over per-trial sum-of-scores, total category MAE against ground truth, drift event count (LLM-emitted tier vs `mapSumToLevel(sum)`), off-the-rails-boundary drift count, empty-output exclusion, and a `tierMatchCount` so the report can auto-check the 2/3 promotion criterion.
- `report.ts` renders that summary into byte-stable `REPORT.md` and `REPORT.csv` strings with locked golden fixtures. The `Promote?` column auto-checks the 4 PRD #66 promotion criteria (tier match ≥ 2/3, MAE ≤ prod, 0 empty, 0 OTR-boundary drift); when no `prodProfile` is supplied, the MAE check renders as `manual` and the operator does that comparison by reading the MAE column.

Both modules are pure — no `node:fs`, no `Effect`, no I/O — exactly per PRD §Test boundaries, so they unit- and golden-file-test with zero infrastructure.

The hard-edge invariant holds: `agreement.ts` never reads `groundTruth.ground_truth.level` for math. Per-trial tier labels come from `mapSumToLevel(sum_of_scores)`, and `groundTruthTier` is recomputed the same way. A test fixture deliberately has corpus `level = "routine"` while scores sum to 18 (mechanical → `off-the-rails`) and asserts the function arrives at `off-the-rails` — failing the test would catch any future read of the corpus's hand-recorded tier.

`PROMOTION_CRITERIA` lives as a single locked constant in `agreement.ts` so the four thresholds (`minTierMatchFraction = 2/3`, `maxEmptyOutputs = 0`, `maxOffTheRailsBoundaryDrift = 0`, `maeComparator = "<=prod"`) are revisable in one place — the `[POLICY]` AC — rather than scattered across report rendering.

This PR stacks on #76 (Slice 2 — corpus loader); base branch is `issue-68-corpus-loader` so the diff is just this slice's contribution. Once #76 merges, GitHub will retarget this PR to main.

## PRD

Closes #69
Refs #66

## Slices

- [x] #67 — profile extraction + production rewire (tracer bullet) — merged
- [ ] #68 — corpus authoring + corpus loader (PR #76, open)
- [x] #69 — pure agreement + report modules — this PR
- [ ] #70 — runner + evals:run CLI subcommand
- [ ] #71 — QA: real-API smoke + acceptance verification

## Key Decisions

- Extended `AgreementSummary` beyond the slice's literal field list with `groundTruthTier`, `tierMatchCount`, and `offTheRailsBoundaryDriftCount`. The slice spec listed core metrics but the AC required an auto-checked Promote? column, which is only computable with these three additions. Each is small, pure, and computed from data the function already touches.
- Added optional `prodProfile?: string` to `ReportInput`. Without it, the MAE-≤-prod check can't be auto-applied; with it, the report compares each non-prod cell's MAE against the prod cell's MAE for the same transcript. Optional so a single-profile run still produces a valid report.
- Tier-mode bimodal tiebreak: higher tier wins. The PRD AC asked for *a* deterministic tiebreak, not a specific one; biasing toward the more dramatic tier means under-call drift surfaces faster than over-call drift, which matches the production override discipline.
- CSV uses raw tier ids (`off-the-rails`) and JS-precision numbers (`toString()`); markdown uses `LEVEL_DISPLAY` strings and `toFixed(2)`. Spreadsheet sortability vs. human readability — different audiences, different format.
- Single-source the `cellKey(profile, transcript) = "<profile>__<transcript>"` convention via an exported helper so future runner.ts and report.ts cannot disagree about the separator.

## Test plan

- [x] 18 agreement.ts unit tests pass — drift detection at every tier boundary, off-the-rails-boundary classification, bimodal tiebreak, partial-agreement MAE, empty-output exclusion, all-empty cell, error-status exclusion, sigma N=1 / N=3, gt-level-disagrees-with-scores invariant, tierMatchCount math
- [x] 6 report.ts golden-file tests pass — REPORT.md exact match, REPORT.csv exact match, null-cell rendering with em dashes, Promote=✗ on zero-trial cells, MAE manual-mode when prodProfile omitted, cellKey shape
- [x] Full project test suite (24 files / 222 tests) passes; no regressions
- [x] `tsc --noEmit` clean across the project
- [x] Biome clean on all 4 changed source files
- [x] Both modules verified pure — no `node:fs` or `effect` imports